### PR TITLE
test: enhance bill cancellation tests 

### DIFF
--- a/bill_payments/src/test.rs
+++ b/bill_payments/src/test.rs
@@ -334,8 +334,23 @@ mod testsuit {
         );
         env.mock_all_auths();
         client.cancel_bill(&owner, &bill_id);
-        let bill = client.get_bill(&bill_id);
-        assert!(bill.is_none());
+        
+        // Verify cancelled bill is completely removed from storage
+        assert!(client.get_bill(&bill_id).is_none(), "cancelled bill should return None");
+        
+        // Create another bill and verify its ID is distinct and cancelled bill still returns None
+        env.mock_all_auths();
+        let new_bill_id = client.create_bill(
+            &owner,
+            &String::from_str(&env, "New Bill"),
+            &200,
+            &2000000,
+            &false,
+            &0,
+        );
+        assert_ne!(bill_id, new_bill_id, "new bill should have different ID");
+        assert!(client.get_bill(&new_bill_id).is_some(), "new bill should exist");
+        assert!(client.get_bill(&bill_id).is_none(), "cancelled bill should still return None");
     }
 
     #[test]
@@ -355,8 +370,9 @@ mod testsuit {
         );
         env.mock_all_auths();
         client.cancel_bill(&owner, &bill_id);
-        let bill = client.get_bill(&bill_id);
-        assert!(bill.is_none());
+        
+        // Verify owner can successfully cancel their own bill and it's removed
+        assert!(client.get_bill(&bill_id).is_none(), "bill should be removed after owner cancellation");
     }
 
     #[test]


### PR DESCRIPTION
Strengthens the bill cancellation tests to verify that cancel_bill() fully removes a bill from storage. After cancellation, get_bill(id) must return None, ensuring no stale records remain that could mislead frontends or dependent contracts.

Changes
Improved test_cancel_bill():
Added assertion confirming get_bill(cancelled_bill_id) returns None immediately after cancellation.
Verified that creating a new bill generates a different ID.
Confirmed the cancelled bill still returns None, ensuring it was not partially retained.
Updated test_cancel_bill_owner_succeeds():
Added clearer assertion message documenting the verification step.

Testing
Executed within the bill_payments test suite.
Included in CI runs.
Closes #105 