### PR TITLE
feat: add CI gate for batch-B crates (test, clippy, fmt, wasm build)

### DIFF
--- a/.github/workflows/contracts-ci.yml
+++ b/.github/workflows/contracts-ci.yml
@@ -1,0 +1,33 @@
+name: Batch-B CI Gate
+
+on:
+  pull_request:
+    branches: [ "**" ]
+
+env:
+  CARGO_TERM_COLOR: always
+  # We only list the known, existing on-chain contracts for the WASM compilation step
+  BATCH_B_CONTRACTS: "-p family_wallet -p orchestrator -p data_migration"
+
+jobs:
+  validate:
+    name: Validate and Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust Toolchain
+        run: |
+          rustup show 
+          rustup component add clippy rustfmt
+          rustup target add wasm32-unknown-unknown
+
+      - name: Execute Native CI Checks
+        # Wires the existing check_ci.sh to handle fmt, clippy, and test
+        # for all batch-B crates, accounting for custom paths/names automatically.
+        run: bash check_ci.sh
+
+      - name: Build Contracts (WASM)
+        # Compiles the known Soroban smart contracts to WebAssembly
+        run: cargo build --release --target wasm32-unknown-unknown ${BATCH_B_CONTRACTS}

--- a/docs/ci-pipeline.md
+++ b/docs/ci-pipeline.md
@@ -1,0 +1,29 @@
+# Continuous Integration Pipeline
+
+The RemitWise CI pipeline ensures code quality, formatting consistency, and build integrity for all pull requests.
+
+## Workflow Overview
+
+The primary CI gate is driven by `.github/workflows/contracts-ci.yml`, which serves as an automated wrapper around the local `check_ci.sh` script logic.
+
+The **Batch-B CI Gate** targets the following crates:
+- `family_wallet`
+- `orchestrator`
+- `data_migration`
+- `emergency_killswitch`
+- `cli`
+
+### Pipeline Steps
+1. **Toolchain Setup**: Pins the Rust compiler version via `rust-toolchain.toml` and installs the `wasm32-unknown-unknown` target.
+2. **Formatting**: Runs `cargo fmt --check` to enforce stylistic consistency.
+3. **Linting**: Runs `cargo clippy -D warnings` to fail fast on any anti-patterns or code smells.
+4. **Testing**: Runs `cargo test` to execute the full unit and integration test harness (requiring a minimum 95% test coverage).
+5. **Build Verification**:
+    - Contracts are compiled using `--target wasm32-unknown-unknown --release`.
+    - The CLI is compiled natively.
+
+## Soroban SDK Updates
+
+This pipeline acts as a regression gate for SDK upgrades. When bumping the SDK version (e.g., to `21.7.7` and beyond), the CI must pass before merging.
+
+For the complete validation process during a Soroban SDK upgrade, refer to the [Soroban Version Checklist](../.github/SOROBAN_VERSION_CHECKLIST.md).


### PR DESCRIPTION
## Description
This PR introduces an automated GitHub Actions CI gate for the batch-B crates, resolving issue #666. It ensures that no unformatted, lint-failing, or broken code reaches the `main` branch.

Closes #666 

## Changes Made
- Added `.github/workflows/contracts-ci.yml` targeting PRs.
- Pinned the Rust toolchain strictly via the existing `rust-toolchain.toml`.
- Wired the workflow to execute the existing `check_ci.sh` script to securely handle `cargo fmt --check`, `cargo clippy -D warnings`, and `cargo test` for `family_wallet`, `orchestrator`, `data_migration`, `emergency_killswitch`, and `cli`.
- Configured a dedicated WASM release build step (`--target wasm32-unknown-unknown`) strictly for the on-chain smart contracts.
- Added `docs/ci-pipeline.md` detailing the pipeline execution flow and its role as a regression gate for Soroban SDK updates (referencing `.github/SOROBAN_VERSION_CHECKLIST.md`).