### PR TITLE
feat: bound and test access-audit pagination cursor for family wallet

### DIFF
--- a/docs/fw-access-audit-pagination.md
+++ b/docs/fw-access-audit-pagination.md
@@ -1,0 +1,125 @@
+# Family Wallet — Access-Audit Pagination
+
+## Overview
+
+`get_access_audit_page` exposes the `ACC_AUDIT` log to Owner/Admin callers in
+fixed-size pages.  This document describes the cursor contract, clamping rules,
+and iteration protocol that off-chain consumers must follow.
+
+---
+
+## Storage key
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `ACC_AUDIT` | `Vec<AccessAuditEntry>` | Rolling audit trail, capped at `MAX_ACCESS_AUDIT_ENTRIES` (200). Oldest entries are evicted when the cap is reached. |
+
+---
+
+## Types
+
+```rust
+pub struct AccessAuditEntry {
+    pub operation: Symbol,   // short label, e.g. "em_mode", "add_mem"
+    pub caller:    Address,
+    pub target:    Option<Address>,
+    pub success:   bool,
+    pub timestamp: u64,      // ledger timestamp at write time
+}
+
+pub struct AccessAuditPage {
+    pub items:       Vec<AccessAuditEntry>,
+    pub next_cursor: u32,  // pass as `from_index` on the next call
+    pub count:       u32,  // number of items in this page
+}
+```
+
+---
+
+## Cursor semantics
+
+`from_index` is the **inclusive, zero-based** index of the first entry to
+return.  `next_cursor` in the response is the index to supply as `from_index`
+on the next call.
+
+### End-of-log sentinel
+
+`next_cursor == total` (where `total` is the length of the log at call time)
+signals that there are no more entries.  Callers should stop iterating when:
+
+- `next_cursor >= total` (returned by a previous page), **or**
+- the returned page is empty (`count == 0`).
+
+> **Why not `0`?**  Index `0` is a valid start position.  Using `0` as a
+> "done" sentinel would force callers to special-case the first page and would
+> cause an infinite loop if naively re-submitted.  Using `total` is
+> unambiguous: it is always one past the last valid index.
+
+---
+
+## Clamping rules (no panic on adversarial input)
+
+| Input condition | Behaviour |
+|-----------------|-----------|
+| `limit == 0` | Promoted to `DEFAULT_AUDIT_PAGE_LIMIT` (20) |
+| `limit > MAX_AUDIT_PAGE_LIMIT` (50) | Clamped to `MAX_AUDIT_PAGE_LIMIT` |
+| `from_index >= total` | Returns empty page; `next_cursor = total` |
+| `from_index == u32::MAX` | Handled by the `>= total` check; no overflow |
+
+---
+
+## Iteration example (off-chain pseudo-code)
+
+```typescript
+let cursor = 0;
+loop {
+    const page = await contract.get_access_audit_page(caller, cursor, 20);
+    process(page.items);
+    if (page.count === 0 || page.next_cursor >= knownTotal) break;
+    cursor = page.next_cursor;
+}
+```
+
+Because `next_cursor` is always `i` after the last consumed entry, and `i`
+equals `total` when the log is exhausted, the loop terminates without
+skipping or duplicating entries even if new entries are appended between calls.
+
+---
+
+## Constants
+
+| Constant | Value | Purpose |
+|----------|-------|---------|
+| `MAX_ACCESS_AUDIT_ENTRIES` | 200 | Rolling cap on stored entries |
+| `MAX_AUDIT_PAGE_LIMIT` | 50 | Maximum entries per page |
+| `DEFAULT_AUDIT_PAGE_LIMIT` | 20 | Page size when `limit == 0` |
+
+---
+
+## Access control
+
+`get_access_audit_page` requires the caller to hold at least the `Admin` role
+(Owner or Admin).  Regular `Member` addresses are rejected.
+
+`get_access_audit` (the simpler tail-read variant) has no role check and
+returns the last `min(limit, log_length)` entries.
+
+---
+
+## Test coverage
+
+Tests live in `family_wallet/src/test.rs` under the
+`// Access-Audit Pagination Tests` section:
+
+| Test | What it verifies |
+|------|-----------------|
+| `test_audit_page_empty_log_returns_sentinel` | Empty log → `count=0`, `next_cursor=0` (sentinel) |
+| `test_audit_page_offset_beyond_length_returns_sentinel` | `from_index=100` on 3-entry log → empty page, `next_cursor=3` |
+| `test_audit_page_offset_u32_max_no_panic` | `from_index=u32::MAX` → no panic, correct sentinel |
+| `test_audit_page_limit_zero_uses_default` | `limit=0` → `DEFAULT_AUDIT_PAGE_LIMIT` entries returned |
+| `test_audit_page_oversized_limit_clamped_to_max` | `limit=u32::MAX` → clamped to `MAX_AUDIT_PAGE_LIMIT` |
+| `test_audit_page_limit_larger_than_remaining_returns_tail` | Partial last page returns only remaining entries |
+| `test_audit_page_exact_boundary_last_entry` | Reading the very last entry yields correct sentinel |
+| `test_audit_page_single_entry_log` | Single-entry log; second call with returned cursor is empty |
+| `test_audit_page_full_iteration_no_skip_no_duplicate` | Full iteration collects every entry exactly once |
+| `test_audit_page_cursor_stable_across_calls` | Same cursor returns identical results on repeated calls |

--- a/family_wallet/src/lib.rs
+++ b/family_wallet/src/lib.rs
@@ -2039,6 +2039,25 @@ impl FamilyWallet {
 
     // Owner/Admin only: audit data is privacy-sensitive — reveals who accessed
     // what and when, so Members are excluded from reading the full trail.
+    //
+    // ## Pagination cursor semantics
+    //
+    // `from_index` is the **inclusive** zero-based index of the first entry to
+    // return.  `next_cursor` in the returned page is the index to pass as
+    // `from_index` on the next call.
+    //
+    // **Sentinel value:** when `next_cursor == total` (i.e. equals the length
+    // of the log at the time of the call) there are no more entries.  Callers
+    // MUST stop iterating when `next_cursor >= count` returned by a previous
+    // page, or when the returned page is empty.
+    //
+    // **Clamping rules (no panic on adversarial input):**
+    // - `limit == 0`            → silently promoted to `DEFAULT_AUDIT_PAGE_LIMIT`.
+    // - `limit > MAX_AUDIT_PAGE_LIMIT` → clamped to `MAX_AUDIT_PAGE_LIMIT`.
+    // - `from_index >= total`   → returns an empty page with
+    //                             `next_cursor = total` (end-of-log sentinel).
+    // - `from_index = u32::MAX` → handled by the `>= total` check above; no
+    //                             arithmetic overflow is possible.
     pub fn get_access_audit_page(
         env: Env,
         caller: Address,
@@ -2054,13 +2073,27 @@ impl FamilyWallet {
             .get(&symbol_short!("ACC_AUDIT"))
             .unwrap_or_else(|| Vec::new(&env));
 
+        // Clamp limit: 0 → default, oversized → max.
         let capped_limit = if limit == 0 {
             DEFAULT_AUDIT_PAGE_LIMIT
         } else {
             limit.min(MAX_AUDIT_PAGE_LIMIT)
         };
+
         let total = entries.len();
+
+        // Out-of-range offset: return empty page with end-of-log sentinel so
+        // callers can detect exhaustion without a separate length query.
+        if from_index >= total {
+            return AccessAuditPage {
+                items: Vec::new(&env),
+                next_cursor: total, // sentinel: no more entries
+                count: 0,
+            };
+        }
+
         let mut items = Vec::new(&env);
+        // `i` is bounded by `total` (u32), so no overflow risk.
         let mut i = from_index;
         while i < total && items.len() < capped_limit {
             if let Some(e) = entries.get(i) {
@@ -2069,7 +2102,9 @@ impl FamilyWallet {
             i += 1;
         }
         let count = items.len();
-        let next_cursor = if i < total { i } else { 0 };
+        // `next_cursor == total` is the end-of-log sentinel.
+        // Callers iterate while `next_cursor < total` (or while `count > 0`).
+        let next_cursor = i; // equals `total` when the log is exhausted
         AccessAuditPage {
             items,
             next_cursor,

--- a/family_wallet/src/test.rs
+++ b/family_wallet/src/test.rs
@@ -3037,3 +3037,228 @@ fn test_set_proposal_expiry_validation() {
     let result = client.try_set_proposal_expiry(&owner, &0);
     assert!(result.is_err());
 }
+
+// ============================================================================
+// Access-Audit Pagination Tests
+//
+// Covers cursor semantics, clamping, and edge cases for get_access_audit_page.
+// The end-of-log sentinel is `next_cursor == total` (length of the log).
+// ============================================================================
+
+/// Helper: seed `n` audit entries by toggling emergency mode on/off.
+fn seed_audit_entries(client: &FamilyWalletClient, owner: &Address, n: u32) {
+    for i in 0..n {
+        client.set_emergency_mode(owner, &(i % 2 == 0));
+    }
+}
+
+#[test]
+fn test_audit_page_empty_log_returns_sentinel() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, FamilyWallet);
+    let client = FamilyWalletClient::new(&env, &contract_id);
+    let owner = Address::generate(&env);
+    client.init(&owner, &vec![&env]);
+
+    // No audit entries have been written yet.
+    let page = client.get_access_audit_page(&owner, &0, &10);
+    assert_eq!(page.count, 0);
+    assert_eq!(page.items.len(), 0);
+    // next_cursor == total (0) — end-of-log sentinel.
+    assert_eq!(page.next_cursor, 0);
+}
+
+#[test]
+fn test_audit_page_offset_beyond_length_returns_sentinel() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, FamilyWallet);
+    let client = FamilyWalletClient::new(&env, &contract_id);
+    let owner = Address::generate(&env);
+    client.init(&owner, &vec![&env]);
+
+    seed_audit_entries(&client, &owner, 3);
+
+    // from_index = 100 is way beyond the 3-entry log.
+    let page = client.get_access_audit_page(&owner, &100, &10);
+    assert_eq!(page.count, 0);
+    assert_eq!(page.items.len(), 0);
+    // Sentinel must equal total (3), not 0.
+    assert_eq!(page.next_cursor, 3);
+}
+
+#[test]
+fn test_audit_page_offset_u32_max_no_panic() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, FamilyWallet);
+    let client = FamilyWalletClient::new(&env, &contract_id);
+    let owner = Address::generate(&env);
+    client.init(&owner, &vec![&env]);
+
+    seed_audit_entries(&client, &owner, 5);
+
+    // Adversarial: u32::MAX offset must not panic or overflow.
+    let page = client.get_access_audit_page(&owner, &u32::MAX, &10);
+    assert_eq!(page.count, 0);
+    assert_eq!(page.items.len(), 0);
+    // Sentinel == total (5).
+    assert_eq!(page.next_cursor, 5);
+}
+
+#[test]
+fn test_audit_page_limit_zero_uses_default() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, FamilyWallet);
+    let client = FamilyWalletClient::new(&env, &contract_id);
+    let owner = Address::generate(&env);
+    client.init(&owner, &vec![&env]);
+
+    // Seed more entries than DEFAULT_AUDIT_PAGE_LIMIT (20).
+    seed_audit_entries(&client, &owner, 25);
+
+    // limit=0 should be promoted to DEFAULT_AUDIT_PAGE_LIMIT (20).
+    let page = client.get_access_audit_page(&owner, &0, &0);
+    assert_eq!(page.count, DEFAULT_AUDIT_PAGE_LIMIT);
+    assert_eq!(page.items.len(), DEFAULT_AUDIT_PAGE_LIMIT);
+    assert_eq!(page.next_cursor, DEFAULT_AUDIT_PAGE_LIMIT);
+}
+
+#[test]
+fn test_audit_page_oversized_limit_clamped_to_max() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, FamilyWallet);
+    let client = FamilyWalletClient::new(&env, &contract_id);
+    let owner = Address::generate(&env);
+    client.init(&owner, &vec![&env]);
+
+    // Seed more entries than MAX_AUDIT_PAGE_LIMIT (50).
+    seed_audit_entries(&client, &owner, 60);
+
+    // limit=u32::MAX should be clamped to MAX_AUDIT_PAGE_LIMIT (50).
+    let page = client.get_access_audit_page(&owner, &0, &u32::MAX);
+    assert_eq!(page.count, MAX_AUDIT_PAGE_LIMIT);
+    assert_eq!(page.items.len(), MAX_AUDIT_PAGE_LIMIT);
+    assert_eq!(page.next_cursor, MAX_AUDIT_PAGE_LIMIT);
+}
+
+#[test]
+fn test_audit_page_limit_larger_than_remaining_returns_tail() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, FamilyWallet);
+    let client = FamilyWalletClient::new(&env, &contract_id);
+    let owner = Address::generate(&env);
+    client.init(&owner, &vec![&env]);
+
+    seed_audit_entries(&client, &owner, 5);
+
+    // Ask for 20 entries starting at index 3 — only 2 remain.
+    let page = client.get_access_audit_page(&owner, &3, &20);
+    assert_eq!(page.count, 2);
+    assert_eq!(page.items.len(), 2);
+    // next_cursor == total (5) — end-of-log sentinel.
+    assert_eq!(page.next_cursor, 5);
+}
+
+#[test]
+fn test_audit_page_exact_boundary_last_entry() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, FamilyWallet);
+    let client = FamilyWalletClient::new(&env, &contract_id);
+    let owner = Address::generate(&env);
+    client.init(&owner, &vec![&env]);
+
+    seed_audit_entries(&client, &owner, 4);
+
+    // from_index = 3 (last valid index), limit = 1 → exactly one entry.
+    let page = client.get_access_audit_page(&owner, &3, &1);
+    assert_eq!(page.count, 1);
+    assert_eq!(page.items.len(), 1);
+    // After reading the last entry, next_cursor == total (4).
+    assert_eq!(page.next_cursor, 4);
+}
+
+#[test]
+fn test_audit_page_single_entry_log() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, FamilyWallet);
+    let client = FamilyWalletClient::new(&env, &contract_id);
+    let owner = Address::generate(&env);
+    client.init(&owner, &vec![&env]);
+
+    // One entry.
+    client.set_emergency_mode(&owner, &true);
+
+    let page = client.get_access_audit_page(&owner, &0, &10);
+    assert_eq!(page.count, 1);
+    assert_eq!(page.items.len(), 1);
+    // Exhausted: next_cursor == total (1).
+    assert_eq!(page.next_cursor, 1);
+
+    // Requesting the next page with the returned cursor yields empty + sentinel.
+    let page2 = client.get_access_audit_page(&owner, &page.next_cursor, &10);
+    assert_eq!(page2.count, 0);
+    assert_eq!(page2.next_cursor, 1); // still == total
+}
+
+#[test]
+fn test_audit_page_full_iteration_no_skip_no_duplicate() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, FamilyWallet);
+    let client = FamilyWalletClient::new(&env, &contract_id);
+    let owner = Address::generate(&env);
+    client.init(&owner, &vec![&env]);
+
+    let total_entries: u32 = 7;
+    seed_audit_entries(&client, &owner, total_entries);
+
+    // Iterate with page size 3 and collect all entries.
+    let mut collected: u32 = 0;
+    let mut cursor: u32 = 0;
+    let page_size: u32 = 3;
+
+    loop {
+        let page = client.get_access_audit_page(&owner, &cursor, &page_size);
+        collected += page.count;
+        if page.count == 0 || page.next_cursor >= total_entries {
+            break;
+        }
+        cursor = page.next_cursor;
+    }
+
+    // Every entry visited exactly once.
+    assert_eq!(collected, total_entries);
+}
+
+#[test]
+fn test_audit_page_cursor_stable_across_calls() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, FamilyWallet);
+    let client = FamilyWalletClient::new(&env, &contract_id);
+    let owner = Address::generate(&env);
+    client.init(&owner, &vec![&env]);
+
+    seed_audit_entries(&client, &owner, 6);
+
+    // Two calls with the same cursor must return identical results.
+    let page_a = client.get_access_audit_page(&owner, &2, &3);
+    let page_b = client.get_access_audit_page(&owner, &2, &3);
+
+    assert_eq!(page_a.count, page_b.count);
+    assert_eq!(page_a.next_cursor, page_b.next_cursor);
+    for idx in 0..page_a.count {
+        let a = page_a.items.get(idx).unwrap();
+        let b = page_b.items.get(idx).unwrap();
+        assert_eq!(a.operation, b.operation);
+        assert_eq!(a.caller, b.caller);
+        assert_eq!(a.timestamp, b.timestamp);
+    }
+}


### PR DESCRIPTION
Closes #641 

- Fix next_cursor sentinel: use total (log length) instead of 0 so
  off-chain consumers can distinguish end-of-log from start-of-log
- Clamp from_index >= total to empty page with sentinel; no panic on
  u32::MAX offset
- Clamp limit=0 to DEFAULT_AUDIT_PAGE_LIMIT; oversized limit to MAX
- Add 10 edge-case tests: empty log, out-of-range offset, u32::MAX,
  limit=0, oversized limit, partial tail, exact boundary, single entry,
  full iteration (no skip/duplicate), cursor stability
- Add docs/fw-access-audit-pagination.md describing cursor contract
