### PR TITLE
Test/reporting paging termination

### DIFF
--- a/reporting/src/lib.rs
+++ b/reporting/src/lib.rs
@@ -5,7 +5,7 @@ use soroban_sdk::{
     Env, Map, Vec,
 };
 
-use remitwise_common::{Category, CoverageType};
+pub use remitwise_common::{Category, CoverageType};
 
 // Storage TTL constants
 const DAY_IN_LEDGERS: u32 = 17280;
@@ -18,6 +18,11 @@ pub const INSTANCE_LIFETIME_THRESHOLD: u32 = PERSISTENT_LIFETIME_THRESHOLD;
 
 pub const ARCHIVE_BUMP_AMOUNT: u32 = 150 * DAY_IN_LEDGERS; // ~150 days
 pub const ARCHIVE_LIFETIME_THRESHOLD: u32 = 1 * DAY_IN_LEDGERS; // 1 day
+
+/// Maximum number of pages fetched from any single dependency per report call.
+/// Loops that reach this cap mark the result `DataAvailability::Partial` so
+/// callers know the aggregate may be incomplete.
+pub const MAX_DEP_PAGES: u32 = 20;
 
 /// Financial health score (0-100)
 #[contracttype]
@@ -99,6 +104,7 @@ pub struct BillComplianceReport {
     pub compliance_percentage: u32,
     pub period_start: u64,
     pub period_end: u64,
+    pub data_availability: DataAvailability,
 }
 
 /// Insurance coverage report
@@ -112,6 +118,7 @@ pub struct InsuranceReport {
     pub coverage_to_premium_ratio: u32,
     pub period_start: u64,
     pub period_end: u64,
+    pub data_availability: DataAvailability,
 }
 
 /// Family spending report
@@ -821,8 +828,6 @@ impl ReportingContract {
             .unwrap_or_else(|| panic!("Contract addresses not configured"));
 
         let bill_client = BillPaymentsClient::new(env, &addresses.bill_payments);
-        let page = bill_client.get_all_bills_for_owner(&user, &0u32, &50u32);
-        let all_bills = page.items;
 
         let mut total_bills = 0u32;
         let mut paid_bills = 0u32;
@@ -831,28 +836,39 @@ impl ReportingContract {
         let mut total_amount = 0i128;
         let mut paid_amount = 0i128;
         let mut unpaid_amount = 0i128;
-
         let current_time = env.ledger().timestamp();
+        let mut data_availability = DataAvailability::Complete;
 
-        for bill in all_bills.iter() {
-            // Filter by period
-            if bill.created_at < period_start || bill.created_at > period_end {
-                continue;
-            }
-
-            total_bills += 1;
-            total_amount += bill.amount;
-
-            if bill.paid {
-                paid_bills += 1;
-                paid_amount += bill.amount;
-            } else {
-                unpaid_bills += 1;
-                unpaid_amount += bill.amount;
-                if bill.due_date < current_time {
-                    overdue_bills += 1;
+        let mut cursor = 0u32;
+        let mut pages_fetched = 0u32;
+        loop {
+            let page = bill_client.get_all_bills_for_owner(&user, &cursor, &50u32);
+            for bill in page.items.iter() {
+                if bill.created_at < period_start || bill.created_at > period_end {
+                    continue;
+                }
+                total_bills += 1;
+                total_amount += bill.amount;
+                if bill.paid {
+                    paid_bills += 1;
+                    paid_amount += bill.amount;
+                } else {
+                    unpaid_bills += 1;
+                    unpaid_amount += bill.amount;
+                    if bill.due_date < current_time {
+                        overdue_bills += 1;
+                    }
                 }
             }
+            pages_fetched += 1;
+            if page.next_cursor == 0 {
+                break;
+            }
+            if pages_fetched >= MAX_DEP_PAGES {
+                data_availability = DataAvailability::Partial;
+                break;
+            }
+            cursor = page.next_cursor;
         }
 
         let compliance_percentage = if total_bills > 0 {
@@ -872,6 +888,7 @@ impl ReportingContract {
             compliance_percentage,
             period_start,
             period_end,
+            data_availability,
         }
     }
 
@@ -901,15 +918,29 @@ impl ReportingContract {
             .unwrap_or_else(|| panic!("Contract addresses not configured"));
 
         let insurance_client = InsuranceClient::new(env, &addresses.insurance);
-        let policy_page = insurance_client.get_active_policies(&user, &0, &50);
-        let policies = policy_page.items;
         let monthly_premium = insurance_client.get_total_monthly_premium(&user);
 
         let mut total_coverage = 0i128;
-        let active_policies = policies.len();
+        let mut active_policies = 0u32;
+        let mut data_availability = DataAvailability::Complete;
 
-        for policy in policies.iter() {
-            total_coverage += policy.coverage_amount;
+        let mut cursor = 0u32;
+        let mut pages_fetched = 0u32;
+        loop {
+            let page = insurance_client.get_active_policies(&user, &cursor, &50);
+            for policy in page.items.iter() {
+                active_policies += 1;
+                total_coverage += policy.coverage_amount;
+            }
+            pages_fetched += 1;
+            if page.next_cursor == 0 {
+                break;
+            }
+            if pages_fetched >= MAX_DEP_PAGES {
+                data_availability = DataAvailability::Partial;
+                break;
+            }
+            cursor = page.next_cursor;
         }
 
         let annual_premium = monthly_premium * 12;
@@ -927,6 +958,7 @@ impl ReportingContract {
             coverage_to_premium_ratio,
             period_start,
             period_end,
+            data_availability,
         }
     }
 

--- a/reporting/src/tests.rs
+++ b/reporting/src/tests.rs
@@ -6,8 +6,8 @@ use soroban_sdk::{
 use testutils::set_ledger_time;
 
 use crate::{
-    Category, ContractAddresses, DataAvailability, ReportingContract, ReportingContractClient,
-    ReportingError,
+    Category, ContractAddresses, CoverageType, DataAvailability, ReportingContract,
+    ReportingContractClient, ReportingError, MAX_DEP_PAGES,
 };
 
 /// Minimal env with mock_all_auths — replaces the removed create_test_env helper.
@@ -103,6 +103,7 @@ mod bill_payments {
                 id: 1,
                 owner: _owner,
                 name: SorobanString::from_str(&env, "Electricity"),
+                external_ref: None,
                 amount: 100,
                 due_date: 1735689600,
                 recurring: true,
@@ -111,6 +112,7 @@ mod bill_payments {
                 created_at: 1704067200,
                 paid_at: None,
                 schedule_id: None,
+                tags: Vec::new(&env),
                 currency: SorobanString::from_str(&env, "XLM"),
             });
             BillPage {
@@ -136,6 +138,7 @@ mod bill_payments {
                 id: 1,
                 owner: _owner.clone(),
                 name: SorobanString::from_str(&env, "Electricity"),
+                external_ref: None,
                 amount: 100,
                 due_date: 1735689600,
                 recurring: true,
@@ -144,12 +147,14 @@ mod bill_payments {
                 created_at: 1704067200,
                 paid_at: None,
                 schedule_id: None,
+                tags: Vec::new(&env),
                 currency: SorobanString::from_str(&env, "XLM"),
             });
             bills.push_back(Bill {
                 id: 2,
                 owner: _owner,
                 name: SorobanString::from_str(&env, "Water"),
+                external_ref: None,
                 amount: 50,
                 due_date: 1735689600,
                 recurring: true,
@@ -158,6 +163,7 @@ mod bill_payments {
                 created_at: 1704067200,
                 paid_at: Some(1704153600),
                 schedule_id: None,
+                tags: Vec::new(&env),
                 currency: SorobanString::from_str(&env, "XLM"),
             });
             BillPage {
@@ -170,7 +176,7 @@ mod bill_payments {
 }
 
 mod insurance {
-    use crate::{InsurancePolicy, InsuranceTrait};
+    use crate::{CoverageType, InsurancePolicy, InsuranceTrait};
     use soroban_sdk::{contract, contractimpl, Address, Env, String as SorobanString, Vec};
 
     #[contract]
@@ -190,12 +196,12 @@ mod insurance {
                 id: 1,
                 owner: _owner,
                 name: SorobanString::from_str(&env, "Health Insurance"),
-                coverage_type: SorobanString::from_str(&env, "health"),
+                external_ref: None,
+                coverage_type: CoverageType::Health,
                 monthly_premium: 200,
                 coverage_amount: 50000,
                 active: true,
                 next_payment_date: 1735689600,
-                schedule_id: None,
             });
             crate::PolicyPage {
                 items: policies,
@@ -2236,24 +2242,40 @@ fn test_check_dependencies_succeeds_with_configured_contracts() {
         &family_wallet_id,
     );
 
-    let statuses = client.check_dependencies(&admin).unwrap();
+    use soroban_sdk::String as SStr;
+    let statuses = client.check_dependencies(&admin);
     assert_eq!(statuses.len(), 5);
 
     // Check each status
-    assert_eq!(statuses.get(0).unwrap().name, "remittance_split");
+    assert_eq!(
+        statuses.get(0).unwrap().name,
+        SStr::from_str(&env, "remittance_split")
+    );
     assert!(statuses.get(0).unwrap().ok);
     assert_eq!(statuses.get(0).unwrap().error_category, None);
 
-    assert_eq!(statuses.get(1).unwrap().name, "savings_goals");
+    assert_eq!(
+        statuses.get(1).unwrap().name,
+        SStr::from_str(&env, "savings_goals")
+    );
     assert!(statuses.get(1).unwrap().ok);
 
-    assert_eq!(statuses.get(2).unwrap().name, "bill_payments");
+    assert_eq!(
+        statuses.get(2).unwrap().name,
+        SStr::from_str(&env, "bill_payments")
+    );
     assert!(statuses.get(2).unwrap().ok);
 
-    assert_eq!(statuses.get(3).unwrap().name, "insurance");
+    assert_eq!(
+        statuses.get(3).unwrap().name,
+        SStr::from_str(&env, "insurance")
+    );
     assert!(statuses.get(3).unwrap().ok);
 
-    assert_eq!(statuses.get(4).unwrap().name, "family_wallet");
+    assert_eq!(
+        statuses.get(4).unwrap().name,
+        SStr::from_str(&env, "family_wallet")
+    );
     assert!(statuses.get(4).unwrap().ok);
 }
 
@@ -2280,4 +2302,387 @@ fn test_check_dependencies_fails_when_not_configured() {
 
     let result = client.try_check_dependencies(&admin);
     assert!(result.is_err());
+}
+
+// ---------------------------------------------------------------------------
+// Dependency paging loop termination tests (Issue #487 / SC-034)
+//
+// These tests prove that the bill-compliance and insurance-report paging loops
+// are bounded and deterministic under two conditions:
+//
+//  1. Normal termination – a dependency returns `next_cursor == 0` after a
+//     finite number of pages.  The loop must collect every item and report
+//     `DataAvailability::Complete`.
+//
+//  2. Cap termination – a dependency never returns `next_cursor == 0`
+//     (simulating an unbounded or misbehaving contract).  The loop must stop
+//     after exactly `MAX_DEP_PAGES` fetches and report
+//     `DataAvailability::Partial`.
+//
+//  3. Monotonic cursor progression – the loop always advances the cursor to
+//     the value returned by the previous page, never revisiting a page.
+//     Tested by asserting item counts from multi-page responses match the
+//     expected per-page accumulation.
+//
+// Mock bill-payments contracts use cursor-value routing so each test's
+// page sequence is hard-coded and requires no shared state.
+// ---------------------------------------------------------------------------
+
+// ── Mock: bill-payments returning exactly 3 pages then cursor = 0 ──────────
+//
+// page 0 (cursor=0) → 1 bill (id=1, created within period), next_cursor=5
+// page 1 (cursor=5) → 1 bill (id=2, created within period), next_cursor=10
+// page 2 (cursor=10) → 1 bill (id=3, created within period), next_cursor=0
+//
+// Expected: 3 bills collected, DataAvailability::Complete
+mod bills_three_pages {
+    use crate::{Bill, BillPage, BillPaymentsTrait};
+    use soroban_sdk::{contract, contractimpl, Address, Env, String as SorobanString, Vec};
+
+    const PERIOD_TS: u64 = 1_704_067_200;
+
+    #[contract]
+    pub struct BillsThreePages;
+
+    #[contractimpl]
+    impl BillPaymentsTrait for BillsThreePages {
+        fn get_unpaid_bills(env: Env, _owner: Address, _c: u32, _l: u32) -> BillPage {
+            BillPage {
+                items: Vec::new(&env),
+                next_cursor: 0,
+                count: 0,
+            }
+        }
+        fn get_total_unpaid(_env: Env, _owner: Address) -> i128 {
+            0
+        }
+        fn get_all_bills_for_owner(env: Env, owner: Address, cursor: u32, _limit: u32) -> BillPage {
+            let (bill_id, next_cursor) = match cursor {
+                0 => (1u32, 5u32),
+                5 => (2, 10),
+                _ => (3, 0),
+            };
+            let mut items = Vec::new(&env);
+            items.push_back(Bill {
+                id: bill_id,
+                owner,
+                name: SorobanString::from_str(&env, "B"),
+                external_ref: None,
+                amount: 100,
+                due_date: PERIOD_TS + 86400,
+                recurring: false,
+                frequency_days: 30,
+                paid: false,
+                created_at: PERIOD_TS,
+                paid_at: None,
+                schedule_id: None,
+                tags: Vec::new(&env),
+                currency: SorobanString::from_str(&env, "XLM"),
+            });
+            BillPage {
+                count: 1,
+                items,
+                next_cursor,
+            }
+        }
+    }
+}
+
+// ── Mock: bill-payments that never returns cursor = 0 ──────────────────────
+//
+// Always returns next_cursor = cursor + 1.  Without a cap this loop would
+// run forever; the contract must stop after MAX_DEP_PAGES.
+mod bills_infinite {
+    use crate::{Bill, BillPage, BillPaymentsTrait};
+    use soroban_sdk::{contract, contractimpl, Address, Env, String as SorobanString, Vec};
+
+    const PERIOD_TS: u64 = 1_704_067_200;
+
+    #[contract]
+    pub struct BillsInfinite;
+
+    #[contractimpl]
+    impl BillPaymentsTrait for BillsInfinite {
+        fn get_unpaid_bills(env: Env, _owner: Address, _c: u32, _l: u32) -> BillPage {
+            BillPage {
+                items: Vec::new(&env),
+                next_cursor: 0,
+                count: 0,
+            }
+        }
+        fn get_total_unpaid(_env: Env, _owner: Address) -> i128 {
+            0
+        }
+        fn get_all_bills_for_owner(env: Env, owner: Address, cursor: u32, _limit: u32) -> BillPage {
+            let mut items = Vec::new(&env);
+            items.push_back(Bill {
+                id: cursor,
+                owner,
+                name: SorobanString::from_str(&env, "B"),
+                external_ref: None,
+                amount: 50,
+                due_date: PERIOD_TS + 86400,
+                recurring: false,
+                frequency_days: 0,
+                paid: false,
+                created_at: PERIOD_TS,
+                paid_at: None,
+                schedule_id: None,
+                tags: Vec::new(&env),
+                currency: SorobanString::from_str(&env, "XLM"),
+            });
+            BillPage {
+                count: 1,
+                items,
+                next_cursor: cursor + 1,
+            }
+        }
+    }
+}
+
+// ── Mock: insurance returning exactly 3 pages then cursor = 0 ─────────────
+mod insurance_three_pages {
+    use crate::{CoverageType, InsurancePolicy, InsuranceTrait, PolicyPage};
+    use soroban_sdk::{contract, contractimpl, Address, Env, String as SorobanString, Vec};
+
+    #[contract]
+    pub struct InsuranceThreePages;
+
+    #[contractimpl]
+    impl InsuranceTrait for InsuranceThreePages {
+        fn get_active_policies(env: Env, owner: Address, cursor: u32, _limit: u32) -> PolicyPage {
+            let (policy_id, next_cursor) = match cursor {
+                0 => (1u32, 7u32),
+                7 => (2, 14),
+                _ => (3, 0),
+            };
+            let mut items = Vec::new(&env);
+            items.push_back(InsurancePolicy {
+                id: policy_id,
+                owner,
+                name: SorobanString::from_str(&env, "P"),
+                external_ref: None,
+                coverage_type: CoverageType::Health,
+                monthly_premium: 100,
+                coverage_amount: 10_000,
+                active: true,
+                next_payment_date: 1_735_689_600,
+            });
+            PolicyPage {
+                count: 1,
+                items,
+                next_cursor,
+            }
+        }
+        fn get_total_monthly_premium(_env: Env, _owner: Address) -> i128 {
+            300
+        }
+    }
+}
+
+// ── Mock: insurance that never returns cursor = 0 ─────────────────────────
+mod insurance_infinite {
+    use crate::{CoverageType, InsurancePolicy, InsuranceTrait, PolicyPage};
+    use soroban_sdk::{contract, contractimpl, Address, Env, String as SorobanString, Vec};
+
+    #[contract]
+    pub struct InsuranceInfinite;
+
+    #[contractimpl]
+    impl InsuranceTrait for InsuranceInfinite {
+        fn get_active_policies(env: Env, owner: Address, cursor: u32, _limit: u32) -> PolicyPage {
+            let mut items = Vec::new(&env);
+            items.push_back(InsurancePolicy {
+                id: cursor,
+                owner,
+                name: SorobanString::from_str(&env, "P"),
+                external_ref: None,
+                coverage_type: CoverageType::Health,
+                monthly_premium: 100,
+                coverage_amount: 10_000,
+                active: true,
+                next_payment_date: 1_735_689_600,
+            });
+            PolicyPage {
+                count: 1,
+                items,
+                next_cursor: cursor + 1,
+            }
+        }
+        fn get_total_monthly_premium(_env: Env, _owner: Address) -> i128 {
+            0
+        }
+    }
+}
+
+// ── Shared setup helper for paging tests ─────────────────────────────────
+
+fn setup_paging_test(
+    env: &Env,
+    bill_payments_id: Address,
+    insurance_id: Address,
+) -> (ReportingContractClient, Address) {
+    let contract_id = env.register_contract(None, ReportingContract);
+    let client = ReportingContractClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    client.init(&admin);
+
+    let remittance_split_id = env.register_contract(None, remittance_split::RemittanceSplit);
+    let savings_goals_id = env.register_contract(None, savings_goals::SavingsGoalsContract);
+    let family_wallet = Address::generate(env);
+
+    client.configure_addresses(
+        &admin,
+        &remittance_split_id,
+        &savings_goals_id,
+        &bill_payments_id,
+        &insurance_id,
+        &family_wallet,
+    );
+    (client, admin)
+}
+
+// ── Test 1: bill paging terminates at cursor = 0 (3 pages) ───────────────
+
+#[test]
+fn test_bill_paging_terminates_at_cursor_zero() {
+    let env = create_test_env();
+    set_ledger_time(&env, 1, 1_704_067_200);
+
+    let bill_id = env.register_contract(None, bills_three_pages::BillsThreePages);
+    let ins_id = env.register_contract(None, insurance::Insurance);
+    let (client, _) = setup_paging_test(&env, bill_id, ins_id);
+
+    let user = Address::generate(&env);
+    let report = client.get_bill_compliance_report(&user, &1_704_067_200u64, &1_706_745_600u64);
+
+    // All 3 pages fetched — no items are filtered out because created_at == period_start
+    assert_eq!(
+        report.data_availability,
+        DataAvailability::Complete,
+        "cursor=0 termination must yield Complete"
+    );
+    assert_eq!(
+        report.total_bills, 3,
+        "all 3 bills from 3 pages must be aggregated"
+    );
+    assert_eq!(report.unpaid_bills, 3);
+}
+
+// ── Test 2: bill paging terminates at MAX_DEP_PAGES cap ──────────────────
+
+#[test]
+fn test_bill_paging_terminates_at_cap() {
+    let env = create_test_env();
+    set_ledger_time(&env, 1, 1_704_067_200);
+
+    let bill_id = env.register_contract(None, bills_infinite::BillsInfinite);
+    let ins_id = env.register_contract(None, insurance::Insurance);
+    let (client, _) = setup_paging_test(&env, bill_id, ins_id);
+
+    let user = Address::generate(&env);
+    let report = client.get_bill_compliance_report(&user, &1_704_067_200u64, &1_706_745_600u64);
+
+    assert_eq!(
+        report.data_availability,
+        DataAvailability::Partial,
+        "unbounded dependency must yield Partial after MAX_DEP_PAGES"
+    );
+    assert_eq!(
+        report.total_bills, MAX_DEP_PAGES,
+        "exactly MAX_DEP_PAGES bills must be collected before the cap fires"
+    );
+}
+
+// ── Test 3: bill cursor monotonicity — items accumulate across all pages ──
+
+#[test]
+fn test_bill_paging_cursor_monotonicity() {
+    let env = create_test_env();
+    set_ledger_time(&env, 1, 1_704_067_200);
+
+    let bill_id = env.register_contract(None, bills_three_pages::BillsThreePages);
+    let ins_id = env.register_contract(None, insurance::Insurance);
+    let (client, _) = setup_paging_test(&env, bill_id, ins_id);
+
+    let user = Address::generate(&env);
+    // Each page delivers exactly 1 bill; 3 pages → 3 bills total.
+    // If the loop visited the same page twice, count would differ.
+    let report = client.get_bill_compliance_report(&user, &1_704_067_200u64, &1_706_745_600u64);
+    assert_eq!(
+        report.total_bills, 3,
+        "cursor must advance monotonically so each page is visited exactly once"
+    );
+    assert_eq!(report.data_availability, DataAvailability::Complete);
+}
+
+// ── Test 4: insurance paging terminates at cursor = 0 (3 pages) ──────────
+
+#[test]
+fn test_insurance_paging_terminates_at_cursor_zero() {
+    let env = create_test_env();
+    set_ledger_time(&env, 1, 1_704_067_200);
+
+    let bill_id = env.register_contract(None, bill_payments::BillPayments);
+    let ins_id = env.register_contract(None, insurance_three_pages::InsuranceThreePages);
+    let (client, _) = setup_paging_test(&env, bill_id, ins_id);
+
+    let user = Address::generate(&env);
+    let report = client.get_insurance_report(&user, &1_704_067_200u64, &1_706_745_600u64);
+
+    assert_eq!(
+        report.data_availability,
+        DataAvailability::Complete,
+        "cursor=0 termination must yield Complete"
+    );
+    assert_eq!(
+        report.active_policies, 3,
+        "all 3 policies from 3 pages must be aggregated"
+    );
+    assert_eq!(report.total_coverage, 30_000);
+}
+
+// ── Test 5: insurance paging terminates at MAX_DEP_PAGES cap ─────────────
+
+#[test]
+fn test_insurance_paging_terminates_at_cap() {
+    let env = create_test_env();
+    set_ledger_time(&env, 1, 1_704_067_200);
+
+    let bill_id = env.register_contract(None, bill_payments::BillPayments);
+    let ins_id = env.register_contract(None, insurance_infinite::InsuranceInfinite);
+    let (client, _) = setup_paging_test(&env, bill_id, ins_id);
+
+    let user = Address::generate(&env);
+    let report = client.get_insurance_report(&user, &1_704_067_200u64, &1_706_745_600u64);
+
+    assert_eq!(
+        report.data_availability,
+        DataAvailability::Partial,
+        "unbounded dependency must yield Partial after MAX_DEP_PAGES"
+    );
+    assert_eq!(
+        report.active_policies, MAX_DEP_PAGES,
+        "exactly MAX_DEP_PAGES policies must be collected before the cap fires"
+    );
+}
+
+// ── Test 6: insurance cursor monotonicity ────────────────────────────────
+
+#[test]
+fn test_insurance_paging_cursor_monotonicity() {
+    let env = create_test_env();
+    set_ledger_time(&env, 1, 1_704_067_200);
+
+    let bill_id = env.register_contract(None, bill_payments::BillPayments);
+    let ins_id = env.register_contract(None, insurance_three_pages::InsuranceThreePages);
+    let (client, _) = setup_paging_test(&env, bill_id, ins_id);
+
+    let user = Address::generate(&env);
+    let report = client.get_insurance_report(&user, &1_704_067_200u64, &1_706_745_600u64);
+    assert_eq!(
+        report.active_policies, 3,
+        "cursor must advance monotonically so each page is visited exactly once"
+    );
+    assert_eq!(report.data_availability, DataAvailability::Complete);
 }

--- a/reporting/tests/gas_bench.rs
+++ b/reporting/tests/gas_bench.rs
@@ -182,6 +182,7 @@ macro_rules! mock_bills {
                             id: i,
                             owner: owner.clone(),
                             name: SorobanString::from_str(&env, "Bench Bill"),
+                            external_ref: None,
                             amount: 100i128,
                             due_date: 1_800_000_000,
                             recurring: false,
@@ -190,6 +191,7 @@ macro_rules! mock_bills {
                             created_at: super::BILL_CREATED_AT,
                             paid_at: None,
                             schedule_id: None,
+                            tags: Vec::new(&env),
                             currency: SorobanString::from_str(&env, "USDC"),
                         });
                     }
@@ -218,6 +220,7 @@ macro_rules! mock_bills {
                             id: i,
                             owner: owner.clone(),
                             name: SorobanString::from_str(&env, "Bench Bill"),
+                            external_ref: None,
                             amount: 100i128,
                             due_date: 1_800_000_000,
                             recurring: false,
@@ -226,6 +229,7 @@ macro_rules! mock_bills {
                             created_at: super::BILL_CREATED_AT,
                             paid_at: if paid { Some(1_700_010_000) } else { None },
                             schedule_id: None,
+                            tags: Vec::new(&env),
                             currency: SorobanString::from_str(&env, "USDC"),
                         });
                     }
@@ -245,7 +249,7 @@ macro_rules! mock_bills {
 macro_rules! mock_insurance {
     ($mod_name:ident, $struct_name:ident, $n:expr) => {
         mod $mod_name {
-            use reporting::{InsurancePolicy, InsuranceTrait, PolicyPage};
+            use reporting::{CoverageType, InsurancePolicy, InsuranceTrait, PolicyPage};
             use soroban_sdk::{contract, contractimpl, Address, Env, String as SorobanString, Vec};
 
             #[contract]
@@ -265,12 +269,12 @@ macro_rules! mock_insurance {
                             id: i,
                             owner: owner.clone(),
                             name: SorobanString::from_str(&env, "Bench Policy"),
-                            coverage_type: SorobanString::from_str(&env, "health"),
+                            external_ref: None,
+                            coverage_type: CoverageType::Health,
                             monthly_premium: 200i128,
                             coverage_amount: 50_000i128,
                             active: true,
                             next_payment_date: 1_800_000_000,
-                            schedule_id: None,
                         });
                     }
                     let count = items.len();


### PR DESCRIPTION
test(reporting): assert dependency paging loops terminate deterministically

Add MAX_DEP_PAGES = 20 safety cap to get_bill_compliance_report and
get_insurance_report. Both functions now loop through dependency pages
until next_cursor == 0 (Complete) or the cap is reached (Partial).
BillComplianceReport and InsuranceReport gain a data_availability field
to surface which condition terminated the loop.

Add 6 tests proving loop termination and cursor monotonicity:
  - cursor=0 termination yields DataAvailability::Complete
  - unbounded dependency yields DataAvailability::Partial after exactly
    MAX_DEP_PAGES fetches
  - each page is visited exactly once (monotonic cursor progression)
Tests use cursor-value-routed mock contracts so page sequences are
hard-coded and require no shared state.

Fix pre-existing compile errors unblocking cargo test -p reporting:
  - Bill constructors missing external_ref and tags fields
  - InsurancePolicy constructors using wrong coverage_type type and
    nonexistent schedule_id field
  - check_dependencies test comparing soroban_sdk::String to &str literals
  - pub use remitwise_common CoverageType so integration tests can access it

Closes #487
