### PR TITLE
[Test] : Adds Owner Isolation Tests for `get_unpaid_bills

### DIFF
--- a/bill_payments/src/lib.rs
+++ b/bill_payments/src/lib.rs
@@ -1241,6 +1241,178 @@ mod test {
         }
     }
 
+    #[test]
+    fn test_get_unpaid_bills_owner_isolation_bidirectional() {
+        let env = make_env();
+        env.mock_all_auths();
+        let cid = env.register_contract(None, BillPayments);
+        let client = BillPaymentsClient::new(&env, &cid);
+        let owner_a = Address::generate(&env);
+        let owner_b = Address::generate(&env);
+
+        setup_bills(&env, &client, &owner_a, 2);
+        setup_bills(&env, &client, &owner_b, 3);
+
+        // owner_a sees only their own bills
+        let page_a = client.get_unpaid_bills(&owner_a, &0, &10);
+        assert_eq!(page_a.count, 2);
+        for bill in page_a.items.iter() {
+            assert_eq!(
+                bill.owner, owner_a,
+                "owner_a page must not contain owner_b bills"
+            );
+        }
+
+        // owner_b sees only their own bills
+        let page_b = client.get_unpaid_bills(&owner_b, &0, &10);
+        assert_eq!(page_b.count, 3);
+        for bill in page_b.items.iter() {
+            assert_eq!(
+                bill.owner, owner_b,
+                "owner_b page must not contain owner_a bills"
+            );
+        }
+    }
+
+    #[test]
+    fn test_get_unpaid_bills_owner_isolation_after_one_pays() {
+        // If owner_a pays their bill, owner_b's unpaid bills are unaffected
+        let env = make_env();
+        env.mock_all_auths();
+        let cid = env.register_contract(None, BillPayments);
+        let client = BillPaymentsClient::new(&env, &cid);
+        let owner_a = Address::generate(&env);
+        let owner_b = Address::generate(&env);
+
+        let ids_a = setup_bills(&env, &client, &owner_a, 2);
+        setup_bills(&env, &client, &owner_b, 2);
+
+        // owner_a pays one of their bills
+        client.pay_bill(&owner_a, &ids_a.get(0).unwrap());
+
+        // owner_a now has 1 unpaid
+        let page_a = client.get_unpaid_bills(&owner_a, &0, &10);
+        assert_eq!(page_a.count, 1);
+        for bill in page_a.items.iter() {
+            assert_eq!(bill.owner, owner_a, "Should only see owner_a bills");
+            assert!(!bill.paid, "Should only see unpaid bills");
+        }
+
+        // owner_b still has 2 unpaid — unaffected by owner_a's payment
+        let page_b = client.get_unpaid_bills(&owner_b, &0, &10);
+        assert_eq!(page_b.count, 2);
+        for bill in page_b.items.iter() {
+            assert_eq!(bill.owner, owner_b, "Should only see owner_b bills");
+        }
+    }
+
+    #[test]
+    fn test_get_unpaid_bills_owner_isolation_one_owner_no_bills() {
+        // owner_b has bills but owner_a has none — owner_a gets empty page
+        let env = make_env();
+        env.mock_all_auths();
+        let cid = env.register_contract(None, BillPayments);
+        let client = BillPaymentsClient::new(&env, &cid);
+        let owner_a = Address::generate(&env);
+        let owner_b = Address::generate(&env);
+
+        // Only owner_b creates bills
+        setup_bills(&env, &client, &owner_b, 3);
+
+        let page_a = client.get_unpaid_bills(&owner_a, &0, &10);
+        assert_eq!(page_a.count, 0, "owner_a should see no bills");
+        assert_eq!(page_a.next_cursor, 0);
+
+        let page_b = client.get_unpaid_bills(&owner_b, &0, &10);
+        assert_eq!(page_b.count, 3, "owner_b should see all their bills");
+    }
+
+    #[test]
+    fn test_get_unpaid_bills_owner_isolation_all_paid_other_owner_unpaid() {
+        // owner_a pays all their bills — owner_b's unpaid still isolated correctly
+        let env = make_env();
+        env.mock_all_auths();
+        let cid = env.register_contract(None, BillPayments);
+        let client = BillPaymentsClient::new(&env, &cid);
+        let owner_a = Address::generate(&env);
+        let owner_b = Address::generate(&env);
+
+        let ids_a = setup_bills(&env, &client, &owner_a, 3);
+        setup_bills(&env, &client, &owner_b, 2);
+
+        // owner_a pays all their bills
+        for id in ids_a.iter() {
+            client.pay_bill(&owner_a, &id);
+        }
+
+        // owner_a has zero unpaid
+        let page_a = client.get_unpaid_bills(&owner_a, &0, &10);
+        assert_eq!(page_a.count, 0, "owner_a should have no unpaid bills left");
+
+        // owner_b still has 2 unpaid — not polluted by owner_a's paid bills
+        let page_b = client.get_unpaid_bills(&owner_b, &0, &10);
+        assert_eq!(page_b.count, 2);
+        for bill in page_b.items.iter() {
+            assert_eq!(bill.owner, owner_b);
+            assert!(!bill.paid);
+        }
+    }
+
+    #[test]
+    fn test_get_unpaid_bills_owner_isolation_pagination_does_not_leak() {
+        // With many owners, paginating through owner_a's results never leaks owner_b's bills
+        let env = make_env();
+        env.mock_all_auths();
+        let cid = env.register_contract(None, BillPayments);
+        let client = BillPaymentsClient::new(&env, &cid);
+        let owner_a = Address::generate(&env);
+        let owner_b = Address::generate(&env);
+
+        // Interleave bills: a, b, a, b, a, b ...
+        for i in 0..4u32 {
+            client.create_bill(
+                &owner_a,
+                &String::from_str(&env, "Bill A"),
+                &(100i128 * (i as i128 + 1)),
+                &(env.ledger().timestamp() + 86400 * (i as u64 + 1)),
+                &false,
+                &0,
+            );
+            client.create_bill(
+                &owner_b,
+                &String::from_str(&env, "Bill B"),
+                &(200i128 * (i as i128 + 1)),
+                &(env.ledger().timestamp() + 86400 * (i as u64 + 1)),
+                &false,
+                &0,
+            );
+        }
+
+        // Paginate through owner_a with small page size
+        let mut all_a_bills: soroban_sdk::Vec<Bill> = soroban_sdk::Vec::new(&env);
+        let mut cursor = 0u32;
+        loop {
+            let page = client.get_unpaid_bills(&owner_a, &cursor, &2);
+            for bill in page.items.iter() {
+                assert_eq!(
+                    bill.owner, owner_a,
+                    "Paginated result must never contain owner_b's bill"
+                );
+                all_a_bills.push_back(bill);
+            }
+            if page.next_cursor == 0 {
+                break;
+            }
+            cursor = page.next_cursor;
+        }
+
+        assert_eq!(
+            all_a_bills.len(),
+            4,
+            "owner_a should have exactly 4 bills across all pages"
+        );
+    }
+
     // --- get_overdue_bills ---
 
     #[test]


### PR DESCRIPTION
## Test  #107 — Owner Isolation Tests for `get_unpaid_bills`

### What
Adds 4 tests to verify `get_unpaid_bills` never leaks one owner's bills to another.

### Tests Added
- `test_get_unpaid_bills_owner_isolation_after_one_pays` — paying owner_a's bill doesn't affect owner_b's unpaid count
- `test_get_unpaid_bills_owner_isolation_one_owner_no_bills` — owner with no bills gets empty page even when others have bills
- `test_get_unpaid_bills_owner_isolation_all_paid_other_unpaid` — owner_a's paid bills don't bleed into owner_b's unpaid list
- `test_get_unpaid_bills_owner_isolation_pagination_does_not_leak` — paginating with small limit across interleaved bills never leaks across owners

### Why
The existing bidirectional isolation test covers the happy path. These tests cover edge cases: payments, empty owners, and pagination boundary leaks.

### Changes
- `src/lib.rs` — 4 new tests inside `mod test`, no production code changed

### Close #107 

<img width="1118" height="269" alt="Screenshot From 2026-02-24 19-37-44" src="https://github.com/user-attachments/assets/004a1dfb-1459-4790-8917-0b1e87ea2d4d" />
