### PR TITLE
test(scenarios): add combined recurring bills + insurance flow

### DIFF
--- a/reporting/src/lib.rs
+++ b/reporting/src/lib.rs
@@ -5,7 +5,7 @@ use soroban_sdk::{
     Env, Map, Vec,
 };
 
-use remitwise_common::Category;
+use remitwise_common::{Category, CoverageType};
 
 // Storage TTL constants
 const DAY_IN_LEDGERS: u32 = 17280;
@@ -240,6 +240,7 @@ pub struct Bill {
     pub id: u32,
     pub owner: Address,
     pub name: soroban_sdk::String,
+    pub external_ref: Option<soroban_sdk::String>,
     pub amount: i128,
     pub due_date: u64,
     pub recurring: bool,
@@ -248,6 +249,7 @@ pub struct Bill {
     pub created_at: u64,
     pub paid_at: Option<u64>,
     pub schedule_id: Option<u32>,
+    pub tags: Vec<soroban_sdk::String>,
     pub currency: soroban_sdk::String,
 }
 
@@ -265,12 +267,12 @@ pub struct InsurancePolicy {
     pub id: u32,
     pub owner: Address,
     pub name: soroban_sdk::String,
-    pub coverage_type: soroban_sdk::String,
+    pub external_ref: Option<soroban_sdk::String>,
+    pub coverage_type: CoverageType,
     pub monthly_premium: i128,
     pub coverage_amount: i128,
     pub active: bool,
     pub next_payment_date: u64,
-    pub schedule_id: Option<u32>,
 }
 
 #[contracttype]

--- a/scenarios/Cargo.toml
+++ b/scenarios/Cargo.toml
@@ -13,3 +13,7 @@ bill_payments = { path = "../bill_payments" }
 insurance = { path = "../insurance" }
 family_wallet = { path = "../family_wallet" }
 reporting = { path = "../reporting" }
+remitwise-common = { path = "../remitwise-common" }
+
+[dev-dependencies]
+proptest = "1"

--- a/scenarios/specs/scenarios-recurring-obligations/.config.kiro
+++ b/scenarios/specs/scenarios-recurring-obligations/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "8984cf35-f66c-48be-969f-def541627cef", "workflowType": "requirements-first", "specType": "feature"}

--- a/scenarios/specs/scenarios-recurring-obligations/design.md
+++ b/scenarios/specs/scenarios-recurring-obligations/design.md
@@ -1,0 +1,309 @@
+# Design Document: Scenarios – Recurring Obligations
+
+## Overview
+
+This feature implements `test_recurring_obligations_flow`, a deterministic end-to-end integration test in `scenarios/tests/flow.rs`. The test exercises the full remittance window lifecycle across six Soroban contracts: RemittanceSplit, BillPayments, Insurance, Reporting, SavingsGoalContract, and FamilyWallet.
+
+The scenario is structured as a linear sequence of phases:
+
+1. Environment and contract initialization
+2. Remittance split configuration
+3. Recurring bill creation
+4. Insurance policy creation and premium payment
+5. Ledger time advancement (simulating billing cycles)
+6. Bill payment and recurring cycle verification
+7. Financial health report verification
+
+The test must be deterministic (no external state, no randomness), isolated (single shared `Env`), and achieve ≥ 95% line coverage of the `scenarios` crate.
+
+---
+
+## Architecture
+
+The scenario lives entirely within the Soroban test harness. All contracts are registered in a single `Env` instance via `env.register_contract(None, ...)`. Cross-contract calls flow through the Reporting contract's client, which in turn calls BillPayments, Insurance, SavingsGoals, and RemittanceSplit via their generated `*Client` types.
+
+```mermaid
+graph TD
+    Test["test_recurring_obligations_flow()"]
+    Env["Soroban Env (mock_all_auths)"]
+    RS["RemittanceSplit"]
+    BP["BillPayments"]
+    INS["Insurance"]
+    SG["SavingsGoalContract"]
+    FW["FamilyWallet"]
+    REP["ReportingContract"]
+
+    Test --> Env
+    Test --> RS
+    Test --> BP
+    Test --> INS
+    Test --> SG
+    Test --> REP
+    REP -->|cross-contract| RS
+    REP -->|cross-contract| BP
+    REP -->|cross-contract| INS
+    REP -->|cross-contract| SG
+    REP -->|cross-contract| FW
+```
+
+The test drives all contracts directly via their clients. The Reporting contract is the only one that makes cross-contract calls; all other contracts are called directly from the test.
+
+---
+
+## Components and Interfaces
+
+### Contracts Used
+
+| Contract            | Client Type                                    | Key Methods Called                                                                                 |
+| ------------------- | ---------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| RemittanceSplit     | `RemittanceSplitClient`                        | `initialize_split`, `calculate_split`, `get_config`                                                |
+| BillPayments        | `BillPaymentsClient`                           | `create_bill`, `get_bill`, `pay_bill`, `get_unpaid_bills`, `get_overdue_bills`, `get_total_unpaid` |
+| Insurance           | `InsuranceClient` (via `insurance::Insurance`) | `create_policy`, `get_policy`, `pay_premium`, `get_total_monthly_premium`                          |
+| SavingsGoalContract | `SavingsGoalContractClient`                    | `create_goal`                                                                                      |
+| ReportingContract   | `ReportingContractClient`                      | `init`, `configure_addresses`, `get_financial_health_report`                                       |
+| FamilyWallet        | registered only                                | (no direct calls; address passed to Reporting)                                                     |
+
+### Ledger Time Advancement
+
+Time is advanced by mutating `env.ledger().set(LedgerInfo { timestamp: ..., ... })`. All other `LedgerInfo` fields (protocol_version, network_id, base_reserve, min_temp_entry_ttl, min_persistent_entry_ttl, max_entry_ttl) are preserved from the initial `setup_env()` configuration.
+
+### Test Function Signature
+
+```rust
+#[test]
+fn test_recurring_obligations_flow() { ... }
+```
+
+Located in `scenarios/tests/flow.rs`.
+
+---
+
+## Data Models
+
+### Key Types (from contract crates)
+
+**Bill** (`bill_payments::Bill`)
+
+```rust
+pub struct Bill {
+    pub id: u32,
+    pub owner: Address,
+    pub name: String,
+    pub amount: i128,
+    pub due_date: u64,
+    pub recurring: bool,
+    pub frequency_days: u32,
+    pub paid: bool,
+    pub created_at: u64,
+    pub paid_at: Option<u64>,
+    pub currency: String,
+    // ...
+}
+```
+
+**InsurancePolicy** (`insurance::InsurancePolicy`)
+
+```rust
+pub struct InsurancePolicy {
+    pub id: u32,
+    pub owner: Address,
+    pub name: String,
+    pub coverage_type: CoverageType,
+    pub monthly_premium: i128,
+    pub coverage_amount: i128,
+    pub active: bool,
+    pub next_payment_date: u64,
+    // ...
+}
+```
+
+**SplitConfig** (`remittance_split::SplitConfig`)
+
+```rust
+pub struct SplitConfig {
+    pub owner: Address,
+    pub spending_percent: u32,
+    pub savings_percent: u32,
+    pub bills_percent: u32,
+    pub insurance_percent: u32,
+    pub initialized: bool,
+    // ...
+}
+```
+
+**FinancialHealthReport** (`reporting::FinancialHealthReport`)
+
+```rust
+pub struct FinancialHealthReport {
+    pub health_score: HealthScore,       // score: u32
+    pub bill_compliance: BillComplianceReport,  // total_bills: u32
+    pub insurance_report: InsuranceReport,      // active_policies: u32
+    pub savings_report: SavingsReport,
+    pub remittance_summary: RemittanceSummary,
+    pub generated_at: u64,
+}
+```
+
+### Scenario-Local State
+
+The test tracks the following local variables across phases:
+
+| Variable                 | Type      | Purpose                                  |
+| ------------------------ | --------- | ---------------------------------------- |
+| `timestamp`              | `u64`     | Initial ledger time (1704067200)         |
+| `user`                   | `Address` | Test user address                        |
+| `admin`                  | `Address` | Reporting admin address                  |
+| `bill_id_1`, `bill_id_2` | `u32`     | IDs of the two recurring bills           |
+| `policy_id`              | `u32`     | ID of the insurance policy               |
+| `total_remittance`       | `i128`    | Total remittance amount for split/report |
+
+---
+
+## Correctness Properties
+
+_A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees._
+
+### Property 1: Split allocation invariant
+
+_For any_ positive total remittance amount and any valid split configuration (four percentages each in [0,100] summing to 100), the sum of all values returned by `calculate_split` must equal the total remittance amount.
+
+**Validates: Requirements 2.4, 2.5**
+
+### Property 2: Invalid percentages rejected
+
+_For any_ combination of four percentages that do not sum to exactly 100 (or where any individual value exceeds 100), `initialize_split` must return `RemittanceSplitError::InvalidPercentages`.
+
+**Validates: Requirements 2.3**
+
+### Property 3: Bill creation produces retrievable unpaid bill
+
+_For any_ valid bill parameters (`amount > 0`, `due_date > current_time`, `recurring = true`, `frequency_days > 0`), calling `create_bill` must return a unique ID, `get_bill(id)` must return a bill with `paid = false`, and the bill must appear in `get_unpaid_bills` for the owner.
+
+**Validates: Requirements 3.1, 3.3, 3.5**
+
+### Property 4: Invalid due date rejected
+
+_For any_ `due_date` strictly less than the current ledger timestamp, `create_bill` must return `BillPaymentsError::InvalidDueDate`.
+
+**Validates: Requirements 3.4**
+
+### Property 5: Overdue detection correctness
+
+_For any_ bill, after advancing ledger time: if `bill.due_date < current_ledger_time` and `bill.paid = false`, the bill must appear in `get_overdue_bills`; if `bill.due_date >= current_ledger_time`, the bill must not appear in `get_overdue_bills`.
+
+**Validates: Requirements 5.2, 5.3, 5.4**
+
+### Property 6: Recurring bill round-trip scheduling
+
+_For any_ recurring bill that is paid via `pay_bill`, the original bill must have `paid = true` and a new unpaid bill must exist with `due_date = original_due_date + frequency_days * 86400`, preserving the original bill's `name`, `amount`, `frequency_days`, and `currency`.
+
+**Validates: Requirements 6.1, 6.2, 6.3, 6.5, 6.6**
+
+### Property 7: Unpaid count non-decrease for recurring bills
+
+_For any_ owner with N unpaid bills where all bills are recurring, after paying one bill the count of unpaid bills for that owner must be >= N (the paid bill is replaced by the next-cycle bill).
+
+**Validates: Requirements 6.4**
+
+### Property 8: Insurance premium payment sets next_payment_date
+
+_For any_ active insurance policy owned by the caller, calling `pay_premium` at ledger time T must return `true` and set `policy.next_payment_date` to exactly `T + 30 * 86400`.
+
+**Validates: Requirements 4.3, 4.4, 8.3**
+
+### Property 9: Policy creation produces active policy
+
+_For any_ valid policy parameters, `create_policy` must return a unique ID and `get_policy(id)` must return a policy with `active = true`.
+
+**Validates: Requirements 4.1, 4.2**
+
+### Property 10: Total monthly premium equals sum of active premiums
+
+_For any_ owner with a set of active policies, `get_total_monthly_premium` must equal the sum of `monthly_premium` across all active policies for that owner.
+
+**Validates: Requirements 4.6**
+
+### Property 11: Bill paid_at equals ledger time at payment
+
+_For any_ unpaid bill, after calling `pay_bill` at ledger time T, `get_bill(id).paid_at` must be `Some(T)`.
+
+**Validates: Requirements 8.2**
+
+### Property 12: Owner isolation
+
+_For any_ two distinct addresses A and B, bills and policies created by A must not appear in `get_unpaid_bills`, `get_active_policies`, or `get_total_monthly_premium` when queried under address B.
+
+**Validates: Requirements 8.5**
+
+### Property 13: Split config round trip
+
+_For any_ valid split configuration `(spending, savings, bills, insurance)` passed to `initialize_split`, the `SplitConfig` retrieved via `get_config` must have matching `spending_percent`, `savings_percent`, `bills_percent`, and `insurance_percent` values.
+
+**Validates: Requirements 8.6**
+
+### Property 14: Health score is non-negative
+
+_For any_ valid scenario state, `FinancialHealthReport.health_score.score` must be a non-negative integer (i.e., `score >= 0`).
+
+**Validates: Requirements 7.3**
+
+---
+
+## Error Handling
+
+| Scenario                                                | Expected Behavior                                                         |
+| ------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `initialize_split` with percentages not summing to 100  | Returns `RemittanceSplitError::InvalidPercentages`; test must not proceed |
+| `create_bill` with `due_date < current_ledger_time`     | Returns `BillPaymentsError::InvalidDueDate`; test must not proceed        |
+| `pay_premium` on non-existent policy ID                 | Returns `false`; test asserts this outcome (Requirement 4.5)              |
+| `reporting.init` or `configure_addresses` returns error | Test panics with descriptive message                                      |
+| Any unexpected `Err` from contract calls                | Test panics immediately (Requirement 8.1)                                 |
+
+All `unwrap()` calls in the scenario must be accompanied by a comment explaining why the value is guaranteed to be `Some` or `Ok`.
+
+---
+
+## Testing Strategy
+
+### Dual Testing Approach
+
+The scenario itself is an integration test. In addition, correctness properties are validated via property-based tests.
+
+**Unit / integration tests** (in `scenarios/tests/flow.rs`):
+
+- `test_recurring_obligations_flow`: the primary scenario, covering all 9 requirements end-to-end
+- Specific assertions for edge cases: non-existent policy premium payment, overdue detection boundary, owner isolation
+
+**Property-based tests** (in `scenarios/tests/flow.rs` or a companion `scenarios/tests/properties.rs`):
+
+- Each correctness property above is implemented as a single property-based test
+- Library: `proptest` (already available in the Rust ecosystem; add to `[dev-dependencies]` in `scenarios/Cargo.toml`)
+- Minimum 100 iterations per property test
+
+### Property Test Tags
+
+Each property test must include a comment in the following format:
+
+```
+// Feature: scenarios-recurring-obligations, Property N: <property_text>
+```
+
+### Coverage
+
+- Target: ≥ 95% line coverage of the `scenarios` crate
+- Measured via `cargo tarpaulin -p scenarios`
+- The scenario must be runnable via `cargo test -p scenarios -- --nocapture` without external network access
+
+### Test Phases and Assertions Summary
+
+| Phase           | Key Assertions                                                                                      |
+| --------------- | --------------------------------------------------------------------------------------------------- |
+| Initialization  | All contracts registered; `reporting.init` and `configure_addresses` succeed                        |
+| Split config    | `initialize_split` returns `Ok(true)`; `get_config` matches input; `calculate_split` sum == total   |
+| Bill creation   | Two bills created; each has `paid = false`; both in `get_unpaid_bills`                              |
+| Policy creation | Policy has `active = true`; `get_total_monthly_premium` == premium                                  |
+| Premium payment | `pay_premium` returns `true`; `next_payment_date == ledger_time + 30*86400`                         |
+| Time advance    | Bills with `due_date < new_time` appear in `get_overdue_bills`                                      |
+| Bill payment    | Original bill `paid = true`, `paid_at == ledger_time`; new bill has correct `due_date`              |
+| Report          | `total_bills >= 2`; `active_policies >= 1`; `health_score.score >= 0`; `period_start <= period_end` |
+| Owner isolation | Querying under different address returns no bills/policies                                          |

--- a/scenarios/specs/scenarios-recurring-obligations/requirements.md
+++ b/scenarios/specs/scenarios-recurring-obligations/requirements.md
@@ -1,0 +1,153 @@
+# Requirements Document
+
+## Introduction
+
+This feature adds a realistic end-to-end scenario test in `scenarios/tests/flow.rs` that exercises the full remittance window lifecycle: configuring a remittance split, creating multiple recurring bills, creating an insurance policy and paying its premium, advancing ledger time across billing cycles, and verifying that the reporting contract reflects correct compliance and coverage signals throughout. The scenario must be deterministic, isolated, well-documented, and achieve at least 95% test coverage of the scenario code paths.
+
+## Glossary
+
+- **System/Scenario**: An integration test exercising multiple contracts together in a realistic user flow.
+- **RemittanceSplit**: Contract that configures how incoming remittance funds are allocated across categories.
+- **BillPayments**: Contract that manages recurring and one-off bill obligations.
+- **Insurance**: Contract that manages insurance policies and premium payments.
+- **Reporting**: Contract that aggregates data from all contracts and produces a FinancialHealthReport.
+- **Remittance_Window**: A defined time period (period_start to period_end) over which a remittance is processed.
+- **Recurring_Bill**: A Bill with recurring = true and a positive frequency_days, which auto-generates the next bill upon payment.
+- **Insurance_Policy**: An InsurancePolicy record with a monthly_premium, coverage_amount, and next_payment_date.
+- **Premium_Payment**: The act of calling pay_premium on an active Insurance_Policy, advancing its next_payment_date by 30 days.
+- **Financial_Health_Report**: The FinancialHealthReport struct returned by Reporting.get_financial_health_report.
+- **Ledger_Time**: The env.ledger().timestamp() value used by all contracts as the authoritative clock.
+- **Env**: The Soroban Env test environment, configured via scenarios::tests::setup_env().
+
+---
+
+## Requirements
+
+### Requirement 1: Environment and Contract Initialization
+
+**User Story:** As a scenario test author, I want all contracts initialized in a shared test environment, so that cross-contract interactions reflect realistic on-chain conditions.
+
+#### Acceptance Criteria
+
+1. THE Scenario SHALL register RemittanceSplit, BillPayments, Insurance, Reporting, SavingsGoalContract, and FamilyWallet contracts in the same Env instance.
+2. THE Scenario SHALL call Reporting.init with a designated admin address before any other reporting calls.
+3. THE Scenario SHALL call Reporting.configure_addresses with the addresses of all registered contracts before generating any report.
+4. IF Reporting.init or Reporting.configure_addresses returns an error, THEN THE Scenario SHALL panic with a descriptive message.
+5. THE Env SHALL be initialized via scenarios::tests::setup_env(), which sets Ledger_Time to 1704067200 (2024-01-01T00:00:00Z).
+
+---
+
+### Requirement 2: Remittance Split Configuration
+
+**User Story:** As a remittance sender, I want to configure how my funds are split across obligations, so that bills and insurance premiums are funded from the correct allocation buckets.
+
+#### Acceptance Criteria
+
+1. WHEN RemittanceSplit.initialize_split is called with valid percentages summing to 100, THE RemittanceSplit SHALL store the split configuration and emit a SplitInitializedEvent.
+2. THE Scenario SHALL configure the split with savings, bills, insurance, and family percentages that sum to exactly 100.
+3. IF the percentages do not sum to 100, THEN THE RemittanceSplit SHALL return a RemittanceSplitError and THE Scenario SHALL not proceed.
+4. WHEN RemittanceSplit.calculate_split is called with a total remittance amount, THE RemittanceSplit SHALL return allocation amounts proportional to the configured percentages.
+5. THE Scenario SHALL assert that the sum of all calculated allocation amounts equals the total remittance amount (allocation invariant).
+
+---
+
+### Requirement 3: Recurring Bill Creation
+
+**User Story:** As a user, I want to create recurring bills for regular obligations, so that each payment cycle automatically schedules the next due date.
+
+#### Acceptance Criteria
+
+1. WHEN BillPayments.create_bill is called with recurring = true and a positive frequency_days, THE BillPayments SHALL create a bill with paid = false and return a unique bill ID.
+2. THE Scenario SHALL create at least two distinct recurring bills (e.g., electricity and internet) with different amounts, due dates, and frequency_days values.
+3. THE Scenario SHALL assert that each created bill is retrievable via BillPayments.get_bill and has paid = false immediately after creation.
+4. IF BillPayments.create_bill is called with a due_date less than the current Ledger_Time, THEN THE BillPayments SHALL return BillPaymentsError::InvalidDueDate and THE Scenario SHALL not proceed.
+5. THE Scenario SHALL assert that BillPayments.get_unpaid_bills returns all created recurring bills before any payment is made.
+
+---
+
+### Requirement 4: Insurance Policy Creation and Premium Payment
+
+**User Story:** As a user, I want to create an insurance policy and pay its premium within the same remittance window, so that my coverage remains active and is reflected in the financial health report.
+
+#### Acceptance Criteria
+
+1. WHEN Insurance.create_policy is called with a valid coverage_type, monthly_premium, and coverage_amount, THE Insurance SHALL create an active policy and return a unique policy ID.
+2. THE Scenario SHALL assert that the created policy is retrievable via Insurance.get_policy with active = true immediately after creation.
+3. WHEN Insurance.pay_premium is called by the policy owner on an active policy, THE Insurance SHALL update next_payment_date to current_Ledger_Time + 30 \* 86400 and return true.
+4. THE Scenario SHALL assert that after pay_premium, the policy's next_payment_date is strictly greater than the Ledger_Time at the time of payment.
+5. IF Insurance.pay_premium is called on a non-existent policy ID, THEN THE Insurance SHALL return false and THE Scenario SHALL assert this outcome.
+6. THE Scenario SHALL assert that Insurance.get_total_monthly_premium for the user equals the sum of all active policy premiums after creation.
+
+---
+
+### Requirement 5: Ledger Time Advancement
+
+**User Story:** As a scenario test author, I want to advance ledger time to simulate billing cycles, so that overdue detection and next-cycle scheduling can be verified.
+
+#### Acceptance Criteria
+
+1. THE Scenario SHALL advance Ledger_Time by at least one full billing cycle (minimum 30 days = 30 \* 86400 seconds) after creating bills and policies.
+2. WHEN Ledger_Time is advanced past a bill's due_date, THE BillPayments SHALL include that bill in the result of get_overdue_bills.
+3. THE Scenario SHALL assert that bills with due_date < current_Ledger_Time appear in get_overdue_bills after the time advance.
+4. THE Scenario SHALL assert that bills with due_date >= current_Ledger_Time do not appear in get_overdue_bills.
+5. WHILE Ledger_Time is advanced, THE Scenario SHALL preserve the protocol_version, network_id, base_reserve, min_temp_entry_ttl, min_persistent_entry_ttl, and max_entry_ttl values from the initial setup_env configuration.
+
+---
+
+### Requirement 6: Bill Payment and Recurring Cycle Verification
+
+**User Story:** As a user, I want to pay recurring bills and verify that the next cycle is automatically created, so that my obligation schedule remains continuous.
+
+#### Acceptance Criteria
+
+1. WHEN BillPayments.pay_bill is called on a recurring bill, THE BillPayments SHALL mark the bill as paid = true and create a new bill with due_date = old_due_date + (frequency_days \* 86400).
+2. THE Scenario SHALL assert that after paying a recurring bill, the original bill has paid = true.
+3. THE Scenario SHALL assert that after paying a recurring bill, a new unpaid bill exists with the correct next due_date (original due_date + frequency_days \* 86400).
+4. THE Scenario SHALL assert that BillPayments.get_unpaid_bills count does not decrease for recurring bills (paid bill is replaced by next cycle bill).
+5. THE Scenario SHALL assert that the new recurring bill preserves the original bill's name, amount, frequency_days, and currency.
+6. FOR ALL recurring bills paid in the scenario, THE Scenario SHALL verify that the next-cycle bill's due_date equals the previous bill's due_date plus frequency_days \* 86400 (round-trip scheduling property).
+
+---
+
+### Requirement 7: Financial Health Report Verification
+
+**User Story:** As a user, I want the financial health report to accurately reflect my bill compliance and insurance coverage after processing payments, so that I can trust the reporting signals.
+
+#### Acceptance Criteria
+
+1. WHEN Reporting.get_financial_health_report is called after all payments, THE Reporting SHALL return a Financial_Health_Report with bill_compliance.total_bills >= 2.
+2. THE Scenario SHALL assert that report.insurance_report.active_policies >= 1 after creating and paying the insurance premium.
+3. THE Scenario SHALL assert that report.health_score.score is a non-negative integer.
+4. THE Scenario SHALL assert that report.bill_compliance.total_bills equals the total number of bills visible to the reporting contract for the user.
+5. WHEN the scenario is run with --nocapture, THE Scenario SHALL print a human-readable summary including: health score, total savings goals, total bills tracked, active insurance policies, and total remittance amount.
+6. THE Scenario SHALL assert that the period_start passed to get_financial_health_report is less than or equal to period_end.
+
+---
+
+### Requirement 8: State Consistency and Event Integrity
+
+**User Story:** As a developer, I want all contract state changes and emitted events to remain consistent across the full scenario, so that the system behaves correctly under realistic multi-contract interactions.
+
+#### Acceptance Criteria
+
+1. THE Scenario SHALL assert that no contract call returns an unexpected error at any step of the flow.
+2. WHEN a bill is paid, THE BillPayments SHALL set the bill's paid_at field, and THE Scenario SHALL verify paid_at is Some and equals the Ledger_Time at the time of payment.
+3. WHEN a premium is paid, THE Insurance SHALL update the policy's next_payment_date, and THE Scenario SHALL verify the updated value equals Ledger_Time + 30 \* 86400.
+4. THE Scenario SHALL assert that BillPayments.get_total_unpaid for the user reflects only unpaid non-recurring bills after all payments.
+5. THE Scenario SHALL assert that owner isolation is maintained: bills and policies created by the test user are not visible when queried under a different address.
+6. THE Scenario SHALL assert that the split configuration stored in RemittanceSplit is retrievable via get_config and matches the values passed to initialize_split.
+
+---
+
+### Requirement 9: Test Coverage and Documentation
+
+**User Story:** As a developer, I want the scenario to be well-documented and achieve at least 95% test coverage, so that the code is maintainable and reviewable.
+
+#### Acceptance Criteria
+
+1. THE Scenario SHALL be implemented in scenarios/tests/flow.rs as a #[test] function named test_recurring_obligations_flow.
+2. THE Scenario SHALL include inline comments explaining each major phase: initialization, split configuration, bill creation, policy creation, time advancement, payment processing, and report verification.
+3. THE Scenario SHALL be runnable via cargo test -p scenarios -- --nocapture without requiring external network access or token funding.
+4. WHERE the scenario exercises a code path that could panic, THE Scenario SHALL use unwrap() only with an accompanying comment explaining why the value is guaranteed to be Some.
+5. THE Scenario SHALL achieve at least 95% line coverage of the scenarios crate as measured by cargo tarpaulin or equivalent.
+6. THE Scenario SHALL not depend on any external state, randomness, or timing outside of the controlled Env ledger.

--- a/scenarios/specs/scenarios-recurring-obligations/tasks.md
+++ b/scenarios/specs/scenarios-recurring-obligations/tasks.md
@@ -1,0 +1,167 @@
+# Implementation Plan: Scenarios – Recurring Obligations
+
+## Overview
+
+Implement `test_recurring_obligations_flow` in `scenarios/tests/flow.rs` as a deterministic end-to-end integration test covering the full remittance window lifecycle across six Soroban contracts. Property-based tests using `proptest` validate correctness properties from the design.
+
+## Tasks
+
+- [x] 1. Set up test infrastructure and dependencies
+  - Add `proptest` to `[dev-dependencies]` in `scenarios/Cargo.toml`
+  - Create or update `scenarios/tests/flow.rs` with required imports: contract client types for RemittanceSplit, BillPayments, Insurance, SavingsGoalContract, FamilyWallet, and ReportingContract
+  - Verify `scenarios::tests::setup_env()` is accessible and sets ledger timestamp to 1704067200
+  - _Requirements: 1.5, 9.1, 9.3_
+
+- [x] 2. Implement environment and contract initialization phase
+  - [x] 2.1 Register all six contracts and initialize Reporting
+    - In `test_recurring_obligations_flow`, call `env.register_contract(None, ...)` for all six contracts
+    - Call `env.mock_all_auths()` to bypass auth checks
+    - Call `reporting.init(admin)` and `reporting.configure_addresses(...)` with all contract addresses
+    - Use `unwrap()` with comments explaining guaranteed success for init calls
+    - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5_
+
+  - [ ]\* 2.2 Write property test for split allocation invariant
+    - **Property 1: Split allocation invariant**
+    - **Validates: Requirements 2.4, 2.5**
+    - `// Feature: scenarios-recurring-obligations, Property 1: split allocation invariant`
+
+  - [ ]\* 2.3 Write property test for invalid percentages rejection
+    - **Property 2: Invalid percentages rejected**
+    - **Validates: Requirements 2.3**
+    - `// Feature: scenarios-recurring-obligations, Property 2: invalid percentages rejected`
+
+- [x] 3. Implement remittance split configuration phase
+  - [x] 3.1 Configure split and assert invariants
+    - Call `remittance_split.initialize_split(user, savings_pct, bills_pct, insurance_pct, family_pct)` with percentages summing to 100
+    - Assert return value is `Ok(true)` (or equivalent success)
+    - Call `remittance_split.get_config(user)` and assert stored percentages match inputs
+    - Call `remittance_split.calculate_split(user, total_remittance)` and assert sum of allocations equals `total_remittance`
+    - _Requirements: 2.1, 2.2, 2.4, 2.5, 8.6_
+
+  - [ ]\* 3.2 Write property test for split config round trip
+    - **Property 13: Split config round trip**
+    - **Validates: Requirements 8.6**
+    - `// Feature: scenarios-recurring-obligations, Property 13: split config round trip`
+
+- [x] 4. Implement recurring bill creation phase
+  - [x] 4.1 Create two recurring bills and assert initial state
+    - Call `bill_payments.create_bill(...)` twice with distinct names, amounts, due dates (> current ledger time), and `frequency_days` values; store returned IDs as `bill_id_1` and `bill_id_2`
+    - Assert each bill is retrievable via `get_bill(id)` with `paid = false`
+    - Assert both bills appear in `get_unpaid_bills(user)`
+    - Add inline comment for each `unwrap()` explaining guaranteed `Some`
+    - _Requirements: 3.1, 3.2, 3.3, 3.5_
+
+  - [ ]\* 4.2 Write property test for bill creation produces retrievable unpaid bill
+    - **Property 3: Bill creation produces retrievable unpaid bill**
+    - **Validates: Requirements 3.1, 3.3, 3.5**
+    - `// Feature: scenarios-recurring-obligations, Property 3: bill creation produces retrievable unpaid bill`
+
+  - [ ]\* 4.3 Write property test for invalid due date rejection
+    - **Property 4: Invalid due date rejected**
+    - **Validates: Requirements 3.4**
+    - `// Feature: scenarios-recurring-obligations, Property 4: invalid due date rejected`
+
+- [x] 5. Implement insurance policy creation and premium payment phase
+  - [x] 5.1 Create policy and pay premium, assert state
+    - Call `insurance.create_policy(user, coverage_type, monthly_premium, coverage_amount)` and store `policy_id`
+    - Assert `get_policy(policy_id).active == true`
+    - Assert `get_total_monthly_premium(user) == monthly_premium`
+    - Call `insurance.pay_premium(user, policy_id)` and assert it returns `true`
+    - Assert `get_policy(policy_id).next_payment_date == ledger_time + 30 * 86400`
+    - Call `insurance.pay_premium(user, nonexistent_id)` and assert it returns `false`
+    - _Requirements: 4.1, 4.2, 4.3, 4.4, 4.5, 4.6_
+
+  - [ ]\* 5.2 Write property test for policy creation produces active policy
+    - **Property 9: Policy creation produces active policy**
+    - **Validates: Requirements 4.1, 4.2**
+    - `// Feature: scenarios-recurring-obligations, Property 9: policy creation produces active policy`
+
+  - [ ]\* 5.3 Write property test for insurance premium payment sets next_payment_date
+    - **Property 8: Insurance premium payment sets next_payment_date**
+    - **Validates: Requirements 4.3, 4.4, 8.3**
+    - `// Feature: scenarios-recurring-obligations, Property 8: insurance premium payment sets next_payment_date`
+
+  - [ ]\* 5.4 Write property test for total monthly premium equals sum of active premiums
+    - **Property 10: Total monthly premium equals sum of active premiums**
+    - **Validates: Requirements 4.6**
+    - `// Feature: scenarios-recurring-obligations, Property 10: total monthly premium equals sum of active premiums`
+
+- [x] 6. Checkpoint – Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [x] 7. Implement ledger time advancement phase
+  - [x] 7.1 Advance ledger time and assert overdue detection
+    - Capture current `LedgerInfo` fields from `setup_env()` configuration
+    - Advance `env.ledger().set(LedgerInfo { timestamp: timestamp + 31 * 86400, ... })` preserving all other fields
+    - Assert bills with `due_date < new_timestamp` appear in `get_overdue_bills(user)`
+    - Assert bills with `due_date >= new_timestamp` do not appear in `get_overdue_bills(user)`
+    - _Requirements: 5.1, 5.2, 5.3, 5.4, 5.5_
+
+  - [ ]\* 7.2 Write property test for overdue detection correctness
+    - **Property 5: Overdue detection correctness**
+    - **Validates: Requirements 5.2, 5.3, 5.4**
+    - `// Feature: scenarios-recurring-obligations, Property 5: overdue detection correctness`
+
+- [x] 8. Implement bill payment and recurring cycle verification phase
+  - [x] 8.1 Pay recurring bills and verify next-cycle scheduling
+    - Call `bill_payments.pay_bill(user, bill_id_1)` and `pay_bill(user, bill_id_2)`
+    - Assert original bills have `paid = true` and `paid_at == Some(current_ledger_time)`
+    - Assert new unpaid bills exist with `due_date == original_due_date + frequency_days * 86400`
+    - Assert new bills preserve `name`, `amount`, `frequency_days`, and `currency` from originals
+    - Assert `get_unpaid_bills(user).len() >= 2` (count does not decrease)
+    - _Requirements: 6.1, 6.2, 6.3, 6.4, 6.5, 6.6, 8.2_
+
+  - [ ]\* 8.2 Write property test for recurring bill round-trip scheduling
+    - **Property 6: Recurring bill round-trip scheduling**
+    - **Validates: Requirements 6.1, 6.2, 6.3, 6.5, 6.6**
+    - `// Feature: scenarios-recurring-obligations, Property 6: recurring bill round-trip scheduling`
+
+  - [ ]\* 8.3 Write property test for unpaid count non-decrease for recurring bills
+    - **Property 7: Unpaid count non-decrease for recurring bills**
+    - **Validates: Requirements 6.4**
+    - `// Feature: scenarios-recurring-obligations, Property 7: unpaid count non-decrease for recurring bills`
+
+  - [ ]\* 8.4 Write property test for bill paid_at equals ledger time at payment
+    - **Property 11: Bill paid_at equals ledger time at payment**
+    - **Validates: Requirements 8.2**
+    - `// Feature: scenarios-recurring-obligations, Property 11: bill paid_at equals ledger time at payment`
+
+- [x] 9. Implement financial health report verification phase
+  - [x] 9.1 Generate and assert financial health report
+    - Call `reporting.get_financial_health_report(user, period_start, period_end)` where `period_start <= period_end`
+    - Assert `report.bill_compliance.total_bills >= 2`
+    - Assert `report.insurance_report.active_policies >= 1`
+    - Assert `report.health_score.score >= 0`
+    - Assert `report.bill_compliance.total_bills` equals total bills visible to reporting for the user
+    - Print human-readable summary via `println!` including health score, total savings goals, total bills tracked, active insurance policies, and total remittance amount
+    - _Requirements: 7.1, 7.2, 7.3, 7.4, 7.5, 7.6_
+
+  - [ ]\* 9.2 Write property test for health score is non-negative
+    - **Property 14: Health score is non-negative**
+    - **Validates: Requirements 7.3**
+    - `// Feature: scenarios-recurring-obligations, Property 14: health score is non-negative`
+
+- [x] 10. Implement state consistency and owner isolation assertions
+  - [x] 10.1 Assert owner isolation and state consistency
+    - Create a second address `other_user` and assert `get_unpaid_bills(other_user)` returns empty
+    - Assert `get_total_monthly_premium(other_user) == 0`
+    - Assert `get_total_unpaid(user)` reflects only unpaid non-recurring bills after all payments
+    - _Requirements: 8.4, 8.5_
+
+  - [ ]\* 10.2 Write property test for owner isolation
+    - **Property 12: Owner isolation**
+    - **Validates: Requirements 8.5**
+    - `// Feature: scenarios-recurring-obligations, Property 12: owner isolation`
+
+- [x] 11. Final checkpoint – Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+  - Verify scenario runs via `cargo test -p scenarios -- --nocapture` without external network access
+  - _Requirements: 9.3, 9.6_
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for faster MVP
+- Each task references specific requirements for traceability
+- Checkpoints ensure incremental validation
+- Property tests use `proptest` with minimum 100 iterations per property
+- All `unwrap()` calls must include a comment explaining why the value is guaranteed

--- a/scenarios/tests/flow.rs
+++ b/scenarios/tests/flow.rs
@@ -158,7 +158,10 @@ fn test_recurring_obligations_flow() {
     // Capture the initial ledger timestamp for use in due-date calculations.
     let timestamp = env.ledger().timestamp();
     // Verify setup_env sets the expected initial ledger timestamp (Requirement 1.5)
-    assert_eq!(timestamp, 1704067200, "setup_env must set ledger timestamp to 1704067200");
+    assert_eq!(
+        timestamp, 1704067200,
+        "setup_env must set ledger timestamp to 1704067200"
+    );
 
     // Register all six contracts in the shared Env instance (Requirement 1.1).
     // env.register_contract(None, ...) assigns a deterministic address and
@@ -209,7 +212,7 @@ fn test_recurring_obligations_flow() {
     let bills_pct: u32 = 40;
     let insurance_pct: u32 = 20;
     let family_pct: u32 = 10; // maps to "spending" bucket in the contract
-    // Sanity check: percentages sum to 100 (Requirement 2.2, 2.3)
+                              // Sanity check: percentages sum to 100 (Requirement 2.2, 2.3)
     assert_eq!(
         family_pct + savings_pct + bills_pct + insurance_pct,
         100,
@@ -244,10 +247,8 @@ fn test_recurring_obligations_flow() {
     // Retrieve the stored config and assert each percentage matches the input
     // (Requirement 8.6: split config round trip).
     // Guaranteed Some: initialize_split just succeeded, so CONFIG is set in storage.
-    let config = remittance_split
-        .get_config()
-        .unwrap(); // guaranteed Some: initialize_split just stored the config
-    // Assert stored percentages match the values passed to initialize_split (Requirement 8.6)
+    let config = remittance_split.get_config().unwrap(); // guaranteed Some: initialize_split just stored the config
+                                                         // Assert stored percentages match the values passed to initialize_split (Requirement 8.6)
     assert_eq!(
         config.spending_percent, family_pct,
         "stored spending_percent must match family_pct input [Req 8.6]"
@@ -276,8 +277,7 @@ fn test_recurring_obligations_flow() {
     // so the sum is always exact.
     let allocation_sum: i128 = allocations.iter().sum();
     assert_eq!(
-        allocation_sum,
-        total_remittance,
+        allocation_sum, total_remittance,
         "sum of all split allocations must equal total_remittance [Req 2.4, 2.5]"
     );
 
@@ -294,7 +294,7 @@ fn test_recurring_obligations_flow() {
         &user,
         &String::from_str(&env, "Electricity"),
         &150i128,
-        &(timestamp + 86400 * 7),  // due in 7 days — guaranteed > current ledger time
+        &(timestamp + 86400 * 7), // due in 7 days — guaranteed > current ledger time
         &true,
         &30u32,
         &None,
@@ -319,18 +319,14 @@ fn test_recurring_obligations_flow() {
 
     // get_bill returns Option<Bill>; guaranteed Some because create_bill just stored
     // the bill with the returned ID in the same contract instance.
-    let bill1 = bill_payments
-        .get_bill(&bill_id_1)
-        .unwrap(); // guaranteed Some: bill was just created with this ID
+    let bill1 = bill_payments.get_bill(&bill_id_1).unwrap(); // guaranteed Some: bill was just created with this ID
     assert!(
         !bill1.paid,
         "bill_id_1 must have paid = false immediately after creation [Req 3.3]"
     );
 
     // get_bill returns Option<Bill>; guaranteed Some for the same reason as bill1.
-    let bill2 = bill_payments
-        .get_bill(&bill_id_2)
-        .unwrap(); // guaranteed Some: bill was just created with this ID
+    let bill2 = bill_payments.get_bill(&bill_id_2).unwrap(); // guaranteed Some: bill was just created with this ID
     assert!(
         !bill2.paid,
         "bill_id_2 must have paid = false immediately after creation [Req 3.3]"
@@ -380,9 +376,7 @@ fn test_recurring_obligations_flow() {
 
     // Assert the policy is retrievable and active immediately after creation (Requirement 4.1, 4.2).
     // Guaranteed Some: create_policy just stored the policy with the returned ID.
-    let policy = insurance
-        .get_policy(&policy_id)
-        .unwrap(); // guaranteed Some: policy was just created with this ID
+    let policy = insurance.get_policy(&policy_id).unwrap(); // guaranteed Some: policy was just created with this ID
     assert!(
         policy.active,
         "newly created policy must have active = true [Req 4.1, 4.2]"
@@ -406,9 +400,7 @@ fn test_recurring_obligations_flow() {
 
     // Assert next_payment_date == ledger_time + 30 * 86400 after paying (Requirement 4.3, 4.4, 8.3).
     // Guaranteed Some: policy still exists (pay_premium does not delete it).
-    let policy_after_pay = insurance
-        .get_policy(&policy_id)
-        .unwrap(); // guaranteed Some: policy still exists after premium payment
+    let policy_after_pay = insurance.get_policy(&policy_id).unwrap(); // guaranteed Some: policy still exists after premium payment
     let expected_next_payment = timestamp + 30 * 86400;
     assert_eq!(
         policy_after_pay.next_payment_date,
@@ -543,9 +535,7 @@ fn test_recurring_obligations_flow() {
     // Assert original bill 1 has paid = true and paid_at == Some(new_timestamp)
     // (Requirements 6.2, 8.2).
     // Guaranteed Some: bill_id_1 still exists in storage (pay_bill does not delete bills).
-    let paid_bill1 = bill_payments
-        .get_bill(&bill_id_1)
-        .unwrap(); // guaranteed Some: pay_bill marks paid but does not remove the bill
+    let paid_bill1 = bill_payments.get_bill(&bill_id_1).unwrap(); // guaranteed Some: pay_bill marks paid but does not remove the bill
     assert!(
         paid_bill1.paid,
         "bill_id_1 must have paid = true after pay_bill [Req 6.2]"
@@ -559,9 +549,7 @@ fn test_recurring_obligations_flow() {
     // Assert original bill 2 has paid = true and paid_at == Some(new_timestamp)
     // (Requirements 6.2, 8.2).
     // Guaranteed Some: same reason as bill_id_1.
-    let paid_bill2 = bill_payments
-        .get_bill(&bill_id_2)
-        .unwrap(); // guaranteed Some: pay_bill marks paid but does not remove the bill
+    let paid_bill2 = bill_payments.get_bill(&bill_id_2).unwrap(); // guaranteed Some: pay_bill marks paid but does not remove the bill
     assert!(
         paid_bill2.paid,
         "bill_id_2 must have paid = true after pay_bill [Req 6.2]"
@@ -619,44 +607,36 @@ fn test_recurring_obligations_flow() {
     // Assert new bills preserve name, amount, frequency_days, and currency from originals
     // (Requirement 6.5).
     assert_eq!(
-        next_bill1.name,
-        bill1.name,
+        next_bill1.name, bill1.name,
         "next-cycle Electricity bill must preserve name [Req 6.5]"
     );
     assert_eq!(
-        next_bill1.amount,
-        bill1.amount,
+        next_bill1.amount, bill1.amount,
         "next-cycle Electricity bill must preserve amount [Req 6.5]"
     );
     assert_eq!(
-        next_bill1.frequency_days,
-        bill1.frequency_days,
+        next_bill1.frequency_days, bill1.frequency_days,
         "next-cycle Electricity bill must preserve frequency_days [Req 6.5]"
     );
     assert_eq!(
-        next_bill1.currency,
-        bill1.currency,
+        next_bill1.currency, bill1.currency,
         "next-cycle Electricity bill must preserve currency [Req 6.5]"
     );
 
     assert_eq!(
-        next_bill2.name,
-        bill2.name,
+        next_bill2.name, bill2.name,
         "next-cycle Internet bill must preserve name [Req 6.5]"
     );
     assert_eq!(
-        next_bill2.amount,
-        bill2.amount,
+        next_bill2.amount, bill2.amount,
         "next-cycle Internet bill must preserve amount [Req 6.5]"
     );
     assert_eq!(
-        next_bill2.frequency_days,
-        bill2.frequency_days,
+        next_bill2.frequency_days, bill2.frequency_days,
         "next-cycle Internet bill must preserve frequency_days [Req 6.5]"
     );
     assert_eq!(
-        next_bill2.currency,
-        bill2.currency,
+        next_bill2.currency, bill2.currency,
         "next-cycle Internet bill must preserve currency [Req 6.5]"
     );
 
@@ -695,12 +675,8 @@ fn test_recurring_obligations_flow() {
     // Guaranteed to succeed: reporting contract is initialized and configured, all
     // dependency contracts are registered and have data, mock_all_auths() bypasses
     // require_auth. The Soroban client panics on Err, satisfying Requirement 8.1.
-    let report = reporting.get_financial_health_report(
-        &user,
-        &total_remittance,
-        &period_start,
-        &period_end,
-    );
+    let report =
+        reporting.get_financial_health_report(&user, &total_remittance, &period_start, &period_end);
 
     // Assert report.bill_compliance.total_bills >= 2 (Requirement 7.1).
     // We created two recurring bills (Electricity and Internet) in Phase 3, and
@@ -758,8 +734,14 @@ fn test_recurring_obligations_flow() {
     println!("==== Financial Health Report Summary ====");
     println!("Health Score       : {}", report.health_score.score);
     println!("Total Savings Goals: {}", report.savings_report.total_goals);
-    println!("Total Bills Tracked: {}", report.bill_compliance.total_bills);
-    println!("Active Policies    : {}", report.insurance_report.active_policies);
+    println!(
+        "Total Bills Tracked: {}",
+        report.bill_compliance.total_bills
+    );
+    println!(
+        "Active Policies    : {}",
+        report.insurance_report.active_policies
+    );
     println!("Total Remittance   : {}", total_remittance);
     println!("=========================================");
 
@@ -780,8 +762,7 @@ fn test_recurring_obligations_flow() {
     // appear under `other_user`).
     let other_unpaid = bill_payments.get_unpaid_bills(&other_user, &0u32, &0u32);
     assert_eq!(
-        other_unpaid.count,
-        0,
+        other_unpaid.count, 0,
         "get_unpaid_bills for a fresh address must return count == 0 [Req 8.5]"
     );
 
@@ -790,8 +771,7 @@ fn test_recurring_obligations_flow() {
     // must not be counted under `other_user`).
     let other_premium = insurance.get_total_monthly_premium(&other_user);
     assert_eq!(
-        other_premium,
-        0,
+        other_premium, 0,
         "get_total_monthly_premium for a fresh address must return 0 [Req 8.5]"
     );
 

--- a/scenarios/tests/flow.rs
+++ b/scenarios/tests/flow.rs
@@ -1,7 +1,8 @@
 use bill_payments::{BillPayments, BillPaymentsClient};
 use family_wallet::FamilyWallet;
-use insurance::Insurance;
+use insurance::{Insurance, InsuranceClient};
 use remittance_split::{RemittanceSplit, RemittanceSplitClient};
+use remitwise_common::CoverageType;
 use reporting::{ReportingContract, ReportingContractClient};
 use savings_goals::{SavingsGoalContract, SavingsGoalContractClient};
 use soroban_sdk::{
@@ -127,4 +128,695 @@ fn test_end_to_end_flow() {
     // Basic assertions
     assert_eq!(report.savings_report.total_goals, 1);
     assert_eq!(report.bill_compliance.total_bills, 1);
+}
+
+/// End-to-end scenario: full remittance window lifecycle across six Soroban contracts.
+///
+/// Phases:
+/// 1. Environment and contract initialization
+/// 2. Remittance split configuration
+/// 3. Recurring bill creation
+/// 4. Insurance policy creation and premium payment
+/// 5. Ledger time advancement (simulating billing cycles)
+/// 6. Bill payment and recurring cycle verification
+/// 7. Financial health report verification
+#[test]
+fn test_recurring_obligations_flow() {
+    // ── Phase 1: Environment and contract initialization ──────────────────────
+    //
+    // setup_env() configures the Soroban mock environment with:
+    //   - ledger timestamp = 1704067200 (2024-01-01T00:00:00Z)  [Requirement 1.5]
+    //   - mock_all_auths_allowing_non_root_auth() to bypass auth checks
+    let env = scenarios::tests::setup_env();
+
+    // Explicitly bypass all auth checks so contract calls succeed without
+    // real signatures. setup_env already calls mock_all_auths_allowing_non_root_auth,
+    // but we call mock_all_auths() here to ensure the strictest bypass is active
+    // for all cross-contract calls made during the scenario.
+    env.mock_all_auths();
+
+    // Capture the initial ledger timestamp for use in due-date calculations.
+    let timestamp = env.ledger().timestamp();
+    // Verify setup_env sets the expected initial ledger timestamp (Requirement 1.5)
+    assert_eq!(timestamp, 1704067200, "setup_env must set ledger timestamp to 1704067200");
+
+    // Register all six contracts in the shared Env instance (Requirement 1.1).
+    // env.register_contract(None, ...) assigns a deterministic address and
+    // installs the contract WASM in the mock environment.
+    let split_id = env.register_contract(None, RemittanceSplit);
+    let savings_id = env.register_contract(None, SavingsGoalContract);
+    let bills_id = env.register_contract(None, BillPayments);
+    let insurance_id = env.register_contract(None, Insurance);
+    let family_id = env.register_contract(None, FamilyWallet);
+    let reporting_id = env.register_contract(None, ReportingContract);
+
+    // Build typed clients for each contract.
+    let remittance_split = RemittanceSplitClient::new(&env, &split_id);
+    let _savings = SavingsGoalContractClient::new(&env, &savings_id);
+    let bill_payments = BillPaymentsClient::new(&env, &bills_id);
+    let insurance = InsuranceClient::new(&env, &insurance_id);
+    let reporting = ReportingContractClient::new(&env, &reporting_id);
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    // Initialize Reporting with the designated admin address (Requirement 1.2).
+    // Guaranteed to succeed: the contract is freshly registered and has no prior
+    // admin set, so ReportingContract::init will not return AlreadyInitialized.
+    reporting.init(&admin);
+
+    // Configure Reporting with the addresses of all registered contracts (Requirement 1.3).
+    // Guaranteed to succeed: admin is correctly set (init just ran), all six
+    // addresses are distinct registered contracts, and none is the reporting
+    // contract itself — so validate_dependency_address_set will not reject them.
+    // If this call were to fail, the non-try_ client method panics with a
+    // descriptive Soroban error, satisfying Requirement 1.4.
+    reporting.configure_addresses(
+        &admin,
+        &split_id,
+        &savings_id,
+        &bills_id,
+        &insurance_id,
+        &family_id,
+    );
+
+    // ── Phase 2: Remittance split configuration ───────────────────────────────
+    //
+    // Configure how incoming remittance funds are allocated across four buckets.
+    // Percentages must sum to exactly 100 (Requirement 2.2).
+    // Mapping: spending=family(10), savings=30, bills=40, insurance=20.
+    let savings_pct: u32 = 30;
+    let bills_pct: u32 = 40;
+    let insurance_pct: u32 = 20;
+    let family_pct: u32 = 10; // maps to "spending" bucket in the contract
+    // Sanity check: percentages sum to 100 (Requirement 2.2, 2.3)
+    assert_eq!(
+        family_pct + savings_pct + bills_pct + insurance_pct,
+        100,
+        "split percentages must sum to 100"
+    );
+
+    // A mock USDC address is required by initialize_split for token-substitution
+    // attack prevention; no actual token transfers occur in this test.
+    let mock_usdc = Address::generate(&env);
+    // Nonce starts at 0 for a freshly registered contract (Requirement 8.1).
+    let nonce: u64 = 0;
+
+    // Call initialize_split with valid percentages summing to 100 (Requirement 2.1).
+    // Guaranteed to return true: contract is freshly registered (no prior config), percentages
+    // are valid and sum to 100, nonce is 0 (correct initial value), and mock_all_auths()
+    // bypasses the require_auth_for_args check. The Soroban client panics on Err.
+    let init_result = remittance_split.initialize_split(
+        &user,
+        &nonce,
+        &mock_usdc,
+        &family_pct,    // spending_percent (family bucket)
+        &savings_pct,   // savings_percent
+        &bills_pct,     // bills_percent
+        &insurance_pct, // insurance_percent
+    );
+    // Assert return value is true — confirms split was stored (Requirement 2.1)
+    assert!(
+        init_result,
+        "initialize_split must return true for valid percentages summing to 100 [Req 2.1]"
+    );
+
+    // Retrieve the stored config and assert each percentage matches the input
+    // (Requirement 8.6: split config round trip).
+    // Guaranteed Some: initialize_split just succeeded, so CONFIG is set in storage.
+    let config = remittance_split
+        .get_config()
+        .unwrap(); // guaranteed Some: initialize_split just stored the config
+    // Assert stored percentages match the values passed to initialize_split (Requirement 8.6)
+    assert_eq!(
+        config.spending_percent, family_pct,
+        "stored spending_percent must match family_pct input [Req 8.6]"
+    );
+    assert_eq!(
+        config.savings_percent, savings_pct,
+        "stored savings_percent must match savings_pct input [Req 8.6]"
+    );
+    assert_eq!(
+        config.bills_percent, bills_pct,
+        "stored bills_percent must match bills_pct input [Req 8.6]"
+    );
+    assert_eq!(
+        config.insurance_percent, insurance_pct,
+        "stored insurance_percent must match insurance_pct input [Req 8.6]"
+    );
+
+    // Calculate the split for a known total remittance amount (Requirement 2.4).
+    let total_remittance: i128 = 5000;
+    // Guaranteed to not panic: contract is initialized and total_remittance > 0.
+    // The Soroban client unwraps the Result automatically and panics on Err.
+    let allocations = remittance_split.calculate_split(&total_remittance);
+
+    // Assert allocation invariant: sum of all allocations equals total_remittance (Requirement 2.5).
+    // The contract assigns the remainder to the last bucket to absorb integer rounding,
+    // so the sum is always exact.
+    let allocation_sum: i128 = allocations.iter().sum();
+    assert_eq!(
+        allocation_sum,
+        total_remittance,
+        "sum of all split allocations must equal total_remittance [Req 2.4, 2.5]"
+    );
+
+    // ── Phase 3: Recurring bill creation ─────────────────────────────────────
+    //
+    // Create two distinct recurring bills with future due dates (Requirement 3.1, 3.2).
+    // Both bills have recurring = true and a positive frequency_days so that paying
+    // them will auto-schedule the next cycle (Requirement 6.1).
+
+    // Bill 1: Electricity — due in 7 days, repeats every 30 days.
+    // create_bill returns Ok(u32); the Soroban client panics on Err, so the
+    // returned value is guaranteed to be the new bill's unique ID.
+    let bill_id_1 = bill_payments.create_bill(
+        &user,
+        &String::from_str(&env, "Electricity"),
+        &150i128,
+        &(timestamp + 86400 * 7),  // due in 7 days — guaranteed > current ledger time
+        &true,
+        &30u32,
+        &None,
+        &String::from_str(&env, "USDC"),
+    );
+
+    // Bill 2: Internet — due in 14 days, repeats every 30 days.
+    // Same guarantee: freshly registered contract, valid params, mock_all_auths active.
+    let bill_id_2 = bill_payments.create_bill(
+        &user,
+        &String::from_str(&env, "Internet"),
+        &80i128,
+        &(timestamp + 86400 * 14), // due in 14 days — guaranteed > current ledger time
+        &true,
+        &30u32,
+        &None,
+        &String::from_str(&env, "USDC"),
+    );
+
+    // Assert each bill is retrievable and has paid = false immediately after creation
+    // (Requirement 3.3).
+
+    // get_bill returns Option<Bill>; guaranteed Some because create_bill just stored
+    // the bill with the returned ID in the same contract instance.
+    let bill1 = bill_payments
+        .get_bill(&bill_id_1)
+        .unwrap(); // guaranteed Some: bill was just created with this ID
+    assert!(
+        !bill1.paid,
+        "bill_id_1 must have paid = false immediately after creation [Req 3.3]"
+    );
+
+    // get_bill returns Option<Bill>; guaranteed Some for the same reason as bill1.
+    let bill2 = bill_payments
+        .get_bill(&bill_id_2)
+        .unwrap(); // guaranteed Some: bill was just created with this ID
+    assert!(
+        !bill2.paid,
+        "bill_id_2 must have paid = false immediately after creation [Req 3.3]"
+    );
+
+    // Assert both bills appear in get_unpaid_bills before any payment (Requirement 3.5).
+    // cursor = 0 (start from beginning), limit = 0 (use contract default, covers all bills).
+    let unpaid_page = bill_payments.get_unpaid_bills(&user, &0u32, &0u32);
+    let mut found_bill1 = false;
+    let mut found_bill2 = false;
+    for bill in unpaid_page.items.iter() {
+        if bill.id == bill_id_1 {
+            found_bill1 = true;
+        }
+        if bill.id == bill_id_2 {
+            found_bill2 = true;
+        }
+    }
+    assert!(
+        found_bill1,
+        "get_unpaid_bills must include bill_id_1 before any payment [Req 3.5]"
+    );
+    assert!(
+        found_bill2,
+        "get_unpaid_bills must include bill_id_2 before any payment [Req 3.5]"
+    );
+
+    // ── Phase 4: Insurance policy creation and premium payment ────────────────
+    //
+    // Create a Health insurance policy and verify it is immediately active,
+    // then pay the premium and assert the next_payment_date advances by 30 days.
+
+    let monthly_premium: i128 = 100;
+    let coverage_amount: i128 = 10_000;
+
+    // create_policy returns a unique u32 policy ID.
+    // Guaranteed to succeed: contract is freshly registered, all params are valid,
+    // and mock_all_auths() bypasses require_auth.
+    let policy_id = insurance.create_policy(
+        &user,
+        &String::from_str(&env, "Health Insurance"),
+        &CoverageType::Health,
+        &monthly_premium,
+        &coverage_amount,
+        &None, // no external_ref
+    );
+
+    // Assert the policy is retrievable and active immediately after creation (Requirement 4.1, 4.2).
+    // Guaranteed Some: create_policy just stored the policy with the returned ID.
+    let policy = insurance
+        .get_policy(&policy_id)
+        .unwrap(); // guaranteed Some: policy was just created with this ID
+    assert!(
+        policy.active,
+        "newly created policy must have active = true [Req 4.1, 4.2]"
+    );
+
+    // Assert get_total_monthly_premium equals the single active policy's premium (Requirement 4.6).
+    let total_premium = insurance.get_total_monthly_premium(&user);
+    assert_eq!(
+        total_premium,
+        monthly_premium,
+        "get_total_monthly_premium must equal the monthly_premium of the single active policy [Req 4.6]"
+    );
+
+    // Pay the premium on the active policy (Requirement 4.3).
+    // Guaranteed true: policy exists, owner matches user, policy is active, mock_all_auths active.
+    let pay_result = insurance.pay_premium(&user, &policy_id);
+    assert!(
+        pay_result,
+        "pay_premium must return true for an active policy owned by the caller [Req 4.3]"
+    );
+
+    // Assert next_payment_date == ledger_time + 30 * 86400 after paying (Requirement 4.3, 4.4, 8.3).
+    // Guaranteed Some: policy still exists (pay_premium does not delete it).
+    let policy_after_pay = insurance
+        .get_policy(&policy_id)
+        .unwrap(); // guaranteed Some: policy still exists after premium payment
+    let expected_next_payment = timestamp + 30 * 86400;
+    assert_eq!(
+        policy_after_pay.next_payment_date,
+        expected_next_payment,
+        "next_payment_date must equal ledger_time + 30 * 86400 after pay_premium [Req 4.3, 4.4, 8.3]"
+    );
+    assert!(
+        policy_after_pay.next_payment_date > timestamp,
+        "next_payment_date must be strictly greater than ledger_time at time of payment [Req 4.4]"
+    );
+
+    // Assert pay_premium returns false for a non-existent policy ID (Requirement 4.5).
+    let nonexistent_id: u32 = 9999;
+    let pay_nonexistent = insurance.pay_premium(&user, &nonexistent_id);
+    assert!(
+        !pay_nonexistent,
+        "pay_premium must return false for a non-existent policy ID [Req 4.5]"
+    );
+
+    // ── Phase 5: Ledger time advancement ─────────────────────────────────────
+    //
+    // Advance ledger time by 31 days to simulate a full billing cycle passing.
+    // This pushes both bills past their due dates so overdue detection can be
+    // verified (Requirements 5.1–5.5).
+    //
+    // Bill 1 (Electricity): due_date = timestamp + 7*86400  = 1704672000
+    // Bill 2 (Internet):    due_date = timestamp + 14*86400 = 1705276800
+    // New timestamp after +31 days:                          1706745600
+    // Both due_dates < new_timestamp → both are OVERDUE (Requirement 5.2, 5.3)
+    //
+    // All LedgerInfo fields except `timestamp` are preserved from setup_env()
+    // (Requirement 5.5): protocol_version=20, sequence_number=1, network_id=[0;32],
+    // base_reserve=10, min_temp_entry_ttl=10, min_persistent_entry_ttl=10,
+    // max_entry_ttl=3110400.
+    let new_timestamp = timestamp + 31 * 86400; // 1704067200 + 2678400 = 1706745600
+    env.ledger().set(soroban_sdk::testutils::LedgerInfo {
+        timestamp: new_timestamp,
+        protocol_version: 20,
+        sequence_number: 1,
+        network_id: [0; 32],
+        base_reserve: 10,
+        min_temp_entry_ttl: 10,
+        min_persistent_entry_ttl: 10,
+        max_entry_ttl: 3110400,
+    });
+
+    // Confirm the ledger timestamp was actually advanced (Requirement 5.1).
+    assert_eq!(
+        env.ledger().timestamp(),
+        new_timestamp,
+        "ledger timestamp must equal new_timestamp after set [Req 5.1]"
+    );
+
+    // Retrieve all overdue bills (cursor=0, limit=0 → contract default covers all).
+    // get_overdue_bills is global (no owner filter); it returns every unpaid bill
+    // whose due_date < current_ledger_time.
+    let overdue_page = bill_payments.get_overdue_bills(&0u32, &0u32);
+
+    // Assert bill_id_1 (Electricity, due_date = timestamp + 7*86400 = 1704672000)
+    // appears in get_overdue_bills because 1704672000 < 1706745600 (Requirement 5.2, 5.3).
+    let mut found_overdue_1 = false;
+    let mut found_overdue_2 = false;
+    for bill in overdue_page.items.iter() {
+        if bill.id == bill_id_1 {
+            // Verify the bill is indeed unpaid and past due (Requirement 5.2)
+            assert!(
+                !bill.paid,
+                "overdue bill_id_1 must still be unpaid [Req 5.2]"
+            );
+            assert!(
+                bill.due_date < new_timestamp,
+                "overdue bill_id_1 due_date must be < new_timestamp [Req 5.3]"
+            );
+            found_overdue_1 = true;
+        }
+        if bill.id == bill_id_2 {
+            // Verify the bill is indeed unpaid and past due (Requirement 5.2)
+            assert!(
+                !bill.paid,
+                "overdue bill_id_2 must still be unpaid [Req 5.2]"
+            );
+            assert!(
+                bill.due_date < new_timestamp,
+                "overdue bill_id_2 due_date must be < new_timestamp [Req 5.3]"
+            );
+            found_overdue_2 = true;
+        }
+    }
+    assert!(
+        found_overdue_1,
+        "bill_id_1 (Electricity, due in 7 days) must appear in get_overdue_bills after 31-day advance [Req 5.3]"
+    );
+    assert!(
+        found_overdue_2,
+        "bill_id_2 (Internet, due in 14 days) must appear in get_overdue_bills after 31-day advance [Req 5.3]"
+    );
+
+    // Assert that no bill in the overdue list has due_date >= new_timestamp
+    // (Requirement 5.4: bills not yet due must NOT appear in get_overdue_bills).
+    for bill in overdue_page.items.iter() {
+        assert!(
+            bill.due_date < new_timestamp,
+            "get_overdue_bills must not contain bills with due_date >= new_timestamp [Req 5.4]"
+        );
+    }
+
+    // ── Phase 6: Bill payment and recurring cycle verification ────────────────
+    //
+    // Pay both recurring bills and verify that:
+    //   1. The original bills are marked paid = true with paid_at == new_timestamp
+    //   2. New unpaid bills are created with the correct next due_date
+    //   3. The new bills preserve name, amount, frequency_days, and currency
+    //   4. get_unpaid_bills count does not decrease (paid bill replaced by next cycle)
+    //
+    // Bill 1 (Electricity): original due_date = timestamp + 7*86400
+    //   next due_date = (timestamp + 7*86400) + 30*86400 = timestamp + 37*86400
+    // Bill 2 (Internet): original due_date = timestamp + 14*86400
+    //   next due_date = (timestamp + 14*86400) + 30*86400 = timestamp + 44*86400
+
+    // Capture unpaid count before payment to verify non-decrease (Requirement 6.4).
+    let unpaid_before = bill_payments.get_unpaid_bills(&user, &0u32, &0u32);
+    let unpaid_count_before = unpaid_before.count;
+
+    // Pay bill 1 (Electricity). Guaranteed to succeed: bill exists, owner matches user,
+    // bill is unpaid, and mock_all_auths() bypasses require_auth. The Soroban client
+    // panics on Err, satisfying Requirement 8.1.
+    bill_payments.pay_bill(&user, &bill_id_1); // guaranteed Ok: bill exists, unpaid, owner matches
+
+    // Pay bill 2 (Internet). Same guarantee as bill 1.
+    bill_payments.pay_bill(&user, &bill_id_2); // guaranteed Ok: bill exists, unpaid, owner matches
+
+    // Assert original bill 1 has paid = true and paid_at == Some(new_timestamp)
+    // (Requirements 6.2, 8.2).
+    // Guaranteed Some: bill_id_1 still exists in storage (pay_bill does not delete bills).
+    let paid_bill1 = bill_payments
+        .get_bill(&bill_id_1)
+        .unwrap(); // guaranteed Some: pay_bill marks paid but does not remove the bill
+    assert!(
+        paid_bill1.paid,
+        "bill_id_1 must have paid = true after pay_bill [Req 6.2]"
+    );
+    assert_eq!(
+        paid_bill1.paid_at,
+        Some(new_timestamp),
+        "bill_id_1 paid_at must equal new_timestamp (ledger time at payment) [Req 8.2]"
+    );
+
+    // Assert original bill 2 has paid = true and paid_at == Some(new_timestamp)
+    // (Requirements 6.2, 8.2).
+    // Guaranteed Some: same reason as bill_id_1.
+    let paid_bill2 = bill_payments
+        .get_bill(&bill_id_2)
+        .unwrap(); // guaranteed Some: pay_bill marks paid but does not remove the bill
+    assert!(
+        paid_bill2.paid,
+        "bill_id_2 must have paid = true after pay_bill [Req 6.2]"
+    );
+    assert_eq!(
+        paid_bill2.paid_at,
+        Some(new_timestamp),
+        "bill_id_2 paid_at must equal new_timestamp (ledger time at payment) [Req 8.2]"
+    );
+
+    // Compute expected next due dates (Requirement 6.3, 6.6).
+    let expected_next_due_1 = (timestamp + 7 * 86400) + 30 * 86400; // timestamp + 37*86400
+    let expected_next_due_2 = (timestamp + 14 * 86400) + 30 * 86400; // timestamp + 44*86400
+
+    // Scan get_unpaid_bills to find the new next-cycle bills (Requirement 6.3).
+    // The new bills were created by pay_bill with the next due_date; we identify
+    // them by matching due_date and owner in the unpaid list.
+    let unpaid_after = bill_payments.get_unpaid_bills(&user, &0u32, &0u32);
+
+    let mut next_bill1: Option<bill_payments::Bill> = None;
+    let mut next_bill2: Option<bill_payments::Bill> = None;
+    for bill in unpaid_after.items.iter() {
+        if bill.due_date == expected_next_due_1 && bill.owner == user {
+            next_bill1 = Some(bill.clone());
+        }
+        if bill.due_date == expected_next_due_2 && bill.owner == user {
+            next_bill2 = Some(bill);
+        }
+    }
+
+    // Assert new bill for Electricity exists with correct next due_date (Requirement 6.3, 6.6).
+    let next_bill1 = next_bill1.unwrap(); // guaranteed Some: pay_bill creates next-cycle bill for recurring bills
+    assert_eq!(
+        next_bill1.due_date,
+        expected_next_due_1,
+        "next-cycle bill for Electricity must have due_date = original_due_date + 30*86400 [Req 6.3, 6.6]"
+    );
+    assert!(
+        !next_bill1.paid,
+        "next-cycle bill for Electricity must be unpaid [Req 6.1]"
+    );
+
+    // Assert new bill for Internet exists with correct next due_date (Requirement 6.3, 6.6).
+    let next_bill2 = next_bill2.unwrap(); // guaranteed Some: pay_bill creates next-cycle bill for recurring bills
+    assert_eq!(
+        next_bill2.due_date,
+        expected_next_due_2,
+        "next-cycle bill for Internet must have due_date = original_due_date + 30*86400 [Req 6.3, 6.6]"
+    );
+    assert!(
+        !next_bill2.paid,
+        "next-cycle bill for Internet must be unpaid [Req 6.1]"
+    );
+
+    // Assert new bills preserve name, amount, frequency_days, and currency from originals
+    // (Requirement 6.5).
+    assert_eq!(
+        next_bill1.name,
+        bill1.name,
+        "next-cycle Electricity bill must preserve name [Req 6.5]"
+    );
+    assert_eq!(
+        next_bill1.amount,
+        bill1.amount,
+        "next-cycle Electricity bill must preserve amount [Req 6.5]"
+    );
+    assert_eq!(
+        next_bill1.frequency_days,
+        bill1.frequency_days,
+        "next-cycle Electricity bill must preserve frequency_days [Req 6.5]"
+    );
+    assert_eq!(
+        next_bill1.currency,
+        bill1.currency,
+        "next-cycle Electricity bill must preserve currency [Req 6.5]"
+    );
+
+    assert_eq!(
+        next_bill2.name,
+        bill2.name,
+        "next-cycle Internet bill must preserve name [Req 6.5]"
+    );
+    assert_eq!(
+        next_bill2.amount,
+        bill2.amount,
+        "next-cycle Internet bill must preserve amount [Req 6.5]"
+    );
+    assert_eq!(
+        next_bill2.frequency_days,
+        bill2.frequency_days,
+        "next-cycle Internet bill must preserve frequency_days [Req 6.5]"
+    );
+    assert_eq!(
+        next_bill2.currency,
+        bill2.currency,
+        "next-cycle Internet bill must preserve currency [Req 6.5]"
+    );
+
+    // Assert get_unpaid_bills count does not decrease for recurring bills (Requirement 6.4).
+    // Each paid recurring bill is replaced by a new next-cycle bill, so count >= before.
+    assert!(
+        unpaid_after.count >= unpaid_count_before,
+        "get_unpaid_bills count must not decrease after paying recurring bills [Req 6.4]: before={}, after={}",
+        unpaid_count_before,
+        unpaid_after.count
+    );
+
+    // ── Phase 7: Financial health report verification ────────────────────────
+    //
+    // Generate a comprehensive financial health report covering the entire remittance
+    // window (period_start to period_end) and verify that it accurately reflects:
+    //   - Bill compliance (total bills tracked, paid/unpaid counts)
+    //   - Insurance coverage (active policies)
+    //   - Health score (non-negative integer)
+    //   - Savings goals (total goals)
+    //
+    // period_start = initial timestamp (1704067200)
+    // period_end = new_timestamp (timestamp + 31*86400 = 1706745600)
+    // total_remittance = 5000 (used for remittance summary calculations)
+
+    let period_start = timestamp; // initial ledger time (1704067200)
+    let period_end = new_timestamp; // current ledger time after 31-day advance (1706745600)
+
+    // Assert period_start <= period_end (Requirement 7.6).
+    assert!(
+        period_start <= period_end,
+        "period_start must be <= period_end when calling get_financial_health_report [Req 7.6]"
+    );
+
+    // Call get_financial_health_report with the user, total_remittance, and period bounds.
+    // Guaranteed to succeed: reporting contract is initialized and configured, all
+    // dependency contracts are registered and have data, mock_all_auths() bypasses
+    // require_auth. The Soroban client panics on Err, satisfying Requirement 8.1.
+    let report = reporting.get_financial_health_report(
+        &user,
+        &total_remittance,
+        &period_start,
+        &period_end,
+    );
+
+    // Assert report.bill_compliance.total_bills >= 2 (Requirement 7.1).
+    // We created two recurring bills (Electricity and Internet) in Phase 3, and
+    // paying them in Phase 6 created two new next-cycle bills. The reporting
+    // contract's get_bill_compliance_report_internal filters bills by created_at
+    // within [period_start, period_end], so all four bills (two original + two
+    // next-cycle) should be counted if their created_at falls in the period.
+    // However, the next-cycle bills are created at new_timestamp (1706745600),
+    // which equals period_end, so they are included (created_at <= period_end).
+    // Therefore, total_bills should be >= 2 (at minimum the two original bills).
+    assert!(
+        report.bill_compliance.total_bills >= 2,
+        "report.bill_compliance.total_bills must be >= 2 [Req 7.1]: got {}",
+        report.bill_compliance.total_bills
+    );
+
+    // Assert report.insurance_report.active_policies >= 1 (Requirement 7.2).
+    // We created one Health insurance policy in Phase 4 and paid its premium,
+    // so it remains active. The reporting contract's get_insurance_report_internal
+    // calls get_active_policies, which returns all active policies for the user.
+    assert!(
+        report.insurance_report.active_policies >= 1,
+        "report.insurance_report.active_policies must be >= 1 [Req 7.2]: got {}",
+        report.insurance_report.active_policies
+    );
+
+    // Assert report.health_score.score >= 0 (Requirement 7.3).
+    // The health score is a u32, so it is always non-negative by type, but we
+    // assert it explicitly to satisfy the requirement.
+    assert!(
+        report.health_score.score >= 0,
+        "report.health_score.score must be >= 0 [Req 7.3]: got {}",
+        report.health_score.score
+    );
+
+    // Assert report.bill_compliance.total_bills equals the total number of bills
+    // visible to the reporting contract for the user (Requirement 7.4).
+    // We verify this by calling get_all_bills_for_owner directly and counting
+    // bills created within [period_start, period_end].
+    let all_bills_page = bill_payments.get_all_bills_for_owner(&user, &0u32, &50u32);
+    let bills_in_period = all_bills_page
+        .items
+        .iter()
+        .filter(|b| b.created_at >= period_start && b.created_at <= period_end)
+        .count() as u32;
+    assert_eq!(
+        report.bill_compliance.total_bills,
+        bills_in_period,
+        "report.bill_compliance.total_bills must equal the count of bills created in [period_start, period_end] [Req 7.4]"
+    );
+
+    // Print human-readable summary (Requirement 7.5).
+    // The summary includes: health score, total savings goals, total bills tracked,
+    // active insurance policies, and total remittance amount.
+    println!("==== Financial Health Report Summary ====");
+    println!("Health Score       : {}", report.health_score.score);
+    println!("Total Savings Goals: {}", report.savings_report.total_goals);
+    println!("Total Bills Tracked: {}", report.bill_compliance.total_bills);
+    println!("Active Policies    : {}", report.insurance_report.active_policies);
+    println!("Total Remittance   : {}", total_remittance);
+    println!("=========================================");
+
+    // ── Phase 8: Owner isolation and state consistency ────────────────────────
+    //
+    // Verify that bills and policies created by `user` are not visible when
+    // queried under a different address (Requirement 8.5), and that
+    // get_total_unpaid for `user` reflects the correct unpaid amount after all
+    // payments (Requirement 8.4).
+
+    // Generate a fresh address that has never interacted with any contract.
+    // Address::generate produces a unique address not present in any contract
+    // storage, so all queries for it must return empty/zero results.
+    let other_user = Address::generate(&env); // guaranteed fresh: never used before
+
+    // Assert get_unpaid_bills(other_user) returns a page with count == 0
+    // (Requirement 8.5: owner isolation — bills created by `user` must not
+    // appear under `other_user`).
+    let other_unpaid = bill_payments.get_unpaid_bills(&other_user, &0u32, &0u32);
+    assert_eq!(
+        other_unpaid.count,
+        0,
+        "get_unpaid_bills for a fresh address must return count == 0 [Req 8.5]"
+    );
+
+    // Assert get_total_monthly_premium(other_user) == 0
+    // (Requirement 8.5: owner isolation — insurance policies created by `user`
+    // must not be counted under `other_user`).
+    let other_premium = insurance.get_total_monthly_premium(&other_user);
+    assert_eq!(
+        other_premium,
+        0,
+        "get_total_monthly_premium for a fresh address must return 0 [Req 8.5]"
+    );
+
+    // Assert get_total_unpaid(user) reflects the correct unpaid amount after all
+    // payments (Requirement 8.4).
+    //
+    // After paying bill_id_1 (Electricity, 150) and bill_id_2 (Internet, 80),
+    // both original bills are marked paid. However, because both bills are
+    // recurring, pay_bill automatically created two new next-cycle bills:
+    //   - next-cycle Electricity: amount = 150, unpaid
+    //   - next-cycle Internet:    amount = 80,  unpaid
+    //
+    // get_total_unpaid sums the `amount` of ALL unpaid bills for the owner,
+    // regardless of the `recurring` flag. Therefore the expected total is:
+    //   150 (next-cycle Electricity) + 80 (next-cycle Internet) = 230.
+    //
+    // There are no non-recurring unpaid bills for `user` at this point, so the
+    // total equals the sum of the two recurring next-cycle bills.
+    let expected_total_unpaid: i128 = bill1.amount + bill2.amount; // 150 + 80 = 230
+    let actual_total_unpaid = bill_payments.get_total_unpaid(&user);
+    assert_eq!(
+        actual_total_unpaid,
+        expected_total_unpaid,
+        "get_total_unpaid(user) must equal the sum of next-cycle recurring bill amounts after paying both bills [Req 8.4]: expected={}, got={}",
+        expected_total_unpaid,
+        actual_total_unpaid
+    );
 }


### PR DESCRIPTION
SC-055 — Add end-to-end flow for recurring bills + insurance premium in same remittance window

What this does
Adds test_recurring_obligations_flow to 
flow.rs
 — a deterministic, isolated integration test that exercises the full remittance window lifecycle across six Soroban contracts in a single shared environment.

Flow covered
Initialization — registers RemittanceSplit, BillPayments, Insurance, SavingsGoalContract, FamilyWallet, and ReportingContract in one Env; initializes and configures Reporting
Split config — configures a 10/30/40/20 remittance split and asserts the allocation invariant (sum of allocations == total remittance)
Recurring bill creation — creates two recurring bills (Electricity 150 USDC / 30-day, Internet 80 USDC / 30-day) and verifies both are unpaid and visible in get_unpaid_bills
Insurance — creates a Health policy, pays the premium, asserts next_payment_date == ledger_time + 30 days, and verifies a non-existent policy returns false
Time advancement — advances ledger by 31 days; asserts both bills appear in get_overdue_bills and no non-overdue bills are included
Bill payment + recurring cycle — pays both bills; asserts paid = true, paid_at == ledger_time, next-cycle bills created with correct due_date = original + frequency_days * 86400, and get_unpaid_bills count does not decrease
Financial health report — calls get_financial_health_report; asserts total_bills >= 2, active_policies >= 1, health_score >= 0, and prints a human-readable summary
Owner isolation — asserts a fresh address sees zero unpaid bills, zero premium, and correct get_total_unpaid for the test user
Changes
flow.rs
 — new test_recurring_obligations_flow test function
Cargo.toml
 — adds proptest to [dev-dependencies]
lib.rs
 — fixes Bill and InsurancePolicy stub structs to match actual contract field types (was causing UnexpectedSize panic in cross-contract deserialization)


Closes #508 