### PR TITLE
fix: Remove non-existent family_wallet from CI workflow and add wasm32v1-none target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
           rustc --version
           cargo --version
           rustup target list --installed | grep wasm32-unknown-unknown || rustup target add wasm32-unknown-unknown
+          rustup target list --installed | grep wasm32v1-none || rustup target add wasm32v1-none || echo "Warning: wasm32v1-none target not available, will use wasm32-unknown-unknown fallback"
 
       - name: Build workspace (WASM)
         run: |
@@ -75,7 +76,7 @@ jobs:
 
       - name: Build Soroban contracts
         run: |
-          for contract in remittance_split savings_goals bill_payments insurance family_wallet; do
+          for contract in remittance_split savings_goals bill_payments insurance; do
             echo "Building contract: $contract"
             cd $contract
             if command -v soroban &> /dev/null; then
@@ -93,7 +94,7 @@ jobs:
 
       - name: Verify WASM files exist
         run: |
-          for contract in remittance_split savings_goals bill_payments insurance family_wallet; do
+          for contract in remittance_split savings_goals bill_payments insurance; do
             wasm_file="target/wasm32-unknown-unknown/release/${contract}.wasm"
             if [ ! -f "$wasm_file" ]; then
               echo "Error: WASM file not found: $wasm_file"


### PR DESCRIPTION
## Problem
The CI workflow was failing with the following errors:
1. **Missing directory error**: The workflow attempted to build `family_wallet` contract, but the directory doesn't exist, causing `cd: family_wallet: No such file or directory` error
2. **Missing Rust target**: The `soroban contract build` command requires `wasm32v1-none` target, which wasn't installed, causing build failures (though builds succeeded via cargo fallback)

## Solution
- Removed `family_wallet` from the build loop and WASM verification steps in the CI workflow
- Added `wasm32v1-none` target installation attempt in the "Verify Rust installation" step (with graceful fallback if target is unavailable)

## Changes
- Updated `.github/workflows/ci.yml`:
  - Removed `family_wallet` from contract build loop (line 78)
  - Removed `family_wallet` from WASM verification loop (line 96)
  - Added `wasm32v1-none` target installation in Rust verification step

## Impact
- CI builds will now only attempt to build contracts that actually exist in the workspace
- Reduces build warnings and potential failures related to missing Rust targets
- Builds will continue to work with cargo fallback if `wasm32v1-none` is unavailable

## Testing
The workflow should now successfully build all four existing contracts:
- ✅ remittance_split
- ✅ savings_goals
- ✅ bill_payments
- ✅ insurance

Closes #19