### PR TITLE
feat(insurance): add per-owner caps and storage stats observability

### DIFF
--- a/insurance/src/lib.rs
+++ b/insurance/src/lib.rs
@@ -3,7 +3,8 @@
 
 use remitwise_common::CoverageType;
 use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short, Address, Env, Map, String, Symbol, Vec,
+    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, Map, String,
+    Symbol, Vec,
 };
 
 // Storage TTL constants
@@ -14,11 +15,37 @@ const INSTANCE_BUMP_AMOUNT: u32 = 518_400; // ~30 days
 pub const DEFAULT_PAGE_LIMIT: u32 = 20;
 pub const MAX_PAGE_LIMIT: u32 = 50;
 
+/// Maximum number of **active** policies a single owner may hold at one time.
+///
+/// Scope: active-only (deactivated and archived policies do not count toward
+/// this limit). This prevents unbounded storage growth and mitigates DoS via
+/// policy spam. The value matches `MAX_PAGE_LIMIT` so a single page always
+/// covers the full active set for any owner.
+pub const MAX_POLICIES_PER_OWNER: u32 = 50;
+
 // Storage keys
 const KEY_PAUSE_ADMIN: Symbol = symbol_short!("PAUSE_ADM");
 const KEY_NEXT_ID: Symbol = symbol_short!("NEXT_ID");
 const KEY_POLICIES: Symbol = symbol_short!("POLICIES");
 const KEY_OWNER_INDEX: Symbol = symbol_short!("OWN_IDX");
+const KEY_ARCHIVED: Symbol = symbol_short!("ARCH_POL");
+const KEY_STATS: Symbol = symbol_short!("STOR_STAT");
+
+// Per-owner active-policy counter map key
+const KEY_OWNER_ACTIVE: Symbol = symbol_short!("OWN_ACT");
+
+/// Errors returned by the Insurance contract.
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum InsuranceError {
+    /// Policy with the given ID does not exist.
+    PolicyNotFound = 1,
+    /// Caller is not the policy owner.
+    Unauthorized = 2,
+    /// Owner has reached `MAX_POLICIES_PER_OWNER` active policies.
+    PolicyLimitExceeded = 3,
+}
 
 #[contracttype]
 #[derive(Clone)]
@@ -34,6 +61,20 @@ pub struct InsurancePolicy {
     pub next_payment_date: u64,
 }
 
+/// Compact record stored in the archive after a policy is deactivated and
+/// explicitly archived via `archive_policies`.
+#[contracttype]
+#[derive(Clone)]
+pub struct ArchivedPolicy {
+    pub id: u32,
+    pub owner: Address,
+    pub name: String,
+    pub coverage_type: CoverageType,
+    pub monthly_premium: i128,
+    pub coverage_amount: i128,
+    pub archived_at: u64,
+}
+
 #[contracttype]
 #[derive(Clone)]
 pub struct PolicyPage {
@@ -42,11 +83,32 @@ pub struct PolicyPage {
     pub count: u32,
 }
 
+/// Snapshot of contract storage usage.
+///
+/// Counters are updated deterministically on every lifecycle transition:
+/// - `create_policy`   → `active_policies` +1
+/// - `deactivate_policy` → `active_policies` -1
+/// - `archive_policies`  → `archived_policies` +N, `active_policies` unchanged
+///   (deactivated policies are already excluded from the active count)
+/// - `restore_policy`    → `archived_policies` -1, `active_policies` +1
+/// - `cleanup_policies`  → `archived_policies` -N
+#[contracttype]
+#[derive(Clone)]
+pub struct StorageStats {
+    pub active_policies: u32,
+    pub archived_policies: u32,
+    pub last_updated: u64,
+}
+
 #[contract]
 pub struct Insurance;
 
 #[contractimpl]
 impl Insurance {
+    // -----------------------------------------------------------------------
+    // Internal helpers
+    // -----------------------------------------------------------------------
+
     fn extend_instance_ttl(env: &Env) {
         env.storage()
             .instance()
@@ -63,6 +125,53 @@ impl Insurance {
         }
     }
 
+    /// Read the current `StorageStats`, defaulting to zeroes if not yet written.
+    fn read_stats(env: &Env) -> StorageStats {
+        env.storage()
+            .instance()
+            .get(&KEY_STATS)
+            .unwrap_or(StorageStats {
+                active_policies: 0,
+                archived_policies: 0,
+                last_updated: 0,
+            })
+    }
+
+    fn write_stats(env: &Env, stats: StorageStats) {
+        env.storage().instance().set(&KEY_STATS, &stats);
+    }
+
+    /// Return the number of active policies for `owner`.
+    fn owner_active_count(env: &Env, owner: &Address) -> u32 {
+        let counts: Map<Address, u32> = env
+            .storage()
+            .instance()
+            .get(&KEY_OWNER_ACTIVE)
+            .unwrap_or_else(|| Map::new(env));
+        counts.get(owner.clone()).unwrap_or(0)
+    }
+
+    /// Adjust the per-owner active-policy counter by `delta` (+1 or -1).
+    fn adjust_owner_active(env: &Env, owner: &Address, delta: i32) {
+        let mut counts: Map<Address, u32> = env
+            .storage()
+            .instance()
+            .get(&KEY_OWNER_ACTIVE)
+            .unwrap_or_else(|| Map::new(env));
+        let current = counts.get(owner.clone()).unwrap_or(0);
+        let next = if delta >= 0 {
+            current.saturating_add(delta as u32)
+        } else {
+            current.saturating_sub((-delta) as u32)
+        };
+        counts.set(owner.clone(), next);
+        env.storage().instance().set(&KEY_OWNER_ACTIVE, &counts);
+    }
+
+    // -----------------------------------------------------------------------
+    // Admin
+    // -----------------------------------------------------------------------
+
     pub fn set_pause_admin(env: Env, caller: Address, new_admin: Address) -> bool {
         caller.require_auth();
         Self::extend_instance_ttl(&env);
@@ -70,6 +179,15 @@ impl Insurance {
         true
     }
 
+    // -----------------------------------------------------------------------
+    // Core policy lifecycle
+    // -----------------------------------------------------------------------
+
+    /// Create a new insurance policy for `owner`.
+    ///
+    /// # Errors
+    /// - `PolicyLimitExceeded` if the owner already holds `MAX_POLICIES_PER_OWNER`
+    ///   active policies.
     pub fn create_policy(
         env: Env,
         owner: Address,
@@ -78,9 +196,15 @@ impl Insurance {
         monthly_premium: i128,
         coverage_amount: i128,
         external_ref: Option<String>,
-    ) -> u32 {
+    ) -> Result<u32, InsuranceError> {
         owner.require_auth();
         Self::extend_instance_ttl(&env);
+
+        // Enforce per-owner active-policy cap.
+        let active_count = Self::owner_active_count(&env, &owner);
+        if active_count >= MAX_POLICIES_PER_OWNER {
+            return Err(InsuranceError::PolicyLimitExceeded);
+        }
 
         let mut next_id: u32 = env.storage().instance().get(&KEY_NEXT_ID).unwrap_or(0);
         next_id += 1;
@@ -105,6 +229,7 @@ impl Insurance {
         policies.set(next_id, policy);
         env.storage().instance().set(&KEY_POLICIES, &policies);
 
+        // Update owner index.
         let mut index: Map<Address, Vec<u32>> = env
             .storage()
             .instance()
@@ -112,11 +237,19 @@ impl Insurance {
             .unwrap_or_else(|| Map::new(&env));
         let mut ids = index.get(owner.clone()).unwrap_or_else(|| Vec::new(&env));
         ids.push_back(next_id);
-        index.set(owner, ids);
+        index.set(owner.clone(), ids);
         env.storage().instance().set(&KEY_OWNER_INDEX, &index);
 
         env.storage().instance().set(&KEY_NEXT_ID, &next_id);
-        next_id
+
+        // Update counters.
+        Self::adjust_owner_active(&env, &owner, 1);
+        let mut stats = Self::read_stats(&env);
+        stats.active_policies = stats.active_policies.saturating_add(1);
+        stats.last_updated = env.ledger().timestamp();
+        Self::write_stats(&env, stats);
+
+        Ok(next_id)
     }
 
     pub fn get_policy(env: Env, policy_id: u32) -> Option<InsurancePolicy> {
@@ -129,7 +262,15 @@ impl Insurance {
         policies.get(policy_id)
     }
 
-    pub fn deactivate_policy(env: Env, caller: Address, policy_id: u32) -> bool {
+    /// Deactivate a policy owned by `caller`.
+    ///
+    /// Decrements the owner's active-policy counter and the global
+    /// `active_policies` stat so the slot becomes available for a new policy.
+    pub fn deactivate_policy(
+        env: Env,
+        caller: Address,
+        policy_id: u32,
+    ) -> Result<bool, InsuranceError> {
         caller.require_auth();
         Self::extend_instance_ttl(&env);
 
@@ -140,15 +281,27 @@ impl Insurance {
             .unwrap_or_else(|| Map::new(&env));
         let mut policy = match policies.get(policy_id) {
             Some(p) => p,
-            None => return false,
+            None => return Err(InsuranceError::PolicyNotFound),
         };
         if policy.owner != caller {
-            return false;
+            return Err(InsuranceError::Unauthorized);
         }
+
+        // Only decrement if the policy was still active.
+        let was_active = policy.active;
         policy.active = false;
-        policies.set(policy_id, policy);
+        policies.set(policy_id, policy.clone());
         env.storage().instance().set(&KEY_POLICIES, &policies);
-        true
+
+        if was_active {
+            Self::adjust_owner_active(&env, &caller, -1);
+            let mut stats = Self::read_stats(&env);
+            stats.active_policies = stats.active_policies.saturating_sub(1);
+            stats.last_updated = env.ledger().timestamp();
+            Self::write_stats(&env, stats);
+        }
+
+        Ok(true)
     }
 
     pub fn pay_premium(env: Env, caller: Address, policy_id: u32) -> bool {
@@ -260,16 +413,217 @@ impl Insurance {
             }
         }
 
-        // If we returned a full page, we may or may not have more items;
-        // keep the cursor as the last returned id (caller can continue).
-        // If we returned less than a full page, no more data -> cursor 0.
         let out_cursor = if items.len() < limit { 0 } else { next_cursor };
-
         let count = items.len();
         PolicyPage {
             items,
             next_cursor: out_cursor,
             count,
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // Archive / restore / cleanup
+    // -----------------------------------------------------------------------
+
+    /// Move all **inactive** policies owned by `caller` into the archive.
+    ///
+    /// Returns the number of policies archived. Increments
+    /// `StorageStats::archived_policies` by that count. The `active_policies`
+    /// counter is unaffected because `deactivate_policy` already decremented it.
+    pub fn archive_policies(env: Env, caller: Address) -> u32 {
+        caller.require_auth();
+        Self::extend_instance_ttl(&env);
+
+        let mut policies: Map<u32, InsurancePolicy> = env
+            .storage()
+            .instance()
+            .get(&KEY_POLICIES)
+            .unwrap_or_else(|| Map::new(&env));
+        let mut archived: Map<u32, ArchivedPolicy> = env
+            .storage()
+            .instance()
+            .get(&KEY_ARCHIVED)
+            .unwrap_or_else(|| Map::new(&env));
+
+        let now = env.ledger().timestamp();
+        let mut to_remove: Vec<u32> = Vec::new(&env);
+        let mut count: u32 = 0;
+
+        for (id, policy) in policies.iter() {
+            if policy.owner == caller && !policy.active {
+                archived.set(
+                    id,
+                    ArchivedPolicy {
+                        id: policy.id,
+                        owner: policy.owner.clone(),
+                        name: policy.name.clone(),
+                        coverage_type: policy.coverage_type,
+                        monthly_premium: policy.monthly_premium,
+                        coverage_amount: policy.coverage_amount,
+                        archived_at: now,
+                    },
+                );
+                to_remove.push_back(id);
+                count += 1;
+            }
+        }
+
+        for id in to_remove.iter() {
+            policies.remove(id);
+        }
+
+        env.storage().instance().set(&KEY_POLICIES, &policies);
+        env.storage().instance().set(&KEY_ARCHIVED, &archived);
+
+        if count > 0 {
+            let mut stats = Self::read_stats(&env);
+            stats.archived_policies = stats.archived_policies.saturating_add(count);
+            stats.last_updated = now;
+            Self::write_stats(&env, stats);
+        }
+
+        count
+    }
+
+    /// Restore an archived policy back to active storage.
+    ///
+    /// The restored policy is marked **inactive** (the caller must explicitly
+    /// reactivate it via a future mechanism if needed). Decrements
+    /// `archived_policies` and increments `active_policies`.
+    ///
+    /// # Errors
+    /// - `PolicyNotFound` if no archived policy with `policy_id` exists.
+    /// - `Unauthorized` if `caller` is not the policy owner.
+    pub fn restore_policy(env: Env, caller: Address, policy_id: u32) -> Result<(), InsuranceError> {
+        caller.require_auth();
+        Self::extend_instance_ttl(&env);
+
+        let mut archived: Map<u32, ArchivedPolicy> = env
+            .storage()
+            .instance()
+            .get(&KEY_ARCHIVED)
+            .unwrap_or_else(|| Map::new(&env));
+        let record = match archived.get(policy_id) {
+            Some(r) => r,
+            None => return Err(InsuranceError::PolicyNotFound),
+        };
+        if record.owner != caller {
+            return Err(InsuranceError::Unauthorized);
+        }
+
+        // Enforce cap on restore as well — restoring counts as gaining an active slot.
+        let active_count = Self::owner_active_count(&env, &caller);
+        if active_count >= MAX_POLICIES_PER_OWNER {
+            return Err(InsuranceError::PolicyLimitExceeded);
+        }
+
+        let mut policies: Map<u32, InsurancePolicy> = env
+            .storage()
+            .instance()
+            .get(&KEY_POLICIES)
+            .unwrap_or_else(|| Map::new(&env));
+
+        policies.set(
+            policy_id,
+            InsurancePolicy {
+                id: record.id,
+                owner: record.owner.clone(),
+                name: record.name.clone(),
+                external_ref: None,
+                coverage_type: record.coverage_type,
+                monthly_premium: record.monthly_premium,
+                coverage_amount: record.coverage_amount,
+                // Restored as inactive; owner decides whether to reactivate.
+                active: false,
+                next_payment_date: env.ledger().timestamp() + (30 * 86_400),
+            },
+        );
+        archived.remove(policy_id);
+
+        env.storage().instance().set(&KEY_POLICIES, &policies);
+        env.storage().instance().set(&KEY_ARCHIVED, &archived);
+
+        let mut stats = Self::read_stats(&env);
+        stats.archived_policies = stats.archived_policies.saturating_sub(1);
+        // Restored policy is inactive, so active_policies is unchanged here.
+        stats.last_updated = env.ledger().timestamp();
+        Self::write_stats(&env, stats);
+
+        Ok(())
+    }
+
+    /// Permanently delete archived policies with `archived_at < before_timestamp`.
+    ///
+    /// Returns the number of records deleted. Decrements `archived_policies`
+    /// by that count.
+    pub fn cleanup_policies(env: Env, caller: Address, before_timestamp: u64) -> u32 {
+        caller.require_auth();
+        Self::extend_instance_ttl(&env);
+
+        let mut archived: Map<u32, ArchivedPolicy> = env
+            .storage()
+            .instance()
+            .get(&KEY_ARCHIVED)
+            .unwrap_or_else(|| Map::new(&env));
+
+        let mut to_remove: Vec<u32> = Vec::new(&env);
+        let mut count: u32 = 0;
+
+        for (id, record) in archived.iter() {
+            if record.archived_at < before_timestamp {
+                to_remove.push_back(id);
+                count += 1;
+            }
+        }
+
+        for id in to_remove.iter() {
+            archived.remove(id);
+        }
+
+        env.storage().instance().set(&KEY_ARCHIVED, &archived);
+
+        if count > 0 {
+            let mut stats = Self::read_stats(&env);
+            stats.archived_policies = stats.archived_policies.saturating_sub(count);
+            stats.last_updated = env.ledger().timestamp();
+            Self::write_stats(&env, stats);
+        }
+
+        count
+    }
+
+    /// Return a snapshot of contract storage usage.
+    pub fn get_storage_stats(env: Env) -> StorageStats {
+        Self::extend_instance_ttl(&env);
+        Self::read_stats(&env)
+    }
+
+    /// Set or clear the `external_ref` on a policy owned by `caller`.
+    pub fn set_external_ref(
+        env: Env,
+        caller: Address,
+        policy_id: u32,
+        external_ref: Option<String>,
+    ) -> Result<(), InsuranceError> {
+        caller.require_auth();
+        Self::extend_instance_ttl(&env);
+
+        let mut policies: Map<u32, InsurancePolicy> = env
+            .storage()
+            .instance()
+            .get(&KEY_POLICIES)
+            .unwrap_or_else(|| Map::new(&env));
+        let mut policy = match policies.get(policy_id) {
+            Some(p) => p,
+            None => return Err(InsuranceError::PolicyNotFound),
+        };
+        if policy.owner != caller {
+            return Err(InsuranceError::Unauthorized);
+        }
+        policy.external_ref = external_ref;
+        policies.set(policy_id, policy);
+        env.storage().instance().set(&KEY_POLICIES, &policies);
+        Ok(())
     }
 }

--- a/insurance/tests/caps_and_stats_tests.rs
+++ b/insurance/tests/caps_and_stats_tests.rs
@@ -1,0 +1,350 @@
+//! Unit tests for per-owner policy caps and StorageStats determinism.
+
+use insurance::{Insurance, InsuranceClient, InsuranceError, MAX_POLICIES_PER_OWNER};
+use remitwise_common::CoverageType;
+use soroban_sdk::{
+    testutils::{Address as AddressTrait, EnvTestConfig},
+    Address, Env, String,
+};
+
+fn make_env() -> Env {
+    let env = Env::new_with_config(EnvTestConfig {
+        capture_snapshot_at_drop: false,
+    });
+    env.mock_all_auths();
+    env
+}
+
+fn setup(env: &Env) -> (Address, InsuranceClient<'_>) {
+    let contract_id = env.register_contract(None, Insurance);
+    let client = InsuranceClient::new(env, &contract_id);
+    let owner = Address::generate(env);
+    (owner, client)
+}
+
+fn create_one(env: &Env, client: &InsuranceClient, owner: &Address) -> u32 {
+    client.create_policy(
+        owner,
+        &String::from_str(env, "Policy"),
+        &CoverageType::Health,
+        &100i128,
+        &10_000i128,
+        &None,
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Per-owner cap
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cap_first_policy_succeeds() {
+    let env = make_env();
+    let (owner, client) = setup(&env);
+    let id = create_one(&env, &client, &owner);
+    assert!(id > 0);
+}
+
+#[test]
+fn cap_at_limit_succeeds() {
+    let env = make_env();
+    let (owner, client) = setup(&env);
+    for _ in 0..MAX_POLICIES_PER_OWNER {
+        create_one(&env, &client, &owner);
+    }
+    let stats = client.get_storage_stats();
+    assert_eq!(stats.active_policies, MAX_POLICIES_PER_OWNER);
+}
+
+#[test]
+fn cap_over_limit_returns_error() {
+    let env = make_env();
+    let (owner, client) = setup(&env);
+    for _ in 0..MAX_POLICIES_PER_OWNER {
+        create_one(&env, &client, &owner);
+    }
+    let result = client.try_create_policy(
+        &owner,
+        &String::from_str(&env, "Over"),
+        &CoverageType::Health,
+        &100i128,
+        &10_000i128,
+        &None,
+    );
+    assert_eq!(result, Err(Ok(InsuranceError::PolicyLimitExceeded)));
+}
+
+#[test]
+fn cap_is_per_owner_not_global() {
+    // Two owners each at the cap must not interfere with each other.
+    let env = Env::new_with_config(EnvTestConfig {
+        capture_snapshot_at_drop: false,
+    });
+    env.mock_all_auths();
+    env.budget().reset_unlimited();
+    let contract_id = env.register_contract(None, Insurance);
+    let client = InsuranceClient::new(&env, &contract_id);
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    for _ in 0..MAX_POLICIES_PER_OWNER {
+        create_one(&env, &client, &alice);
+        create_one(&env, &client, &bob);
+    }
+
+    // Both at cap — each additional create must fail independently.
+    assert_eq!(
+        client.try_create_policy(
+            &alice,
+            &String::from_str(&env, "X"),
+            &CoverageType::Health,
+            &1i128,
+            &1i128,
+            &None
+        ),
+        Err(Ok(InsuranceError::PolicyLimitExceeded))
+    );
+    assert_eq!(
+        client.try_create_policy(
+            &bob,
+            &String::from_str(&env, "X"),
+            &CoverageType::Health,
+            &1i128,
+            &1i128,
+            &None
+        ),
+        Err(Ok(InsuranceError::PolicyLimitExceeded))
+    );
+}
+
+#[test]
+fn cap_deactivate_frees_slot() {
+    let env = make_env();
+    let (owner, client) = setup(&env);
+    let mut ids = std::vec![];
+    for _ in 0..MAX_POLICIES_PER_OWNER {
+        ids.push(create_one(&env, &client, &owner));
+    }
+
+    // At cap — must fail.
+    assert_eq!(
+        client.try_create_policy(
+            &owner,
+            &String::from_str(&env, "X"),
+            &CoverageType::Health,
+            &1i128,
+            &1i128,
+            &None
+        ),
+        Err(Ok(InsuranceError::PolicyLimitExceeded))
+    );
+
+    // Free one slot.
+    client.deactivate_policy(&owner, &ids[0]);
+
+    // Now must succeed.
+    let new_id = create_one(&env, &client, &owner);
+    assert!(new_id > 0);
+}
+
+// ---------------------------------------------------------------------------
+// StorageStats — active_policies counter
+// ---------------------------------------------------------------------------
+
+#[test]
+fn stats_initial_state_is_zero() {
+    let env = make_env();
+    let (_, client) = setup(&env);
+    let stats = client.get_storage_stats();
+    assert_eq!(stats.active_policies, 0);
+    assert_eq!(stats.archived_policies, 0);
+}
+
+#[test]
+fn stats_increments_on_create() {
+    let env = make_env();
+    let (owner, client) = setup(&env);
+    create_one(&env, &client, &owner);
+    assert_eq!(client.get_storage_stats().active_policies, 1);
+    create_one(&env, &client, &owner);
+    assert_eq!(client.get_storage_stats().active_policies, 2);
+}
+
+#[test]
+fn stats_decrements_on_deactivate() {
+    let env = make_env();
+    let (owner, client) = setup(&env);
+    let id = create_one(&env, &client, &owner);
+    assert_eq!(client.get_storage_stats().active_policies, 1);
+    client.deactivate_policy(&owner, &id);
+    assert_eq!(client.get_storage_stats().active_policies, 0);
+}
+
+#[test]
+fn stats_deactivate_already_inactive_is_idempotent() {
+    // Deactivating an already-inactive policy must not double-decrement.
+    let env = make_env();
+    let (owner, client) = setup(&env);
+    let id = create_one(&env, &client, &owner);
+    client.deactivate_policy(&owner, &id);
+    assert_eq!(client.get_storage_stats().active_policies, 0);
+    // Second deactivate on same policy.
+    client.deactivate_policy(&owner, &id);
+    assert_eq!(
+        client.get_storage_stats().active_policies,
+        0,
+        "active_policies must not underflow on double-deactivate"
+    );
+}
+
+#[test]
+fn stats_archive_increments_archived_count() {
+    let env = make_env();
+    let (owner, client) = setup(&env);
+    let id1 = create_one(&env, &client, &owner);
+    let id2 = create_one(&env, &client, &owner);
+    client.deactivate_policy(&owner, &id1);
+    client.deactivate_policy(&owner, &id2);
+
+    let archived = client.archive_policies(&owner);
+    assert_eq!(archived, 2);
+
+    let stats = client.get_storage_stats();
+    assert_eq!(stats.archived_policies, 2);
+    assert_eq!(stats.active_policies, 0);
+}
+
+#[test]
+fn stats_archive_does_not_change_active_count() {
+    // active_policies was already decremented by deactivate; archive must not touch it.
+    let env = make_env();
+    let (owner, client) = setup(&env);
+    let id = create_one(&env, &client, &owner);
+    create_one(&env, &client, &owner); // stays active
+
+    client.deactivate_policy(&owner, &id);
+    assert_eq!(client.get_storage_stats().active_policies, 1);
+
+    client.archive_policies(&owner);
+    assert_eq!(
+        client.get_storage_stats().active_policies,
+        1,
+        "archive must not change active_policies"
+    );
+}
+
+#[test]
+fn stats_restore_decrements_archived_increments_nothing() {
+    // restore_policy brings a policy back as inactive, so active_policies stays the same.
+    let env = make_env();
+    let (owner, client) = setup(&env);
+    let id = create_one(&env, &client, &owner);
+    client.deactivate_policy(&owner, &id);
+    client.archive_policies(&owner);
+
+    let stats_before = client.get_storage_stats();
+    assert_eq!(stats_before.archived_policies, 1);
+    assert_eq!(stats_before.active_policies, 0);
+
+    client.restore_policy(&owner, &id);
+
+    let stats_after = client.get_storage_stats();
+    assert_eq!(stats_after.archived_policies, 0);
+    // Restored as inactive — active_policies unchanged.
+    assert_eq!(stats_after.active_policies, 0);
+}
+
+#[test]
+fn stats_cleanup_decrements_archived_count() {
+    let env = make_env();
+    let (owner, client) = setup(&env);
+    let id1 = create_one(&env, &client, &owner);
+    let id2 = create_one(&env, &client, &owner);
+    client.deactivate_policy(&owner, &id1);
+    client.deactivate_policy(&owner, &id2);
+    client.archive_policies(&owner);
+
+    assert_eq!(client.get_storage_stats().archived_policies, 2);
+
+    // Cleanup with before_timestamp = u64::MAX removes all archived records.
+    let deleted = client.cleanup_policies(&owner, &u64::MAX);
+    assert_eq!(deleted, 2);
+    assert_eq!(client.get_storage_stats().archived_policies, 0);
+}
+
+#[test]
+fn stats_full_lifecycle_determinism() {
+    // create → deactivate → archive → cleanup: verify each step's counter.
+    let env = make_env();
+    let (owner, client) = setup(&env);
+
+    // Step 1: create 3 policies.
+    let ids: std::vec::Vec<u32> = (0..3).map(|_| create_one(&env, &client, &owner)).collect();
+    assert_eq!(client.get_storage_stats().active_policies, 3);
+    assert_eq!(client.get_storage_stats().archived_policies, 0);
+
+    // Step 2: deactivate 2.
+    client.deactivate_policy(&owner, &ids[0]);
+    client.deactivate_policy(&owner, &ids[1]);
+    assert_eq!(client.get_storage_stats().active_policies, 1);
+    assert_eq!(client.get_storage_stats().archived_policies, 0);
+
+    // Step 3: archive the 2 inactive ones.
+    client.archive_policies(&owner);
+    assert_eq!(client.get_storage_stats().active_policies, 1);
+    assert_eq!(client.get_storage_stats().archived_policies, 2);
+
+    // Step 4: cleanup all archived.
+    client.cleanup_policies(&owner, &u64::MAX);
+    assert_eq!(client.get_storage_stats().active_policies, 1);
+    assert_eq!(client.get_storage_stats().archived_policies, 0);
+}
+
+// ---------------------------------------------------------------------------
+// deactivate_policy — authorization
+// ---------------------------------------------------------------------------
+
+#[test]
+fn deactivate_wrong_owner_returns_unauthorized() {
+    let env = make_env();
+    let contract_id = env.register_contract(None, Insurance);
+    let client = InsuranceClient::new(&env, &contract_id);
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    let id = create_one(&env, &client, &alice);
+    let result = client.try_deactivate_policy(&bob, &id);
+    assert_eq!(result, Err(Ok(InsuranceError::Unauthorized)));
+}
+
+#[test]
+fn deactivate_nonexistent_returns_not_found() {
+    let env = make_env();
+    let (owner, client) = setup(&env);
+    let result = client.try_deactivate_policy(&owner, &999u32);
+    assert_eq!(result, Err(Ok(InsuranceError::PolicyNotFound)));
+}
+
+// ---------------------------------------------------------------------------
+// restore_policy — cap enforcement
+// ---------------------------------------------------------------------------
+
+#[test]
+fn restore_at_cap_returns_limit_exceeded() {
+    let env = make_env();
+    let (owner, client) = setup(&env);
+
+    // Create one, deactivate, archive it — this is the candidate for restore.
+    let archived_id = create_one(&env, &client, &owner);
+    client.deactivate_policy(&owner, &archived_id);
+    client.archive_policies(&owner);
+
+    // Fill up to cap with new active policies.
+    for _ in 0..MAX_POLICIES_PER_OWNER {
+        create_one(&env, &client, &owner);
+    }
+
+    // Restore must be rejected because owner is at cap.
+    let result = client.try_restore_policy(&owner, &archived_id);
+    assert_eq!(result, Err(Ok(InsuranceError::PolicyLimitExceeded)));
+}

--- a/insurance/tests/gas_bench.rs
+++ b/insurance/tests/gas_bench.rs
@@ -1,4 +1,4 @@
-use insurance::{Insurance, InsuranceClient};
+use insurance::{Insurance, InsuranceClient, MAX_POLICIES_PER_OWNER};
 use remitwise_common::CoverageType;
 use soroban_sdk::testutils::{Address as AddressTrait, EnvTestConfig, Ledger, LedgerInfo};
 use soroban_sdk::{Address, Env, String};
@@ -37,6 +37,7 @@ where
     (cpu, mem, result)
 }
 
+/// Benchmark get_total_monthly_premium at the maximum allowed active-policy count.
 #[test]
 fn bench_get_total_monthly_premium_worst_case() {
     let env = bench_env();
@@ -47,16 +48,16 @@ fn bench_get_total_monthly_premium_worst_case() {
 
     let name = String::from_str(&env, "BenchPolicy");
     let coverage_type = CoverageType::Health;
-    for _ in 0..100 {
+    for _ in 0..MAX_POLICIES_PER_OWNER {
         client.create_policy(&owner, &name, &coverage_type, &100i128, &10_000i128, &None);
     }
 
-    let expected_total = 100i128 * 100i128;
+    let expected_total = MAX_POLICIES_PER_OWNER as i128 * 100i128;
     let (cpu, mem, total) = measure(&env, || client.get_total_monthly_premium(&owner));
     assert_eq!(total, expected_total);
 
     println!(
-        r#"{{"contract":"insurance","method":"get_total_monthly_premium","scenario":"100_active_policies","cpu":{},"mem":{}}}"#,
-        cpu, mem
+        r#"{{"contract":"insurance","method":"get_total_monthly_premium","scenario":"{}_active_policies","cpu":{},"mem":{}}}"#,
+        MAX_POLICIES_PER_OWNER, cpu, mem
     );
 }

--- a/insurance/tests/stress_tests.rs
+++ b/insurance/tests/stress_tests.rs
@@ -1,6 +1,6 @@
 //! Stress tests for insurance storage limits and TTL behavior.
 
-use insurance::{Insurance, InsuranceClient};
+use insurance::{Insurance, InsuranceClient, InsuranceError, MAX_POLICIES_PER_OWNER};
 use remitwise_common::CoverageType;
 use soroban_sdk::testutils::storage::Instance as _;
 use soroban_sdk::testutils::{Address as AddressTrait, EnvTestConfig, Ledger, LedgerInfo};
@@ -39,10 +39,10 @@ where
     (cpu, mem, result)
 }
 
-/// Create 200 policies for a single user and verify full dataset is returned
-/// by get_active_policies (returns all active policies).
+/// Create exactly MAX_POLICIES_PER_OWNER (50) policies for a single user and
+/// verify the full dataset is returned by get_active_policies.
 #[test]
-fn stress_200_policies_single_user() {
+fn stress_max_policies_single_user() {
     let env = stress_env();
     let contract_id = env.register_contract(None, Insurance);
     let client = InsuranceClient::new(&env, &contract_id);
@@ -51,7 +51,7 @@ fn stress_200_policies_single_user() {
     let name = String::from_str(&env, "StressPolicy");
     let coverage_type = CoverageType::Health;
 
-    for _ in 0..200 {
+    for _ in 0..MAX_POLICIES_PER_OWNER {
         client.create_policy(&owner, &name, &coverage_type, &100i128, &10_000i128, &None);
     }
 
@@ -59,14 +59,14 @@ fn stress_200_policies_single_user() {
     let total_premium = client.get_total_monthly_premium(&owner);
     assert_eq!(
         total_premium,
-        200 * 100i128,
-        "get_total_monthly_premium must sum premiums across all 200 policies"
+        MAX_POLICIES_PER_OWNER as i128 * 100i128,
+        "get_total_monthly_premium must sum premiums across all {} policies",
+        MAX_POLICIES_PER_OWNER
     );
 
-    // Exhaust all pages (MAX_PAGE_LIMIT = 50 → 4 pages)
+    // Exhaust all pages (MAX_PAGE_LIMIT = 50 → 1 full page + possible trailing empty)
     let mut collected = 0u32;
     let mut cursor = 0u32;
-    let mut pages = 0u32;
     loop {
         let page = client.get_active_policies(&owner, &cursor, &50u32);
         assert!(
@@ -75,7 +75,6 @@ fn stress_200_policies_single_user() {
             page.count
         );
         collected += page.count;
-        pages += 1;
         if page.next_cursor == 0 {
             break;
         }
@@ -83,22 +82,88 @@ fn stress_200_policies_single_user() {
     }
 
     assert_eq!(
-        collected, 200,
-        "Pagination must return all 200 active policies"
-    );
-    // get_active_policies sets next_cursor = last_returned_id; when a page is exactly
-    // full the caller receives a non-zero cursor that produces a trailing empty page,
-    // so the round-trip count is pages = ceil(200/50) + 1 trailing = 5.
-    assert!(
-        (4..=5).contains(&pages),
-        "Expected 4-5 pages for 200 policies at limit 50, got {}",
-        pages
+        collected, MAX_POLICIES_PER_OWNER,
+        "Pagination must return all {} active policies",
+        MAX_POLICIES_PER_OWNER
     );
 }
 
-/// Create 200 policies and verify instance TTL remains valid.
+/// Verify that creating a policy beyond MAX_POLICIES_PER_OWNER returns
+/// PolicyLimitExceeded and does not modify state.
 #[test]
-fn stress_instance_ttl_valid_after_200_policies() {
+fn stress_owner_cap_enforced() {
+    let env = stress_env();
+    let contract_id = env.register_contract(None, Insurance);
+    let client = InsuranceClient::new(&env, &contract_id);
+    let owner = Address::generate(&env);
+
+    let name = String::from_str(&env, "CapPolicy");
+    let coverage_type = CoverageType::Health;
+
+    for _ in 0..MAX_POLICIES_PER_OWNER {
+        client.create_policy(&owner, &name, &coverage_type, &100i128, &10_000i128, &None);
+    }
+
+    // The (MAX + 1)-th create must be rejected.
+    let result =
+        client.try_create_policy(&owner, &name, &coverage_type, &100i128, &10_000i128, &None);
+    assert_eq!(
+        result,
+        Err(Ok(InsuranceError::PolicyLimitExceeded)),
+        "create_policy must return PolicyLimitExceeded when owner is at cap"
+    );
+
+    // Active count must remain at MAX_POLICIES_PER_OWNER.
+    let stats = client.get_storage_stats();
+    assert_eq!(
+        stats.active_policies, MAX_POLICIES_PER_OWNER,
+        "active_policies must not exceed MAX_POLICIES_PER_OWNER after rejected create"
+    );
+}
+
+/// Deactivating a policy frees a slot so a new policy can be created.
+#[test]
+fn stress_deactivate_frees_slot() {
+    let env = stress_env();
+    let contract_id = env.register_contract(None, Insurance);
+    let client = InsuranceClient::new(&env, &contract_id);
+    let owner = Address::generate(&env);
+
+    let name = String::from_str(&env, "SlotPolicy");
+    let coverage_type = CoverageType::Health;
+
+    let mut ids = std::vec![];
+    for _ in 0..MAX_POLICIES_PER_OWNER {
+        let id = client.create_policy(&owner, &name, &coverage_type, &100i128, &10_000i128, &None);
+        ids.push(id);
+    }
+
+    // At cap — next create must fail.
+    assert_eq!(
+        client.try_create_policy(&owner, &name, &coverage_type, &100i128, &10_000i128, &None),
+        Err(Ok(InsuranceError::PolicyLimitExceeded))
+    );
+
+    // Deactivate one policy to free a slot.
+    client.deactivate_policy(&owner, &ids[0]);
+
+    // Now a new policy must succeed.
+    let new_id = client.create_policy(&owner, &name, &coverage_type, &100i128, &10_000i128, &None);
+    assert!(
+        new_id > 0,
+        "New policy must be created after freeing a slot"
+    );
+
+    let stats = client.get_storage_stats();
+    assert_eq!(
+        stats.active_policies, MAX_POLICIES_PER_OWNER,
+        "active_policies must be back at cap after deactivate + create"
+    );
+}
+
+/// Verify instance TTL remains valid after MAX_POLICIES_PER_OWNER creates.
+#[test]
+fn stress_instance_ttl_valid_after_max_policies() {
     let env = stress_env();
     let contract_id = env.register_contract(None, Insurance);
     let client = InsuranceClient::new(&env, &contract_id);
@@ -107,20 +172,21 @@ fn stress_instance_ttl_valid_after_200_policies() {
     let name = String::from_str(&env, "TTLPolicy");
     let coverage_type = CoverageType::Life;
 
-    for _ in 0..200 {
+    for _ in 0..MAX_POLICIES_PER_OWNER {
         client.create_policy(&owner, &name, &coverage_type, &50i128, &5_000i128, &None);
     }
 
     let ttl = env.as_contract(&contract_id, || env.storage().instance().get_ttl());
     assert!(
         ttl >= 518_400,
-        "Instance TTL ({}) must remain >= INSTANCE_BUMP_AMOUNT (518,400) after 200 creates",
-        ttl
+        "Instance TTL ({}) must remain >= INSTANCE_BUMP_AMOUNT (518,400) after {} creates",
+        ttl,
+        MAX_POLICIES_PER_OWNER
     );
 }
 
 /// Create 20 policies each for 10 different users (200 total) and verify
-/// per-owner isolation.
+/// per-owner isolation. Each user is well within the cap.
 #[test]
 fn stress_policies_across_10_users() {
     let env = stress_env();
@@ -131,7 +197,6 @@ fn stress_policies_across_10_users() {
     const POLICIES_PER_USER: u32 = 20;
     const PREMIUM_PER_POLICY: i128 = 150;
     let name = String::from_str(&env, "UserPolicy");
-    let coverage_type = CoverageType::Health;
 
     let users: std::vec::Vec<Address> = (0..N_USERS).map(|_| Address::generate(&env)).collect();
 
@@ -157,9 +222,8 @@ fn stress_policies_across_10_users() {
         );
 
         let page = client.get_active_policies(user, &0u32, &50u32);
-        let active = page.items;
         assert_eq!(
-            active.len(),
+            page.items.len(),
             POLICIES_PER_USER,
             "Each user must see exactly their own {} policies",
             POLICIES_PER_USER
@@ -178,8 +242,8 @@ fn stress_ttl_re_bumped_after_ledger_advancement() {
     let name = String::from_str(&env, "TTLStress");
     let coverage_type = CoverageType::Health;
 
-    // Phase 1: 50 creates
-    for _ in 0..50 {
+    // Phase 1: 10 creates (well within cap)
+    for _ in 0..10 {
         client.create_policy(&owner, &name, &coverage_type, &100i128, &10_000i128, &None);
     }
 
@@ -260,7 +324,7 @@ fn stress_ttl_re_bumped_by_pay_premium_after_ledger_advancement() {
     );
 }
 
-/// Create 50 policies and pay all premiums in a single batch.
+/// Create MAX_POLICIES_PER_OWNER policies and pay all premiums in a single batch.
 #[test]
 fn stress_batch_pay_premiums_at_max_batch_size() {
     let env = stress_env();
@@ -268,12 +332,11 @@ fn stress_batch_pay_premiums_at_max_batch_size() {
     let client = InsuranceClient::new(&env, &contract_id);
     let owner = Address::generate(&env);
 
-    const BATCH_SIZE: u32 = 50;
     let name = String::from_str(&env, "BatchPolicy");
     let coverage_type = CoverageType::Health;
 
     let mut policy_ids = std::vec![];
-    for _ in 0..BATCH_SIZE {
+    for _ in 0..MAX_POLICIES_PER_OWNER {
         let id = client.create_policy(&owner, &name, &coverage_type, &100i128, &10_000i128, &None);
         policy_ids.push(id);
     }
@@ -285,9 +348,9 @@ fn stress_batch_pay_premiums_at_max_batch_size() {
 
     let paid_count = client.batch_pay_premiums(&owner, &ids_vec);
     assert_eq!(
-        paid_count, BATCH_SIZE,
+        paid_count, MAX_POLICIES_PER_OWNER,
         "batch_pay_premiums must process all {} policies",
-        BATCH_SIZE
+        MAX_POLICIES_PER_OWNER
     );
 
     let expected_next = 1_700_000_000u64 + (30 * 86400);
@@ -306,9 +369,9 @@ fn stress_batch_pay_premiums_at_max_batch_size() {
     }
 }
 
-/// Create 200 policies and deactivate 100, verify only 100 remain active.
+/// Create MAX_POLICIES_PER_OWNER policies and deactivate half, verify only half remain active.
 #[test]
-fn stress_deactivate_half_of_200_policies() {
+fn stress_deactivate_half_of_max_policies() {
     let env = stress_env();
     let contract_id = env.register_contract(None, Insurance);
     let client = InsuranceClient::new(&env, &contract_id);
@@ -318,17 +381,19 @@ fn stress_deactivate_half_of_200_policies() {
     let coverage_type = CoverageType::Life;
 
     let mut all_ids = std::vec![];
-    for _ in 0..200 {
+    for _ in 0..MAX_POLICIES_PER_OWNER {
         let id = client.create_policy(&owner, &name, &coverage_type, &80i128, &8_000i128, &None);
         all_ids.push(id);
     }
 
-    // Deactivate even-indexed policies
+    // Deactivate odd-indexed policies (half)
     for (i, &id) in all_ids.iter().enumerate() {
         if i % 2 == 1 {
             client.deactivate_policy(&owner, &id);
         }
     }
+
+    let half = MAX_POLICIES_PER_OWNER / 2;
 
     // Count all active policies via pagination.
     let mut collected = 0u32;
@@ -342,21 +407,31 @@ fn stress_deactivate_half_of_200_policies() {
         cursor = page.next_cursor;
     }
     assert_eq!(
-        collected, 100,
-        "After deactivating 100 of 200 policies, only 100 must remain active"
+        collected, half,
+        "After deactivating half of {} policies, only {} must remain active",
+        MAX_POLICIES_PER_OWNER, half
     );
 
     let remaining_premium = client.get_total_monthly_premium(&owner);
     assert_eq!(
         remaining_premium,
-        100 * 80i128,
-        "Monthly premium must reflect only the 100 still-active policies"
+        half as i128 * 80i128,
+        "Monthly premium must reflect only the {} still-active policies",
+        half
+    );
+
+    // StorageStats must reflect the correct active count.
+    let stats = client.get_storage_stats();
+    assert_eq!(
+        stats.active_policies, half,
+        "StorageStats::active_policies must equal {} after deactivating half",
+        half
     );
 }
 
-/// Measure CPU and memory cost for get_active_policies with 200 policies.
+/// Measure CPU and memory cost for get_active_policies with MAX_POLICIES_PER_OWNER policies.
 #[test]
-fn bench_get_active_policies_200_policies() {
+fn bench_get_active_policies_max_policies() {
     let env = stress_env();
     let contract_id = env.register_contract(None, Insurance);
     let client = InsuranceClient::new(&env, &contract_id);
@@ -365,22 +440,27 @@ fn bench_get_active_policies_200_policies() {
     let name = String::from_str(&env, "BenchPolicy");
     let coverage_type = CoverageType::Health;
 
-    for _ in 0..200 {
+    for _ in 0..MAX_POLICIES_PER_OWNER {
         client.create_policy(&owner, &name, &coverage_type, &100i128, &10_000i128, &None);
     }
 
     let (cpu, mem, active) = measure(&env, || client.get_active_policies(&owner, &0u32, &50u32));
-    assert_eq!(active.items.len(), 50, "Must return first page (limit 50)");
+    assert_eq!(
+        active.items.len(),
+        MAX_POLICIES_PER_OWNER,
+        "Must return all {} policies in one page",
+        MAX_POLICIES_PER_OWNER
+    );
 
     println!(
-        r#"{{"contract":"insurance","method":"get_active_policies","scenario":"200_policies","cpu":{},"mem":{}}}"#,
-        cpu, mem
+        r#"{{"contract":"insurance","method":"get_active_policies","scenario":"{}_policies","cpu":{},"mem":{}}}"#,
+        MAX_POLICIES_PER_OWNER, cpu, mem
     );
 }
 
-/// Measure CPU and memory cost for get_total_monthly_premium with 200 active policies.
+/// Measure CPU and memory cost for get_total_monthly_premium with MAX_POLICIES_PER_OWNER active policies.
 #[test]
-fn bench_get_total_monthly_premium_200_policies() {
+fn bench_get_total_monthly_premium_max_policies() {
     let env = stress_env();
     let contract_id = env.register_contract(None, Insurance);
     let client = InsuranceClient::new(&env, &contract_id);
@@ -389,23 +469,23 @@ fn bench_get_total_monthly_premium_200_policies() {
     let name = String::from_str(&env, "PremBench");
     let coverage_type = CoverageType::Health;
 
-    for _ in 0..200 {
+    for _ in 0..MAX_POLICIES_PER_OWNER {
         client.create_policy(&owner, &name, &coverage_type, &100i128, &10_000i128, &None);
     }
 
-    let expected = 200i128 * 100;
+    let expected = MAX_POLICIES_PER_OWNER as i128 * 100;
     let (cpu, mem, total) = measure(&env, || client.get_total_monthly_premium(&owner));
     assert_eq!(total, expected);
 
     println!(
-        r#"{{"contract":"insurance","method":"get_total_monthly_premium","scenario":"200_active_policies","cpu":{},"mem":{}}}"#,
-        cpu, mem
+        r#"{{"contract":"insurance","method":"get_total_monthly_premium","scenario":"{}_active_policies","cpu":{},"mem":{}}}"#,
+        MAX_POLICIES_PER_OWNER, cpu, mem
     );
 }
 
-/// Measure CPU and memory cost for batch_pay_premiums with 50 policies.
+/// Measure CPU and memory cost for batch_pay_premiums with MAX_POLICIES_PER_OWNER policies.
 #[test]
-fn bench_batch_pay_premiums_50_policies() {
+fn bench_batch_pay_premiums_max_policies() {
     let env = stress_env();
     let contract_id = env.register_contract(None, Insurance);
     let client = InsuranceClient::new(&env, &contract_id);
@@ -415,7 +495,7 @@ fn bench_batch_pay_premiums_50_policies() {
     let coverage_type = CoverageType::Health;
 
     let mut policy_ids = std::vec![];
-    for _ in 0..50 {
+    for _ in 0..MAX_POLICIES_PER_OWNER {
         let id = client.create_policy(&owner, &name, &coverage_type, &100i128, &10_000i128, &None);
         policy_ids.push(id);
     }
@@ -426,11 +506,11 @@ fn bench_batch_pay_premiums_50_policies() {
     }
 
     let (cpu, mem, count) = measure(&env, || client.batch_pay_premiums(&owner, &ids_vec));
-    assert_eq!(count, 50);
+    assert_eq!(count, MAX_POLICIES_PER_OWNER);
 
     println!(
-        r#"{{"contract":"insurance","method":"batch_pay_premiums","scenario":"50_policies","cpu":{},"mem":{}}}"#,
-        cpu, mem
+        r#"{{"contract":"insurance","method":"batch_pay_premiums","scenario":"{}_policies","cpu":{},"mem":{}}}"#,
+        MAX_POLICIES_PER_OWNER, cpu, mem
     );
 }
 
@@ -444,20 +524,14 @@ fn stress_batch_pay_mixed_states() {
     let name = String::from_str(&env, "MixedBatch");
     let coverage_type = CoverageType::Health;
 
+    // Create 50 policies: deactivate odd-indexed ones.
     let mut policy_ids = std::vec![];
-    for i in 0..50 {
-        if i % 2 == 0 {
-            // Valid policy
-            let id =
-                client.create_policy(&owner, &name, &coverage_type, &100i128, &10_000i128, &None);
-            policy_ids.push(id);
-        } else {
-            // Invalid policy: deactivated
-            let id =
-                client.create_policy(&owner, &name, &coverage_type, &100i128, &10_000i128, &None);
+    for i in 0..MAX_POLICIES_PER_OWNER {
+        let id = client.create_policy(&owner, &name, &coverage_type, &100i128, &10_000i128, &None);
+        if i % 2 == 1 {
             client.deactivate_policy(&owner, &id);
-            policy_ids.push(id);
         }
+        policy_ids.push(id);
     }
 
     let mut ids_vec = soroban_sdk::Vec::new(&env);
@@ -466,10 +540,14 @@ fn stress_batch_pay_mixed_states() {
     }
 
     let (cpu, mem, count) = measure(&env, || client.batch_pay_premiums(&owner, &ids_vec));
-    assert_eq!(count, 25, "Exactly 25 policies should be paid");
+    assert_eq!(
+        count,
+        MAX_POLICIES_PER_OWNER / 2,
+        "Exactly half the policies should be paid (active ones)"
+    );
 
     println!(
-        r#"{{"contract":"insurance","method":"batch_pay_premiums","scenario":"50_policies_mixed","cpu":{},"mem":{}}}"#,
-        cpu, mem
+        r#"{{"contract":"insurance","method":"batch_pay_premiums","scenario":"{}_policies_mixed","cpu":{},"mem":{}}}"#,
+        MAX_POLICIES_PER_OWNER, cpu, mem
     );
 }


### PR DESCRIPTION

## Summary

Adds MAX_POLICIES_PER_OWNER to prevent storage bloat/DoS via policy spam, and introduces StorageStats with 
deterministic counter updates across all policy lifecycle operations.

## Changes

### Contract (insurance/src/lib.rs)
- Add InsuranceError enum (PolicyNotFound, Unauthorized, PolicyLimitExceeded) replacing silent bool returns
- Add MAX_POLICIES_PER_OWNER = 50 (active-only scope) enforced in create_policy and restore_policy
- Add per-owner active counter map for O(1) cap checks
- Add StorageStats { active_policies, archived_policies, last_updated } with deterministic updates:
  - create_policy → active_policies +1
  - deactivate_policy → active_policies -1 (idempotent: only if was active)
  - archive_policies → archived_policies +N (active count unchanged)
  - restore_policy → archived_policies -1 (restored as inactive)
  - cleanup_policies → archived_policies -N
- Add ArchivedPolicy struct and archive_policies / restore_policy / cleanup_policies with full auth checks
- Add get_storage_stats public entry point

### Tests
- **caps_and_stats_tests.rs** (17 new tests) — cap enforcement, per-owner isolation, stats determinism across all 
lifecycle ops, idempotent deactivate, restore-at-cap rejection, auth errors
- **stress_tests.rs** — updated to respect the 50-policy cap
- **gas_bench.rs** — benchmarks at MAX_POLICIES_PER_OWNER instead of hardcoded 100

## Cap scope

The cap applies to active policies only. Deactivated and archived policies do not count toward the limit. This is 
documented on MAX_POLICIES_PER_OWNER and StorageStats. The value of 50 matches MAX_PAGE_LIMIT so a single page 
always covers the full active set for any owner.

## Testing

bash
cargo test -p insurance
# 31 tests, 0 failures

## Closes: #488 