### PR TITLE
Feature/family wallet access audit pagination

### DIFF
--- a/family_wallet/src/lib.rs
+++ b/family_wallet/src/lib.rs
@@ -30,6 +30,9 @@ const MAX_BATCH_MEMBERS: u32 = 50;
 
 // Access audit bounds
 const MAX_ACCESS_AUDIT_ENTRIES: u32 = 200;
+const MAX_AUDIT_PAGE_LIMIT: u32 = 50;
+const DEFAULT_AUDIT_PAGE_LIMIT: u32 = 20;
+
 #[contracttype]
 #[derive(Clone)]
 pub struct AccessAuditEntry {
@@ -38,6 +41,14 @@ pub struct AccessAuditEntry {
     pub target: Option<Address>,
     pub success: bool,
     pub timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct AccessAuditPage {
+    pub items: Vec<AccessAuditEntry>,
+    pub next_cursor: u32,
+    pub count: u32,
 }
 
 #[contracttype]
@@ -1941,6 +1952,46 @@ impl FamilyWallet {
             }
         }
         out
+    }
+
+    // Owner/Admin only: audit data is privacy-sensitive — reveals who accessed
+    // what and when, so Members are excluded from reading the full trail.
+    pub fn get_access_audit_page(
+        env: Env,
+        caller: Address,
+        from_index: u32,
+        limit: u32,
+    ) -> AccessAuditPage {
+        caller.require_auth();
+        Self::require_role_at_least(&env, &caller, FamilyRole::Admin);
+
+        let entries: Vec<AccessAuditEntry> = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("ACC_AUDIT"))
+            .unwrap_or_else(|| Vec::new(&env));
+
+        let capped_limit = if limit == 0 {
+            DEFAULT_AUDIT_PAGE_LIMIT
+        } else {
+            limit.min(MAX_AUDIT_PAGE_LIMIT)
+        };
+        let total = entries.len();
+        let mut items = Vec::new(&env);
+        let mut i = from_index;
+        while i < total && items.len() < capped_limit {
+            if let Some(e) = entries.get(i) {
+                items.push_back(e);
+            }
+            i += 1;
+        }
+        let count = items.len();
+        let next_cursor = if i < total { i } else { 0 };
+        AccessAuditPage {
+            items,
+            next_cursor,
+            count,
+        }
     }
 
     // -----------------------------------------------------------------------

--- a/family_wallet/src/test.rs
+++ b/family_wallet/src/test.rs
@@ -2609,3 +2609,177 @@ fn test_disabled_rollover_only_checks_single_tx_limits() {
     let result = client.try_withdraw(&member, &token_contract.address(), &recipient, &500_0000000);
     assert!(result.is_err());
 }
+
+// ---------------------------------------------------------------------------
+// get_access_audit_page tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_audit_page_owner_can_read_first_page() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = FamilyWalletClient::new(&env, &env.register_contract(None, FamilyWallet));
+    let owner = Address::generate(&env);
+    let admin = Address::generate(&env);
+    let member = Address::generate(&env);
+    client.init(&owner, &Vec::new(&env));
+    client.add_member(&owner, &admin, &FamilyRole::Admin, &0i128);
+    client.add_member(&owner, &member, &FamilyRole::Member, &0i128);
+
+    client.set_emergency_mode(&owner, &true);
+    let page = client.get_access_audit_page(&owner, &0, &10);
+    assert!(page.count > 0);
+    assert_eq!(page.next_cursor, 0);
+}
+
+#[test]
+fn test_audit_page_admin_can_read() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = FamilyWalletClient::new(&env, &env.register_contract(None, FamilyWallet));
+    let owner = Address::generate(&env);
+    let admin = Address::generate(&env);
+    client.init(&owner, &Vec::new(&env));
+    client.add_member(&owner, &admin, &FamilyRole::Admin, &0i128);
+
+    client.set_emergency_mode(&owner, &true);
+    let page = client.get_access_audit_page(&admin, &0, &10);
+    assert!(page.count > 0);
+}
+
+#[test]
+#[should_panic]
+fn test_audit_page_member_denied() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = FamilyWalletClient::new(&env, &env.register_contract(None, FamilyWallet));
+    let owner = Address::generate(&env);
+    let member = Address::generate(&env);
+    client.init(&owner, &Vec::new(&env));
+    client.add_member(&owner, &member, &FamilyRole::Member, &0i128);
+
+    client.set_emergency_mode(&owner, &true);
+    client.get_access_audit_page(&member, &0, &10);
+}
+
+#[test]
+fn test_audit_page_cursor_progression() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.budget().reset_unlimited();
+    let client = FamilyWalletClient::new(&env, &env.register_contract(None, FamilyWallet));
+    let owner = Address::generate(&env);
+    client.init(&owner, &Vec::new(&env));
+
+    for _ in 0..10 {
+        client.set_emergency_mode(&owner, &true);
+        client.set_emergency_mode(&owner, &false);
+    }
+    // 20 entries; fetch in pages of 7
+    let page1 = client.get_access_audit_page(&owner, &0, &7);
+    assert_eq!(page1.count, 7);
+    assert_ne!(page1.next_cursor, 0);
+
+    let page2 = client.get_access_audit_page(&owner, &page1.next_cursor, &7);
+    assert_eq!(page2.count, 7);
+    assert_ne!(page2.next_cursor, 0);
+
+    assert!(page2.next_cursor > page1.next_cursor);
+
+    let page3 = client.get_access_audit_page(&owner, &page2.next_cursor, &7);
+    assert_eq!(page3.count, 6);
+    assert_eq!(page3.next_cursor, 0);
+}
+
+#[test]
+fn test_audit_page_terminates_at_cursor_zero() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = FamilyWalletClient::new(&env, &env.register_contract(None, FamilyWallet));
+    let owner = Address::generate(&env);
+    client.init(&owner, &Vec::new(&env));
+    client.set_emergency_mode(&owner, &true);
+
+    let mut cursor = 0u32;
+    let mut iterations = 0u32;
+    loop {
+        let page = client.get_access_audit_page(&owner, &cursor, &DEFAULT_AUDIT_PAGE_LIMIT);
+        iterations += 1;
+        if page.next_cursor == 0 {
+            break;
+        }
+        cursor = page.next_cursor;
+        assert!(iterations < 100, "paging loop did not terminate");
+    }
+    assert!(iterations >= 1);
+}
+
+#[test]
+fn test_audit_page_limit_capped_at_max() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.budget().reset_unlimited();
+    let client = FamilyWalletClient::new(&env, &env.register_contract(None, FamilyWallet));
+    let owner = Address::generate(&env);
+    client.init(&owner, &Vec::new(&env));
+
+    for _ in 0..60 {
+        client.set_emergency_mode(&owner, &true);
+        client.set_emergency_mode(&owner, &false);
+    }
+    let page = client.get_access_audit_page(&owner, &0, &200);
+    assert!(page.count <= MAX_AUDIT_PAGE_LIMIT);
+}
+
+#[test]
+fn test_audit_page_zero_limit_uses_default() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.budget().reset_unlimited();
+    let client = FamilyWalletClient::new(&env, &env.register_contract(None, FamilyWallet));
+    let owner = Address::generate(&env);
+    client.init(&owner, &Vec::new(&env));
+
+    for _ in 0..25 {
+        client.set_emergency_mode(&owner, &true);
+    }
+    let page = client.get_access_audit_page(&owner, &0, &0);
+    assert_eq!(page.count, DEFAULT_AUDIT_PAGE_LIMIT);
+}
+
+#[test]
+fn test_audit_page_out_of_bounds_returns_empty() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = FamilyWalletClient::new(&env, &env.register_contract(None, FamilyWallet));
+    let owner = Address::generate(&env);
+    client.init(&owner, &Vec::new(&env));
+
+    let page = client.get_access_audit_page(&owner, &1000, &10);
+    assert_eq!(page.count, 0);
+    assert_eq!(page.next_cursor, 0);
+}
+
+#[test]
+fn test_audit_page_items_match_get_access_audit() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = FamilyWalletClient::new(&env, &env.register_contract(None, FamilyWallet));
+    let owner = Address::generate(&env);
+    client.init(&owner, &Vec::new(&env));
+
+    client.set_emergency_mode(&owner, &true);
+    client.set_emergency_mode(&owner, &false);
+
+    let all = client.get_access_audit(&200);
+    let page = client.get_access_audit_page(&owner, &0, &200);
+
+    assert_eq!(page.count, all.len());
+    for i in 0..page.count {
+        let a = all.get(i).unwrap();
+        let b = page.items.get(i).unwrap();
+        assert_eq!(a.operation, b.operation);
+        assert_eq!(a.caller, b.caller);
+        assert_eq!(a.success, b.success);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `get_access_audit_page(caller, from_index, limit) -> AccessAuditPage` to `family_wallet`
- Auth policy: **Owner/Admin only** — audit data reveals who accessed what and when across all members, making it privacy-sensitive; plain Members are excluded
- `AccessAuditPage` returns `{ items, next_cursor, count }`; `next_cursor = 0` is the end-of-data sentinel
- Page size is capped at `MAX_AUDIT_PAGE_LIMIT = 50`; passing `limit = 0` uses `DEFAULT_AUDIT_PAGE_LIMIT = 20`
- Existing `get_access_audit(limit)` function is unchanged

## Test plan

- [x] `test_audit_page_owner_can_read_first_page` — owner can call and gets results
- [x] `test_audit_page_admin_can_read` — Admin role passes the auth guard
- [x] `test_audit_page_member_denied` — Member role panics (auth rejected)
- [x] `test_audit_page_cursor_progression` — 20 entries paged at size 7; cursors strictly increase, final page has `next_cursor = 0`
- [x] `test_audit_page_terminates_at_cursor_zero` — a standard paging loop terminates deterministically
- [x] `test_audit_page_limit_capped_at_max` — requesting 200 returns ≤ 50 entries
- [x] `test_audit_page_zero_limit_uses_default` — `limit = 0` returns exactly `DEFAULT_AUDIT_PAGE_LIMIT` entries
- [x] `test_audit_page_out_of_bounds_returns_empty` — `from_index` past the end returns `count = 0, next_cursor = 0`
- [x] `test_audit_page_items_match_get_access_audit` — paginated output is consistent with the legacy function

Closes #522