### PR TITLE
feat : Contract Event Versioning and Migration Plan

### DIFF
--- a/check_ci.sh
+++ b/check_ci.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+echo "Building WASM..."
+cargo build --release --target wasm32-unknown-unknown
+
+echo "Running tests..."
+cargo test --all-features
+
+echo "Running clippy..."
+cargo clippy --all-targets --all-features -- -D warnings
+
+echo "Checking format..."
+cargo fmt --all -- --check
+
+echo "Running audit..."
+cargo audit --deny warnings
+
+echo "Running gas benchmarks..."
+./scripts/run_gas_benchmarks.sh
+
+echo "✅ All checks passed!"


### PR DESCRIPTION
# Version Event Payloads for Migration

## Description
This PR introduces versioned event payloads allowing indexers and off-chain services to handle breaking schema migrations safely. The base [MigrationEvent](cci:2://file:///home/olowo/Desktop/ike/Remitwise-Contracts/data_migration/src/lib.rs:30:0-35:1) and V1 schema are defined in the `data_migration` utility crate to be adopted across all contracts.

## Changes Made
- Added [MigrationEvent](cci:2://file:///home/olowo/Desktop/ike/Remitwise-Contracts/data_migration/src/lib.rs:30:0-35:1) enum to support future-proof event schemas.
- Added [MigrationEventV1](cci:2://file:///home/olowo/Desktop/ike/Remitwise-Contracts/data_migration/src/lib.rs:30:0-35:1) containing core metrics (`contract_id`, `migration_type`, [version](cci:1://file:///home/olowo/Desktop/ike/Remitwise-Contracts/data_migration/src/lib.rs:115:4-118:5), `timestamp_ms`).
- Added indexer migration guidance documentation for handling current and future schemas defensively.
- Added serialization validation tests to ensure indexers can cleanly decode the versioned wrappers.

## Issue / Requirement Addressed
Version event payloads so indexers can handle breaking schema changes safely.
- Add version field in event payloads or encoded in topics.
- Declare current events as v1 and define rules for v2+.
- Document migration guidance for indexers.

closes #156
