### PR TITLE
Add Contract Quickstart Sections to Each README

### DIFF
--- a/bill_payments/README.md
+++ b/bill_payments/README.md
@@ -15,6 +15,40 @@ The Bill Payments contract allows users to create, manage, and pay bills. It sup
 - Event emission for audit trails
 - Storage TTL management for efficiency
 
+## Quickstart
+
+This section provides a minimal example of how to interact with the Bill Payments contract. 
+
+**Gotchas:** 
+- The contract uses a paginated API for most list queries natively.
+- Bill amounts are specified in the lowest denomination (e.g., stroops for XLM).
+- If a bill is marked as `recurring`, paying it automatically generates the next bill.
+
+### Write Example: Creating a Bill
+*Note: This is pseudo-code demonstrating the Soroban Rust SDK CLI or client approach.*
+```rust
+
+let bill_id = client.create_bill(
+    &owner_address,
+    &String::from_str(&env, "Internet Bill"),
+    &500_0000000,                           
+    &(env.ledger().timestamp() + 2592000), 
+    &false,                                
+    &0,                                     
+    &String::from_str(&env, "XLM")          
+);
+
+```
+
+### Read Example: Fetching Unpaid Bills
+```rust
+
+let limit = 10;
+let cursor = 0; 
+let page = client.get_unpaid_bills(&owner_address, &cursor, &limit);
+
+```
+
 ## API Reference
 
 ### Data Structures

--- a/insurance/README.md
+++ b/insurance/README.md
@@ -16,6 +16,39 @@ The Insurance contract enables users to create and manage insurance policies, tr
 - Event emission for audit trails
 - Storage TTL management
 
+## Quickstart
+
+This section provides a minimal example of how to interact with the Insurance contract.
+
+**Gotchas:**
+- Amounts are specified in the lowest denomination (e.g., stroops for XLM).
+- The `pay_premium` function assumes authorization succeeds and sets `next_payment_date`. Ensure you handle asset transfers depending on your implementation.
+- `deactivate_policy` stops future premium calculations but cannot be reversed in the current implementation.
+
+### Write Example: Creating a Policy
+*Note: This is pseudo-code demonstrating the Soroban Rust SDK CLI or client approach.*
+```rust
+
+let policy_id = client.create_policy(
+    &owner_address,
+    &String::from_str(&env, "Life Insurance"),
+    &String::from_str(&env, "Life"),
+    &100_0000000,                            
+    &10000_0000000,                         
+    &String::from_str(&env, "XLM")          
+);
+
+```
+
+### Read Example: Fetching Active Policies
+```rust
+
+let limit = 10;
+let cursor = 0;
+let page = client.get_active_policies(&owner_address, &cursor, &limit);
+
+```
+
 ## API Reference
 
 ### Data Structures

--- a/remittance_split/README.md
+++ b/remittance_split/README.md
@@ -15,6 +15,37 @@ The Remittance Split contract manages percentage-based allocations for incoming 
 - Event emission for audit trails
 - Backward compatibility with vector-based storage
 
+## Quickstart
+
+This section provides a minimal example of how to interact with the Remittance Split contract.
+
+**Gotchas:**
+- The configured percentages MUST sum up exactly to 100.
+- `initialize_split` must be called with a valid `nonce` for replay protection.
+- To execute actual underlying asset transfers, use `distribute_usdc` rather than just calculating numbers.
+
+### Write Example: Initializing the Split
+*Note: This is pseudo-code demonstrating the Soroban Rust SDK CLI or client approach.*
+```rust
+
+let success = client.initialize_split(
+    &owner_address,
+    &0,  
+    &50, 
+    &30, 
+    &15, 
+    &5   
+);
+
+```
+
+### Read Example: Fetching the Configuration
+```rust
+
+let config = client.get_config();
+
+```
+
 ## API Reference
 
 ### Data Structures

--- a/savings_goals/README.md
+++ b/savings_goals/README.md
@@ -17,6 +17,39 @@ The Savings Goals contract allows users to create savings goals, add/withdraw fu
 - Event emission for audit trails
 - Storage TTL management
 
+## Quickstart
+
+This section provides a minimal example of how to interact with the Savings Goals contract.
+
+**Gotchas:**
+- Amounts are specified in the lowest denomination (e.g., stroops for XLM).
+- If a goal is `locked = true`, you cannot withdraw from it until it is unlocked.
+- By default, the contract uses paginated reads for scalability, so ensure you handle cursors when querying user goals.
+
+### Write Example: Creating a Goal
+*Note: This is pseudo-code demonstrating the Soroban Rust SDK CLI or client approach.*
+```rust
+
+let goal_id = client.create_goal(
+    &owner_address,
+    &String::from_str(&env, "University Fund"),
+    &5000_0000000,                          
+    &(env.ledger().timestamp() + 31536000)  
+);
+
+```
+
+### Read Example: Checking Goal Status
+```rust
+
+let goal_opt = client.get_goal(&goal_id);
+
+if let Some(goal) = goal_opt {
+
+}
+
+```
+
 ## API Reference
 
 ### Data Structures


### PR DESCRIPTION
I implemented a short  Quickstart Sections to each  Contract in the README.







This PR closes this issue #184 