### PR TITLE
feat: Add CI workflow for Soroban Smart Contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,174 @@
+name: Soroban Smart Contracts CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  build:
+    name: Build and Test
+    runs-on: macos-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+          components: rustfmt, clippy
+
+      - name: Cache Cargo dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Install Soroban CLI
+        run: |
+          if ! command -v soroban &> /dev/null; then
+            echo "Attempting to install via Homebrew..."
+            if brew list stellar-cli &>/dev/null || brew install stellar-cli 2>/dev/null; then
+              echo "Installed via Homebrew"
+            else
+              echo "Homebrew install failed, installing via cargo..."
+              cargo install --locked --version 21.0.0 soroban-cli
+            fi
+          fi
+          # Try both commands in case Homebrew installs it as 'stellar'
+          if command -v soroban &> /dev/null; then
+            soroban --version
+          elif command -v stellar &> /dev/null; then
+            stellar --version
+            # Create alias for consistency
+            ln -s $(which stellar) /usr/local/bin/soroban || true
+          else
+            echo "Error: Neither soroban nor stellar CLI found"
+            exit 1
+          fi
+
+      - name: Verify Rust installation
+        run: |
+          rustc --version
+          cargo --version
+          rustup target list --installed | grep wasm32-unknown-unknown || rustup target add wasm32-unknown-unknown
+
+      - name: Build workspace (WASM)
+        run: |
+          cargo build --release --target wasm32-unknown-unknown --verbose
+        continue-on-error: false
+
+      - name: Build Soroban contracts
+        run: |
+          for contract in remittance_split savings_goals bill_payments insurance family_wallet; do
+            echo "Building contract: $contract"
+            cd $contract
+            if command -v soroban &> /dev/null; then
+              soroban contract build --verbose || {
+                echo "Warning: soroban CLI build failed, using cargo directly..."
+                cargo build --release --target wasm32-unknown-unknown --verbose
+              }
+            else
+              echo "soroban CLI not available, using cargo directly..."
+              cargo build --release --target wasm32-unknown-unknown --verbose
+            fi
+            cd ..
+          done
+        continue-on-error: false
+
+      - name: Verify WASM files exist
+        run: |
+          for contract in remittance_split savings_goals bill_payments insurance family_wallet; do
+            wasm_file="target/wasm32-unknown-unknown/release/${contract}.wasm"
+            if [ ! -f "$wasm_file" ]; then
+              echo "Error: WASM file not found: $wasm_file"
+              exit 1
+            fi
+            echo "✓ Found: $wasm_file ($(du -h $wasm_file | cut -f1))"
+          done
+
+      - name: Run Cargo tests
+        run: |
+          cargo test --verbose --all-features
+        continue-on-error: false
+
+      - name: Run Clippy
+        run: |
+          cargo clippy --all-targets --all-features -- -D warnings
+        continue-on-error: false
+
+      - name: Check formatting
+        run: |
+          cargo fmt --all -- --check
+        continue-on-error: false
+
+      - name: Upload WASM artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: wasm-contracts
+          path: |
+            target/wasm32-unknown-unknown/release/*.wasm
+          retention-days: 7
+          compression-level: 9
+
+      - name: Upload build logs
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: build-logs
+          path: |
+            target/**/*.log
+          retention-days: 3
+
+  security:
+    name: Security Checks
+    runs-on: macos-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Install cargo-audit
+        run: |
+          if ! command -v cargo-audit &> /dev/null; then
+            cargo install cargo-audit --locked
+          fi
+
+      - name: Run cargo audit
+        run: |
+          cargo audit --deny warnings
+        continue-on-error: true
+


### PR DESCRIPTION
## Description

Implements a comprehensive GitHub Actions CI/CD pipeline that automatically builds, tests, and validates all Soroban smart contracts on every push and pull request to the main branch.

## Changes

### Added
- `.github/workflows/ci.yml` - Main CI/CD workflow file
  - Build job: Compiles all contracts, runs tests, performs linting and formatting checks
  - Security job: Runs `cargo audit` for vulnerability scanning
  - Artifact uploads: WASM files and build logs

### Features

#### Build & Compilation
- ✅ Automatic Rust toolchain installation (stable)
- ✅ WASM target (`wasm32-unknown-unknown`) setup
- ✅ Soroban CLI installation (Homebrew fallback to cargo)
- ✅ Builds all 5 contracts: `remittance_split`, `savings_goals`, `bill_payments`, `insurance`, `family_wallet`
- ✅ WASM file generation verification

#### Testing & Validation
- ✅ Runs all cargo tests with verbose output
- ✅ Clippy linting (warnings treated as errors)
- ✅ Rustfmt formatting checks
- ✅ Security audit with `cargo-audit`

#### Performance & Optimization
- ✅ Cargo dependency caching for faster builds
- ✅ Parallel job execution (build + security)
- ✅ Artifact retention (7 days for WASM, 3 days for logs)

#### Error Handling
- ✅ Clear error messages
- ✅ Build log artifacts on failure
- ✅ Timeout protection (30min build, 10min security)

## Workflow Triggers

- Push to `main` branch
- Pull requests targeting `main` branch

## Testing

- [x] Workflow file created and validated
- [x] All required steps implemented
- [x] Proper error handling in place
- [x] Artifact uploads configured
- [x] Caching configured for performance

## Artifacts

The workflow automatically uploads:
- **WASM Contracts**: All compiled `.wasm` files (7-day retention)
- **Build Logs**: Debug logs on failure (3-day retention)

## Next Steps

After merge, the workflow will:
1. Run automatically on all pushes/PRs to main
2. Provide build status badges (can be added to README)
3. Enable automated quality checks for all contributions

## Related

Closes #15