### PR TITLE
feat(family_wallet): add pending tx pagination; test(bill_payments): …

### DIFF
--- a/bill_payments/src/lib.rs
+++ b/bill_payments/src/lib.rs
@@ -968,14 +968,17 @@ impl BillPayments {
         bill.paid_at = Some(current_time);
 
         if bill.recurring {
-            let next_due_date = bill
+            let period = (bill.frequency_days as u64)
+                .checked_mul(SECONDS_PER_DAY)
+                .ok_or(Error::InvalidFrequency)?;
+            let mut next_due_date = bill
                 .due_date
-                .checked_add(
-                    (bill.frequency_days as u64)
-                        .checked_mul(SECONDS_PER_DAY)
-                        .ok_or(Error::InvalidFrequency)?,
-                )
+                .checked_add(period)
                 .ok_or(Error::InvalidDueDate)?;
+            // Advance forward by frequency periods until the next due date is strictly in the future
+            while next_due_date <= current_time {
+                next_due_date = next_due_date.checked_add(period).ok_or(Error::InvalidDueDate)?;
+            }
             let next_id = env
                 .storage()
                 .instance()

--- a/bill_payments/src/test.rs
+++ b/bill_payments/src/test.rs
@@ -752,6 +752,75 @@ mod testsuit {
     }
 
     #[test]
+    fn test_create_bill_invalid_due_dates() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, BillPayments);
+        let client = BillPaymentsClient::new(&env, &contract_id);
+        let owner = <soroban_sdk::Address as AddressTrait>::generate(&env);
+
+        env.mock_all_auths();
+        // due_date == 0 should be rejected
+        let res = client.try_create_bill(
+            &owner,
+            &String::from_str(&env, "Invalid"),
+            &100,
+            &0u64,
+            &false,
+            &0u32,
+            &None,
+            &String::from_str(&env, "XLM"),
+        );
+        assert_eq!(res, Err(Ok(Error::InvalidDueDate)));
+
+        // due_date <= now should be rejected
+        set_ledger_time(&env, 1, 1_000_000);
+        env.mock_all_auths();
+        let res2 = client.try_create_bill(
+            &owner,
+            &String::from_str(&env, "Invalid"),
+            &100,
+            &1_000_000u64, // equal to now
+            &false,
+            &0u32,
+            &None,
+            &String::from_str(&env, "XLM"),
+        );
+        assert_eq!(res2, Err(Ok(Error::InvalidDueDate)));
+    }
+
+    #[test]
+    fn test_recurring_generation_never_in_past() {
+        let env = Env::default();
+        // initial time
+        set_ledger_time(&env, 1, 1_000_000);
+        let contract_id = env.register_contract(None, BillPayments);
+        let client = BillPaymentsClient::new(&env, &contract_id);
+        let owner = <soroban_sdk::Address as AddressTrait>::generate(&env);
+
+        env.mock_all_auths();
+        // create recurring bill due shortly after now
+        let bill_id = client.create_bill(
+            &owner,
+            &String::from_str(&env, "Rent"),
+            &1000,
+            &(1_000_010u64),
+            &true,
+            &30u32,
+            &None,
+            &String::from_str(&env, "XLM"),
+        );
+
+        // advance far into the future so next_due_date would otherwise be in the past
+        set_ledger_time(&env, 2, 2_000_000);
+        env.mock_all_auths();
+        client.pay_bill(&owner, &bill_id).unwrap();
+
+        // The next generated recurring bill (id 2) must have due_date > current time
+        let next_bill = client.get_bill(&2).unwrap();
+        assert!(next_bill.due_date > 2_000_000);
+    }
+
+    #[test]
     fn test_get_all_bills_for_owner_basic() {
         let env = Env::default();
         let contract_id = env.register_contract(None, BillPayments);

--- a/family_wallet/src/lib.rs
+++ b/family_wallet/src/lib.rs
@@ -32,6 +32,8 @@ const MAX_BATCH_MEMBERS: u32 = 50;
 const MAX_ACCESS_AUDIT_ENTRIES: u32 = 200;
 const MAX_AUDIT_PAGE_LIMIT: u32 = 50;
 const DEFAULT_AUDIT_PAGE_LIMIT: u32 = 20;
+const MAX_PENDING_PAGE_LIMIT: u32 = 100;
+const DEFAULT_PENDING_PAGE_LIMIT: u32 = 20;
 
 #[contracttype]
 #[derive(Clone)]
@@ -81,6 +83,14 @@ pub struct PendingTransaction {
     pub created_at: u64,
     pub expires_at: u64,
     pub data: TransactionData,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct PendingTxPage {
+    pub items: Vec<PendingTransaction>,
+    pub next_cursor: u64,
+    pub count: u32,
 }
 
 #[contracttype]
@@ -1155,6 +1165,65 @@ impl FamilyWallet {
             .unwrap_or_else(|| panic!("Pending transactions map not initialized"));
 
         pending_txs.get(tx_id)
+    }
+
+    /// Paginated listing of pending multisig proposals.
+    ///
+    /// - `caller` must be authenticated.
+    /// - Owner/Admin may list all pending proposals.
+    /// - Regular members may only list proposals they proposed.
+    ///
+    /// Cursor is the last-seen `tx_id`. Pass `0` for the first page.
+    pub fn get_pending_transactions_page(
+        env: Env,
+        caller: Address,
+        cursor: u64,
+        limit: u32,
+    ) -> PendingTxPage {
+        caller.require_auth();
+
+        let capped_limit = if limit == 0 {
+            DEFAULT_PENDING_PAGE_LIMIT
+        } else {
+            limit.min(MAX_PENDING_PAGE_LIMIT)
+        };
+
+        let pending_txs: Map<u64, PendingTransaction> = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("PEND_TXS"))
+            .unwrap_or_else(|| Map::new(&env));
+
+        let next_tx: u64 = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("NEXT_TX"))
+            .unwrap_or(1u64);
+
+        let mut items: Vec<PendingTransaction> = Vec::new(&env);
+
+        let mut id = cursor.saturating_add(1);
+        let mut last_returned: u64 = 0;
+        let is_admin = Self::is_owner_or_admin(&env, &caller);
+
+        while id < next_tx && items.len() < capped_limit {
+            if let Some(tx) = pending_txs.get(id) {
+                if is_admin || tx.proposer == caller {
+                    items.push_back(tx.clone());
+                    last_returned = id;
+                }
+            }
+            id = id.saturating_add(1);
+        }
+
+        let next_cursor = if id < next_tx && last_returned != 0 { last_returned } else { 0u64 };
+        let count = items.len();
+
+        PendingTxPage {
+            items,
+            next_cursor,
+            count,
+        }
     }
 
     pub fn get_multisig_config(env: Env, tx_type: TransactionType) -> Option<MultiSigConfig> {

--- a/family_wallet/src/test.rs
+++ b/family_wallet/src/test.rs
@@ -2012,6 +2012,50 @@ fn test_paused_contract_rejects_multisig_config() {
 }
 
 #[test]
+fn test_pending_transactions_pagination_and_auth() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, FamilyWallet);
+    let client = FamilyWalletClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let member1 = Address::generate(&env);
+    let member2 = Address::generate(&env);
+    let initial_members = vec![&env, member1.clone(), member2.clone()];
+
+    client.init(&owner, &initial_members);
+
+    // Create 5 pending proposals, alternating proposers
+    env.mock_all_auths();
+    client.propose_split_config_change(&member1, &10, &40, &30, &20);
+    env.mock_all_auths();
+    client.propose_split_config_change(&member2, &11, &39, &30, &20);
+    env.mock_all_auths();
+    client.propose_split_config_change(&member1, &12, &38, &30, &20);
+    env.mock_all_auths();
+    client.propose_split_config_change(&member2, &13, &37, &30, &20);
+    env.mock_all_auths();
+    client.propose_split_config_change(&member1, &14, &36, &30, &20);
+
+    // Owner (admin) can list all pending txs paginated
+    env.mock_all_auths();
+    let page1 = client.get_pending_transactions_page(&owner, &0u64, &2u32);
+    assert_eq!(page1.items.len(), 2);
+    assert!(page1.next_cursor != 0);
+
+    env.mock_all_auths();
+    let page2 = client.get_pending_transactions_page(&owner, &page1.next_cursor, &2u32);
+    assert!(page2.items.len() >= 1 && page2.items.len() <= 2);
+
+    // Member1 should only see their own proposals
+    env.mock_all_auths();
+    let m1_all = client.get_pending_transactions_page(&member1, &0u64, &100u32);
+    for tx in m1_all.items.iter() {
+        assert_eq!(tx.proposer, member1);
+    }
+}
+
+#[test]
 fn test_admin_can_configure_multisig() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
# Feature: Pending Multisig Pagination + Bill Payments due-date tests

Branch: feature/family-wallet-pending-pagination

## Summary
- Add cursor-pagination API for pending multisig proposals in the `family_wallet` contract with deterministic ordering by `tx_id` (ascending).
- Add `PendingTxPage` response type and `get_pending_transactions_page(caller, cursor, limit)` with explicit auth rules (Owner/Admin vs Member).
- Ensure recurring bill generation in `bill_payments` never creates a bill with `due_date <= now` by advancing the next due date forward when payments are late.
- Add unit tests: pagination + auth behavior (family_wallet) and invalid due-date checks + recurring generation (bill_payments).

## Files changed
- family_wallet/src/lib.rs — pagination types and `get_pending_transactions_page` implementation
- family_wallet/src/test.rs — pagination + auth tests
- bill_payments/src/lib.rs — recurring due_date fix
- bill_payments/src/test.rs — invalid due-date tests

## How to test locally
Run the crate tests (requires Rust toolchain + cargo):

```bash
# family wallet tests
cargo test -p family_wallet

# bill payments tests
cargo test -p bill_payments

# or run all tests
cargo test
```

## Notes
- Branch created and committed as `feature/family-wallet-pending-pagination`.
- I couldn't run `cargo test` from this environment; please run the commands above and share any failures and I'll fix them.

## PR title suggestion
feat(family_wallet): add paginated pending multisig proposal listing


#close  #469  #close  #491
