### PR TITLE
test(integration): Add reporting DataAvailability degradation tests (Closes #503)

### DIFF
--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -11,6 +11,8 @@ savings_goals = { path = "../savings_goals" }
 bill_payments = { path = "../bill_payments" }
 insurance = { path = "../insurance" }
 remitwise-common = { path = "../remitwise-common" }
+reporting = { path = "../reporting" }
+family_wallet = { path = "../family_wallet" }
 
 [dev-dependencies]
 soroban-sdk = { version = "=21.7.7", features = ["testutils"] }

--- a/integration_tests/tests/multi_contract_integration.rs
+++ b/integration_tests/tests/multi_contract_integration.rs
@@ -7,9 +7,11 @@
 //! - remittance_split
 
 use bill_payments::{BillPayments, BillPaymentsClient};
+use family_wallet::{FamilyWallet, FamilyWalletClient};
 use insurance::{Insurance, InsuranceClient};
 use remittance_split::{RemittanceSplit, RemittanceSplitClient};
 use remitwise_common::CoverageType;
+use reporting::{DataAvailability, ReportingContract, ReportingContractClient};
 use savings_goals::{SavingsGoalContract, SavingsGoalContractClient};
 use soroban_sdk::testutils::{Address as _, Ledger, LedgerInfo};
 use soroban_sdk::{Address, Env, String as SorobanString};
@@ -210,4 +212,106 @@ fn test_multiple_entities_creation() {
         &None,
     );
     assert_eq!(policy2, 2u32);
+}
+
+#[test]
+fn test_reporting_data_availability_missing() {
+    let env = make_env();
+    let user = Address::generate(&env);
+    let admin = Address::generate(&env);
+
+    let reporting_contract_id = env.register_contract(None, ReportingContract);
+    let reporting_client = ReportingContractClient::new(&env, &reporting_contract_id);
+
+    // Initialize with admin
+    reporting_client.init(&admin);
+
+    // Do not configure addresses - should result in Missing
+
+    let total_amount = 10_000i128;
+    let period_start = env.ledger().timestamp();
+    let period_end = period_start + (30 * 86400);
+
+    let summary = reporting_client.get_remittance_summary(&user, &total_amount, &period_start, &period_end);
+    assert_eq!(summary.data_availability, DataAvailability::Missing);
+}
+
+#[test]
+fn test_reporting_data_availability_partial() {
+    let env = make_env();
+    let user = Address::generate(&env);
+    let admin = Address::generate(&env);
+
+    let reporting_contract_id = env.register_contract(None, ReportingContract);
+    let reporting_client = ReportingContractClient::new(&env, &reporting_contract_id);
+
+    // Initialize with admin
+    reporting_client.init(&admin);
+
+    let remittance_contract_id = env.register_contract(None, RemittanceSplit);
+    let savings_contract_id = env.register_contract(None, SavingsGoalContract);
+    let bills_contract_id = env.register_contract(None, BillPayments);
+    let insurance_contract_id = env.register_contract(None, Insurance);
+    let family_wallet_id = env.register_contract(None, FamilyWallet);
+
+    // Configure addresses
+    reporting_client.configure_addresses(
+        &admin,
+        &remittance_contract_id,
+        &savings_contract_id,
+        &bills_contract_id,
+        &insurance_contract_id,
+        &family_wallet_id,
+    );
+
+    // Do not initialize remittance split - get_split should fail, resulting in Partial
+
+    let total_amount = 10_000i128;
+    let period_start = env.ledger().timestamp();
+    let period_end = period_start + (30 * 86400);
+
+    let summary = reporting_client.get_remittance_summary(&user, &total_amount, &period_start, &period_end);
+    assert_eq!(summary.data_availability, DataAvailability::Partial);
+}
+
+#[test]
+fn test_reporting_data_availability_complete() {
+    let env = make_env();
+    let user = Address::generate(&env);
+    let admin = Address::generate(&env);
+
+    let reporting_contract_id = env.register_contract(None, ReportingContract);
+    let reporting_client = ReportingContractClient::new(&env, &reporting_contract_id);
+
+    // Initialize with admin
+    reporting_client.init(&admin);
+
+    let remittance_contract_id = env.register_contract(None, RemittanceSplit);
+    let remittance_client = RemittanceSplitClient::new(&env, &remittance_contract_id);
+
+    let savings_contract_id = env.register_contract(None, SavingsGoalContract);
+    let bills_contract_id = env.register_contract(None, BillPayments);
+    let insurance_contract_id = env.register_contract(None, Insurance);
+    let family_wallet_id = env.register_contract(None, FamilyWallet);
+
+    // Configure addresses
+    reporting_client.configure_addresses(
+        &admin,
+        &remittance_contract_id,
+        &savings_contract_id,
+        &bills_contract_id,
+        &insurance_contract_id,
+        &family_wallet_id,
+    );
+
+    // Initialize remittance split
+    let mock_usdc = Address::generate(&env);
+    remittance_client.initialize_split(&user, &0u64, &mock_usdc, &40u32, &30u32, &20u32, &10u32);
+
+    let total_amount = 10_000i128;
+    let period_start = env.ledger().timestamp();
+    let period_end = period_start + (30 * 86400);
+
+    let summary = reporting_client.get_remittance_summary(&user, &total_amount, &period_start, &period_end);
+    assert_eq!(summary.data_availability, DataAvailability::Complete);
 }


### PR DESCRIPTION
## What this PR does
Add integration tests covering reporting graceful degradation modes.

## Changes
- Add `test_reporting_data_availability_missing()`: validates Missing state when contract addresses not configured
- Add `test_reporting_data_availability_partial()`: validates Partial state when one dependency fails
- Add `test_reporting_data_availability_complete()`: validates Complete state when all dependencies healthy

## Test scenarios
1. **Missing**: Addresses not configured → addresses.is_none() → DataAvailability::Missing
2. **Partial**: Addresses configured but remittance split uninit → get_split fails → DataAvailability::Partial  
3. **Complete**: Addresses configured and remittance split init → all calls succeed → DataAvailability::Complete

## Testing
Each scenario uses deterministic contract setup with mock contracts registered in test env.
Follows existing multi-contract integration test patterns.

Closes #503