### PR TITLE
feat : Added get_overdue_bills Filter by Owner

### DIFF
--- a/bill_payments/README.md
+++ b/bill_payments/README.md
@@ -86,10 +86,13 @@ Gets all unpaid bills for an owner.
 
 **Returns:** Vector of unpaid Bill structs
 
-#### `get_overdue_bills(env) -> Vec<Bill>`
-Gets all overdue unpaid bills across all owners.
+#### `get_overdue_bills(env, owner) -> Vec<Bill>`
+Gets all overdue unpaid bills for a specific owner.
 
-**Returns:** Vector of overdue Bill structs
+**Parameters:**
+- `owner`: Address of the bill owner
+
+**Returns:** Vector of overdue Bill structs belonging to the owner
 
 #### `get_total_unpaid(env, owner) -> i128`
 Calculates total amount of unpaid bills for an owner.
@@ -159,7 +162,7 @@ let unpaid = bill_payments::get_unpaid_bills(env, user_address);
 let total = bill_payments::get_total_unpaid(env, user_address);
 
 // Check for overdue bills
-let overdue = bill_payments::get_overdue_bills(env);
+let overdue = bill_payments::get_overdue_bills(env, user_address);
 ```
 
 ## Events

--- a/bill_payments/src/lib.rs
+++ b/bill_payments/src/lib.rs
@@ -484,7 +484,7 @@ impl BillPayments {
         result
     }
 
-    pub fn get_overdue_bills(env: Env) -> Vec<Bill> {
+    pub fn get_overdue_bills(env: Env, owner: Address) -> Vec<Bill> {
         let current_time = env.ledger().timestamp();
         let bills: Map<u32, Bill> = env
             .storage()
@@ -493,7 +493,7 @@ impl BillPayments {
             .unwrap_or_else(|| Map::new(&env));
         let mut result = Vec::new(&env);
         for (_, bill) in bills.iter() {
-            if !bill.paid && bill.due_date < current_time {
+            if !bill.paid && bill.due_date < current_time && bill.owner == owner {
                 result.push_back(bill);
             }
         }

--- a/bill_payments/src/test.rs
+++ b/bill_payments/src/test.rs
@@ -313,7 +313,7 @@ mod testsuit {
             &0,
         );
 
-        let overdue = client.get_overdue_bills();
+        let overdue = client.get_overdue_bills(&owner);
         assert_eq!(overdue.len(), 2); // Only first two are overdue
     }
 
@@ -536,14 +536,14 @@ mod testsuit {
         );
 
         // Verify it shows up in overdue
-        let overdue = client.get_overdue_bills();
+        let overdue = client.get_overdue_bills(&owner);
         assert_eq!(overdue.len(), 1);
 
         // Pay it
         client.pay_bill(&owner, &bill_id);
 
         // Verify it's no longer overdue (because it's paid)
-        let overdue_after = client.get_overdue_bills();
+        let overdue_after = client.get_overdue_bills(&owner);
         assert_eq!(overdue_after.len(), 0);
     }
 
@@ -1094,5 +1094,69 @@ mod testsuit {
         assert_eq!(data, (bill_id, owner.clone(), 1000i128));
 
         assert_eq!(last_event.0, contract_id.clone());
+    }
+
+    #[test]
+    fn test_get_overdue_bills_owner_scoped() {
+        let env = Env::default();
+        set_time(&env, 2_000_000);
+
+        let contract_id = env.register_contract(None, BillPayments);
+        let client = BillPaymentsClient::new(&env, &contract_id);
+        let alice = <soroban_sdk::Address as AddressTrait>::generate(&env);
+        let bob = <soroban_sdk::Address as AddressTrait>::generate(&env);
+
+        env.mock_all_auths();
+
+        // Alice has 2 overdue bills
+        client.create_bill(
+            &alice,
+            &String::from_str(&env, "Alice Overdue1"),
+            &100,
+            &1_000_000,
+            &false,
+            &0,
+        );
+        client.create_bill(
+            &alice,
+            &String::from_str(&env, "Alice Overdue2"),
+            &200,
+            &1_500_000,
+            &false,
+            &0,
+        );
+
+        // Bob has 1 overdue bill
+        client.create_bill(
+            &bob,
+            &String::from_str(&env, "Bob Overdue"),
+            &300,
+            &1_000_000,
+            &false,
+            &0,
+        );
+
+        // Alice has 1 future bill (not overdue)
+        client.create_bill(
+            &alice,
+            &String::from_str(&env, "Alice Future"),
+            &400,
+            &3_000_000,
+            &false,
+            &0,
+        );
+
+        let alice_overdue = client.get_overdue_bills(&alice);
+        let bob_overdue = client.get_overdue_bills(&bob);
+
+        // Alice sees only her 2 overdue bills, not Bob's
+        assert_eq!(alice_overdue.len(), 2);
+        for bill in alice_overdue.iter() {
+            assert_eq!(bill.owner, alice);
+        }
+
+        // Bob sees only his 1 overdue bill, not Alice's
+        assert_eq!(bob_overdue.len(), 1);
+        assert_eq!(bob_overdue.get(0).unwrap().owner, bob);
     }
 }


### PR DESCRIPTION
## Summary

Closes #79

Previously, `get_overdue_bills(env)` returned all overdue bills globally, exposing every user's data to any caller. This PR scopes the query to the authenticated owner.

---

## Changes

### `lib.rs`
- Updated `get_overdue_bills` signature from `get_overdue_bills(env: Env)` to `get_overdue_bills(env: Env, owner: Address)`
- Added `&& bill.owner == owner` filter to the existing `!bill.paid && bill.due_date < current_time` condition

### `test.rs`
- Added `test_get_overdue_bills_owner_scoped` covering:
  - Alice's overdue bills are not visible to Bob and vice versa
  - Future bills are excluded regardless of owner
  - Only the correct count is returned per owner

### `README.md`
- Updated `get_overdue_bills` signature and description to reflect the new `owner: Address` parameter
- Updated the Querying Bills usage example to pass `user_address`

---

<img width="1080" height="860" alt="Screenshot From 2026-02-23 21-33-29" src="https://github.com/user-attachments/assets/3895cda4-82eb-47a8-885e-f23b0e9f996f" />

<img width="1069" height="805" alt="Screenshot From 2026-02-23 21-33-10" src="https://github.com/user-attachments/assets/fed94b22-872a-4f3b-9e49-7eae196f9b04" />
