### PR TITLE
feat: Add contracttype round-trip tests, shared TTL helpers, role expiry docs, and indexer event processors

### DIFF
--- a/STORAGE_LAYOUT.md
+++ b/STORAGE_LAYOUT.md
@@ -19,11 +19,12 @@ All storage keys follow strict naming conventions to ensure consistency and comp
 
 - **Maximum length:** 9 characters (enforced by `symbol_short!`)
 - **Format:** UPPERCASE_WITH_UNDERSCORES
-- **Valid characters:** A-Z, 0-9, _ (underscore)
+- **Valid characters:** A-Z, 0-9, \_ (underscore)
 
 These conventions are automatically validated in CI. See [Storage Key Naming Conventions](docs/storage-key-naming-conventions.md) for detailed guidelines and [testutils/tests/README.md](testutils/tests/README.md) for information about the automated validation tests.
 
 **Run validation tests:**
+
 ```bash
 cargo test --package testutils storage_key_naming_test -- --nocapture
 ```
@@ -45,6 +46,18 @@ cargo test --package testutils storage_key_naming_test -- --nocapture
   - `ARCHIVE_BUMP_AMOUNT = 2592000` (~180 days)
 - Important implementation detail:
   - Archive bump helpers still call `instance().extend_ttl(...)`; they extend the contract instance entry TTL, not a separate archive namespace.
+
+### Shared TTL-bump helpers (remitwise-common)
+
+`remitwise-common` exports three helpers that centralise the canonical TTL policy:
+
+| Helper                      | Threshold                                 | Bump                               | Purpose                    |
+| --------------------------- | ----------------------------------------- | ---------------------------------- | -------------------------- |
+| `bump_instance(env)`        | `INSTANCE_LIFETIME_THRESHOLD` (1 day)     | `INSTANCE_BUMP_AMOUNT` (30 days)   | Active instance data       |
+| `bump_persistent(env, key)` | `PERSISTENT_LIFETIME_THRESHOLD` (15 days) | `PERSISTENT_BUMP_AMOUNT` (60 days) | Persistent storage entries |
+| `bump_archive(env)`         | `ARCHIVE_LIFETIME_THRESHOLD` (1 day)      | `ARCHIVE_BUMP_AMOUNT` (150 days)   | Archive instance window    |
+
+Using these helpers prevents the common mistake of swapping `threshold` and `bump` arguments. See [docs/ttl-bump-helpers.md](docs/ttl-bump-helpers.md) for usage guidance.
 
 ### ID allocation patterns
 
@@ -95,7 +108,6 @@ cargo test --package testutils storage_key_naming_test -- --nocapture
 | `UNP_AT`    | `u64`                       | Optional time-locked unpause timestamp |
 | `UPG_ADM`   | `Address`                   | Upgrade admin                          |
 | `VERSION`   | `u32`                       | Contract version                       |
-
 
 | Key       | Type                    | Notes                           |
 | --------- | ----------------------- | ------------------------------- |

--- a/docs/fw-role-expiry.md
+++ b/docs/fw-role-expiry.md
@@ -1,0 +1,111 @@
+# Family Wallet: Role Expiry Semantics
+
+## Overview
+
+`family_wallet` supports optional per-member role expiry. When a role expires, the member loses all privileges associated with that role and is treated as if they no longer hold it — even though their membership record still exists.
+
+## Setting Role Expiry
+
+```rust
+pub fn set_role_expiry(
+    env: Env,
+    caller: Address,    // Must be Owner or Admin (non-expired)
+    member: Address,    // Target family member (must exist)
+    expires_at: Option<u64>,  // Unix timestamp in seconds; None clears expiry
+) -> bool
+```
+
+- Only an Owner or Admin with a **non-expired** role may call this.
+- `member` must already be in the `MEMBERS` map; non-members are rejected with `"Member not found"`.
+- `Some(t)` sets the expiry; `None` clears it (role becomes permanent again).
+- The operation is recorded in `ACC_AUDIT` with operation `role_exp`.
+
+## Expiry Boundary
+
+The expiry is **inclusive**: a member is considered expired when:
+
+```
+ledger.timestamp() >= expires_at
+```
+
+At `expires_at - 1` the role is still active. At `expires_at` it is expired.
+
+## Storage
+
+Expiry timestamps are stored in `ROLE_EXP` (`Map<Address, u64>`) in instance storage. Members without an entry in this map have no expiry (their role is permanent).
+
+## Enforcement Points
+
+Role expiry is checked at every privileged operation via two internal helpers:
+
+### `require_role_at_least(env, caller, min_role)`
+
+Called by all privileged public functions. Panics with:
+
+- `"Role has expired"` if the caller's role has expired
+- `"Insufficient role"` if the caller's role is below the required minimum
+- `"Not a family member"` if the caller is not in `MEMBERS`
+
+### `is_owner_or_admin_in_members(env, members, address)`
+
+Returns `false` if the member's role has expired, even if they hold Owner or Admin role. Used by `configure_multisig`, `archive_old_transactions`, `cleanup_expired_pending`, and other admin-gated operations.
+
+## Affected Operations
+
+The following operations reject an expired role:
+
+| Operation                     | Required role            | Enforcement path               |
+| ----------------------------- | ------------------------ | ------------------------------ |
+| `propose_transaction`         | Member                   | `require_role_at_least`        |
+| `sign_transaction`            | Member                   | `require_role_at_least`        |
+| `configure_multisig`          | Admin                    | `is_owner_or_admin_in_members` |
+| `configure_emergency`         | Admin                    | `is_owner_or_admin_in_members` |
+| `set_emergency_mode`          | Admin                    | `is_owner_or_admin_in_members` |
+| `pause` / `unpause`           | Pause admin (role check) | `require_role_at_least`        |
+| `archive_old_transactions`    | Admin                    | `is_owner_or_admin_in_members` |
+| `cleanup_expired_pending`     | Admin                    | `is_owner_or_admin_in_members` |
+| `batch_add_family_members`    | Admin                    | `is_owner_or_admin_in_members` |
+| `batch_remove_family_members` | Owner                    | `is_owner_or_admin_in_members` |
+| `set_proposal_expiry`         | Owner                    | `require_role_at_least`        |
+| `set_upgrade_admin`           | Owner                    | `require_role_at_least`        |
+| `set_version`                 | Upgrade admin            | `require_role_at_least`        |
+| `set_role_expiry`             | Admin                    | `require_role_at_least`        |
+
+## Renewal
+
+An expired admin **cannot renew their own expiry** — `set_role_expiry` calls `require_role_at_least(Admin)` which will panic with `"Role has expired"`. Only a non-expired Owner or Admin can renew another member's expiry.
+
+## Tests
+
+Role expiry tests are in `family_wallet/src/test.rs`:
+
+- `test_role_expiry_boundary_allows_before_expiry` — active at `expires_at - 1`
+- `test_role_expiry_boundary_revokes_at_expiry_timestamp` — expired at `expires_at`
+- `test_role_expiry_renewal_restores_permissions` — renewal by Owner restores access
+- `test_role_expiry_unauthorized_member_cannot_renew` — regular members cannot set expiry
+- `test_role_expiry_expired_admin_cannot_renew_self` — expired admin cannot self-renew
+- `test_role_expiry_cannot_be_set_for_non_member` — non-members rejected
+- `test_expired_admin_cannot_pause` / `test_expired_admin_cannot_unpause`
+- `test_expired_admin_cannot_archive_transactions`
+- `test_expired_admin_cannot_cleanup_expired_pending`
+- `test_expired_admin_cannot_configure_multisig`
+- `test_expired_admin_cannot_configure_emergency`
+- `test_expired_admin_cannot_set_emergency_mode`
+- `test_expired_admin_cannot_batch_add_members`
+- `test_expired_owner_cannot_batch_remove_members`
+- `test_expired_owner_cannot_set_proposal_expiry`
+- `test_expired_owner_cannot_set_upgrade_admin`
+- `test_expired_owner_cannot_set_version`
+- `test_non_expired_admin_can_perform_privileged_operations`
+
+## Security Notes
+
+- Role expiry does **not** remove the member from `MEMBERS`. The member record persists; only their privilege level is revoked.
+- Expiry is evaluated against `ledger.timestamp()` (ledger seconds), not wall-clock time. Ledger timestamps are set by validators and cannot be manipulated by contract callers.
+- An expired Owner can still be renewed by another Owner (if one exists). If the only Owner's role expires, the wallet is effectively locked until the expiry is cleared via a governance process.
+
+## References
+
+- `family_wallet/src/lib.rs` — `set_role_expiry`, `role_has_expired`, `require_role_at_least`, `is_owner_or_admin_in_members`
+- `family_wallet/src/test.rs` — role expiry test suite
+- `STORAGE_LAYOUT.md` — `ROLE_EXP` key documentation

--- a/docs/shared-type-stability.md
+++ b/docs/shared-type-stability.md
@@ -1,0 +1,54 @@
+# Shared-Type Stability Guarantee
+
+## Overview
+
+`remitwise-common` defines three `#[contracttype] #[repr(u32)]` enums that are shared across all Remitwise contracts:
+
+| Type           | Variants                                            | Used in                                                                    |
+| -------------- | --------------------------------------------------- | -------------------------------------------------------------------------- |
+| `Category`     | `Spending=1, Savings=2, Bills=3, Insurance=4`       | remittance_split split percentages, reporting                              |
+| `CoverageType` | `Health=1, Life=2, Property=3, Auto=4, Liability=5` | insurance `PolicyCreatedEvent.coverage_type`, policy storage               |
+| `FamilyRole`   | `Owner=1, Admin=2, Member=3, Viewer=4`              | family_wallet member records, multisig proposals, role-change transactions |
+
+## Why Stability Matters
+
+These types are written to Soroban **persistent/instance storage** and emitted in **event payloads** (e.g. `PolicyCreatedEvent.coverage_type`). Because Soroban encodes `#[contracttype]` enums by their discriminant value, any renumbering silently corrupts:
+
+- Data already stored on-chain (reads back as the wrong variant)
+- Cross-contract calls that pass these types as arguments
+- Off-chain indexer rows that decode event payloads
+
+## Stability Guarantee
+
+The discriminant values are **pinned** by two independent test layers in `remitwise-common/src/lib.rs`:
+
+1. **Discriminant tests** (`category_discriminants`, `coverage_type_discriminants`, `family_role_discriminants`) — assert the raw `as u32` value of every variant.
+
+2. **Round-trip tests** (`*_roundtrip`, `*_all_variants_roundtrip`, `*_roundtrip_preserves_discriminant`) — encode each variant through `IntoVal<Env, Val>` and decode it back with `TryFromVal<Env, Val>`, asserting the decoded value equals the original and that the discriminant is unchanged.
+
+Both layers must pass in CI before any change to these types can be merged.
+
+## Adding a New Variant
+
+If you need to add a new variant:
+
+1. **Append only** — assign the next sequential discriminant (e.g. `Category::Investment = 5`). Never reuse or reorder existing values.
+2. Update the discriminant test to include the new variant.
+3. Add a round-trip test for the new variant.
+4. Update any off-chain indexer code that switches on the enum value.
+5. Document the addition in `CHANGELOG_CONTRACTS.md`.
+
+## Removing or Renaming a Variant
+
+Removing or renaming a variant is a **breaking change**. It requires:
+
+1. A contract migration path for any on-chain data that stores the old variant.
+2. A version bump in `CONTRACT_VERSION`.
+3. Coordination with all indexer consumers.
+
+## References
+
+- `remitwise-common/src/lib.rs` — enum definitions and tests
+- `insurance/src/lib.rs` — `CoverageType` usage in `PolicyCreatedEvent`
+- `family_wallet/src/lib.rs` — `FamilyRole` usage in `FamilyMember` and `TransactionData::RoleChange`
+- `remittance_split/src/lib.rs` — `Category` usage in split configuration

--- a/docs/ttl-bump-helpers.md
+++ b/docs/ttl-bump-helpers.md
@@ -1,0 +1,89 @@
+# Shared TTL-Bump Helpers
+
+## Overview
+
+`remitwise-common` provides three helper functions that centralise the canonical TTL extension policy for all contracts. Using these helpers instead of calling `extend_ttl` directly prevents the common mistake of swapping the `threshold` and `bump` arguments.
+
+## Helpers
+
+```rust
+/// Extend the instance storage entry TTL (active data).
+pub fn bump_instance(env: &Env)
+
+/// Extend a persistent storage entry TTL.
+pub fn bump_persistent<K: IntoVal<Env, Val>>(env: &Env, key: &K)
+
+/// Extend the instance storage entry TTL using the archive window.
+pub fn bump_archive(env: &Env)
+```
+
+## Constants Used
+
+| Helper            | Threshold constant                        | Bump constant                      | Effective window                      |
+| ----------------- | ----------------------------------------- | ---------------------------------- | ------------------------------------- |
+| `bump_instance`   | `INSTANCE_LIFETIME_THRESHOLD` = 1 day     | `INSTANCE_BUMP_AMOUNT` = 30 days   | Extends to 30 days when TTL ≤ 1 day   |
+| `bump_persistent` | `PERSISTENT_LIFETIME_THRESHOLD` = 15 days | `PERSISTENT_BUMP_AMOUNT` = 60 days | Extends to 60 days when TTL ≤ 15 days |
+| `bump_archive`    | `ARCHIVE_LIFETIME_THRESHOLD` = 1 day      | `ARCHIVE_BUMP_AMOUNT` = 150 days   | Extends to 150 days when TTL ≤ 1 day  |
+
+The invariant `threshold < bump` is asserted by constant tests in `remitwise-common/src/lib.rs` and by the helper unit tests.
+
+## Usage
+
+Import the helpers from `remitwise-common`:
+
+```rust
+use remitwise_common::{bump_instance, bump_archive, bump_persistent};
+```
+
+Call `bump_instance` on every state-changing operation:
+
+```rust
+pub fn my_mutating_fn(env: Env, ...) {
+    // ... auth checks ...
+    bump_instance(&env);   // keep instance alive for 30 days
+    // ... write storage ...
+}
+```
+
+Call `bump_archive` after writing to an archive map:
+
+```rust
+pub fn archive_old_transactions(env: Env, ...) {
+    bump_instance(&env);   // active window
+    // ... move rows to ARCH_TX ...
+    bump_archive(&env);    // extend to 150-day archive window
+}
+```
+
+Call `bump_persistent` when writing to a persistent storage key:
+
+```rust
+pub fn write_persistent_data(env: Env, key: &DataKey, value: &MyType) {
+    env.storage().persistent().set(key, value);
+    bump_persistent(&env, key);
+}
+```
+
+## Why Not Inline `extend_ttl`?
+
+Each contract previously called `extend_ttl` directly with its own local constants. This created two risks:
+
+1. **Argument swap** — `extend_ttl(bump, threshold)` instead of `extend_ttl(threshold, bump)` silently sets a very short TTL (threshold) as the target, causing data to expire almost immediately.
+2. **Drift** — local constants could diverge from the canonical values in `remitwise-common`, making the effective TTL policy inconsistent across contracts.
+
+The helpers eliminate both risks by being the single source of truth.
+
+## Tests
+
+The helpers are tested in `remitwise-common/src/lib.rs`:
+
+- `bump_instance_extends_instance_ttl` — verifies TTL ≥ `INSTANCE_BUMP_AMOUNT` after call
+- `bump_archive_extends_instance_ttl_to_archive_amount` — verifies TTL ≥ `ARCHIVE_BUMP_AMOUNT` after call
+- `bump_instance_threshold_less_than_bump_invariant` — constant ordering check
+- `bump_persistent_threshold_less_than_bump_invariant` — constant ordering check
+- `bump_archive_threshold_less_than_bump_invariant` — constant ordering check
+
+## References
+
+- `remitwise-common/src/lib.rs` — helper implementations and tests
+- `STORAGE_LAYOUT.md` — per-contract TTL strategy

--- a/family_wallet/src/test.rs
+++ b/family_wallet/src/test.rs
@@ -948,20 +948,20 @@ fn test_add_member_already_exists() {
     client.init(&owner, &initial_members);
 
     // Try to add member1 again (they already exist from initialization)
-    let result = client.try_add_family_member(&owner, &member1, &FamilyRole::Admin);
+    let result = client.try_add_member(&owner, &member1, &FamilyRole::Admin, &0);
     assert_eq!(result, Err(Ok(Error::MemberAlreadyExists)));
 
     // Try to add owner (they already exist and are the owner)
-    let result = client.try_add_family_member(&owner, &owner, &FamilyRole::Admin);
+    let result = client.try_add_member(&owner, &owner, &FamilyRole::Admin, &0);
     assert_eq!(result, Err(Ok(Error::MemberAlreadyExists)));
 
     // Add a new member successfully
     let new_member = Address::generate(&env);
-    let result = client.try_add_family_member(&owner, &new_member, &FamilyRole::Member);
+    let result = client.try_add_member(&owner, &new_member, &FamilyRole::Member, &0);
     assert!(result.is_ok());
 
     // Try to add the same new member again
-    let result = client.try_add_family_member(&owner, &new_member, &FamilyRole::Admin);
+    let result = client.try_add_member(&owner, &new_member, &FamilyRole::Admin, &0);
     assert_eq!(result, Err(Ok(Error::MemberAlreadyExists)));
 }
 

--- a/indexer/src/db/schema.ts
+++ b/indexer/src/db/schema.ts
@@ -5,16 +5,16 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import Database from 'better-sqlite3';
+import Database from "better-sqlite3";
 
 export function initializeDatabase(dbPath: string): Database.Database {
   const db = new Database(dbPath);
-  
+
   // Enable WAL mode for better concurrency
-  db.pragma('journal_mode = WAL');
-  
+  db.pragma("journal_mode = WAL");
+
   createTables(db);
-  
+
   return db;
 }
 
@@ -122,5 +122,68 @@ function createTables(db: Database.Database): void {
     );
   `);
 
-  console.log('Database schema initialized');
+  // Family Wallet events table
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS family_wallet_events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      event_type TEXT NOT NULL,
+      contract_address TEXT NOT NULL,
+      member TEXT,
+      role TEXT,
+      spending_limit TEXT,
+      limit_amount TEXT,
+      tx_id TEXT,
+      proposer TEXT,
+      recipient TEXT,
+      amount TEXT,
+      timestamp INTEGER NOT NULL,
+      ledger INTEGER NOT NULL,
+      tx_hash TEXT NOT NULL,
+      raw_data TEXT NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS idx_fw_events_type ON family_wallet_events(event_type);
+    CREATE INDEX IF NOT EXISTS idx_fw_events_member ON family_wallet_events(member);
+    CREATE INDEX IF NOT EXISTS idx_fw_events_timestamp ON family_wallet_events(timestamp);
+  `);
+
+  // Orchestrator flow events table
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS orchestrator_events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      event_type TEXT NOT NULL,
+      contract_address TEXT NOT NULL,
+      executor TEXT,
+      amount TEXT,
+      error_code INTEGER,
+      timestamp INTEGER NOT NULL,
+      ledger INTEGER NOT NULL,
+      tx_hash TEXT NOT NULL,
+      raw_data TEXT NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS idx_orch_events_type ON orchestrator_events(event_type);
+    CREATE INDEX IF NOT EXISTS idx_orch_events_executor ON orchestrator_events(executor);
+    CREATE INDEX IF NOT EXISTS idx_orch_events_timestamp ON orchestrator_events(timestamp);
+  `);
+
+  // Emergency Killswitch events table — drives alerting hooks
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS killswitch_events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      event_type TEXT NOT NULL,
+      contract_address TEXT NOT NULL,
+      scope TEXT,
+      module_id TEXT,
+      func_name TEXT,
+      timestamp INTEGER NOT NULL,
+      ledger INTEGER NOT NULL,
+      tx_hash TEXT NOT NULL,
+      raw_data TEXT NOT NULL,
+      alert_sent INTEGER NOT NULL DEFAULT 0
+    );
+    CREATE INDEX IF NOT EXISTS idx_ks_events_type ON killswitch_events(event_type);
+    CREATE INDEX IF NOT EXISTS idx_ks_events_timestamp ON killswitch_events(timestamp);
+    CREATE INDEX IF NOT EXISTS idx_ks_events_alert ON killswitch_events(alert_sent);
+  `);
+
+  console.log("Database schema initialized");
 }

--- a/indexer/src/eventProcessor.ts
+++ b/indexer/src/eventProcessor.ts
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import Database from 'better-sqlite3';
-import { xdr } from '@stellar/stellar-sdk';
+import Database from "better-sqlite3";
+import { xdr } from "@stellar/stellar-sdk";
 
 export class EventProcessor {
   constructor(private db: Database.Database) {}
@@ -16,28 +16,42 @@ export class EventProcessor {
     txHash: string,
     contractAddress: string,
     event: any,
-    timestamp: number
+    timestamp: number,
   ): void {
     try {
       const topic = this.parseEventTopic(event);
       const data = this.parseEventData(event);
 
       // Store raw event
-      this.storeRawEvent(ledger, txHash, contractAddress, topic, data, timestamp);
+      this.storeRawEvent(
+        ledger,
+        txHash,
+        contractAddress,
+        topic,
+        data,
+        timestamp,
+      );
 
       // Process specific event types
-      this.processSpecificEvent(contractAddress, topic, data, timestamp);
+      this.processSpecificEvent(
+        contractAddress,
+        topic,
+        data,
+        timestamp,
+        ledger,
+        txHash,
+      );
     } catch (error) {
-      console.error('Error processing event:', error);
+      console.error("Error processing event:", error);
     }
   }
 
   private parseEventTopic(event: any): string {
     // Extract event topic from Soroban event structure
     if (event.topic && Array.isArray(event.topic)) {
-      return event.topic.map((t: any) => this.scValToString(t)).join('::');
+      return event.topic.map((t: any) => this.scValToString(t)).join("::");
     }
-    return 'unknown';
+    return "unknown";
   }
 
   private parseEventData(event: any): any {
@@ -89,13 +103,13 @@ export class EventProcessor {
     contractAddress: string,
     topic: string,
     data: any,
-    timestamp: number
+    timestamp: number,
   ): void {
     const stmt = this.db.prepare(`
       INSERT INTO events (ledger, tx_hash, contract_address, event_type, topic, data, timestamp)
       VALUES (?, ?, ?, ?, ?, ?, ?)
     `);
-    
+
     stmt.run(
       ledger,
       txHash,
@@ -103,55 +117,154 @@ export class EventProcessor {
       this.extractEventType(topic),
       topic,
       JSON.stringify(data),
-      timestamp
+      timestamp,
     );
   }
 
   private extractEventType(topic: string): string {
     // Extract event type from topic
-    const parts = topic.split('::');
-    return parts[parts.length - 1] || 'unknown';
+    const parts = topic.split("::");
+    return parts[parts.length - 1] || "unknown";
   }
 
   private processSpecificEvent(
     contractAddress: string,
     topic: string,
     data: any,
-    timestamp: number
+    timestamp: number,
+    ledger: number,
+    txHash: string,
   ): void {
     const eventType = this.extractEventType(topic);
 
     // Process based on event type
     switch (eventType) {
-      case 'goal_created':
+      case "goal_created":
         this.processGoalCreated(data, timestamp);
         break;
-      case 'goal_deposit':
+      case "goal_deposit":
         this.processGoalDeposit(data, timestamp);
         break;
-      case 'goal_withdraw':
+      case "goal_withdraw":
         this.processGoalWithdraw(data, timestamp);
         break;
-      case 'bill_created':
+      case "bill_created":
         this.processBillCreated(data, timestamp);
         break;
-      case 'bill_paid':
+      case "bill_paid":
         this.processBillPaid(data, timestamp);
         break;
-      case 'policy_created':
+      case "policy_created":
         this.processPolicyCreated(data, timestamp);
         break;
-      case 'split_created':
+      case "split_created":
         this.processSplitCreated(data, timestamp);
         break;
-      case 'split_executed':
+      case "split_executed":
         this.processSplitExecuted(data, timestamp);
         break;
-      case 'tags_add':
+      case "tags_add":
         this.processTagsAdded(contractAddress, data, timestamp);
         break;
-      case 'tags_rem':
+      case "tags_rem":
         this.processTagsRemoved(contractAddress, data, timestamp);
+        break;
+      // Family Wallet events
+      case "member":
+        this.processFamilyWalletMember(
+          contractAddress,
+          eventType,
+          data,
+          timestamp,
+          ledger,
+          txHash,
+        );
+        break;
+      case "limit":
+        this.processFamilyWalletLimit(
+          contractAddress,
+          eventType,
+          data,
+          timestamp,
+          ledger,
+          txHash,
+        );
+        break;
+      case "em_prop":
+        this.processFamilyWalletEmProp(
+          contractAddress,
+          eventType,
+          data,
+          timestamp,
+          ledger,
+          txHash,
+        );
+        break;
+      case "archived":
+        this.processFamilyWalletArchived(
+          contractAddress,
+          eventType,
+          data,
+          timestamp,
+          ledger,
+          txHash,
+        );
+        break;
+      // Orchestrator events
+      case "flow_ok":
+        this.processOrchestratorFlowOk(
+          contractAddress,
+          data,
+          timestamp,
+          ledger,
+          txHash,
+        );
+        break;
+      case "flow_fail":
+        this.processOrchestratorFlowFail(
+          contractAddress,
+          data,
+          timestamp,
+          ledger,
+          txHash,
+        );
+        break;
+      // Emergency Killswitch events — also trigger alerting
+      case "paused":
+        this.processKillswitchPaused(
+          contractAddress,
+          data,
+          timestamp,
+          ledger,
+          txHash,
+        );
+        break;
+      case "unpaused":
+        this.processKillswitchUnpaused(
+          contractAddress,
+          data,
+          timestamp,
+          ledger,
+          txHash,
+        );
+        break;
+      case "f_paused":
+        this.processKillswitchFunctionPaused(
+          contractAddress,
+          data,
+          timestamp,
+          ledger,
+          txHash,
+        );
+        break;
+      case "m_paused":
+        this.processKillswitchModulePaused(
+          contractAddress,
+          data,
+          timestamp,
+          ledger,
+          txHash,
+        );
         break;
       default:
         // Unknown event type, already stored in raw events
@@ -165,47 +278,47 @@ export class EventProcessor {
       (id, owner, name, target_amount, current_amount, target_date, locked, unlock_date, tags, created_at, updated_at)
       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
-    
+
     stmt.run(
       data.goal_id || data[0],
       data.owner || data[1],
-      data.name || data[2] || 'Unnamed Goal',
-      data.target_amount || data[3] || '0',
-      '0',
+      data.name || data[2] || "Unnamed Goal",
+      data.target_amount || data[3] || "0",
+      "0",
       data.target_date || data[4] || 0,
       0,
       null,
-      '[]',
+      "[]",
       timestamp,
-      timestamp
+      timestamp,
     );
   }
 
   private processGoalDeposit(data: any, timestamp: number): void {
     const goalId = data.goal_id || data[0];
     const amount = data.amount || data[1];
-    
+
     const stmt = this.db.prepare(`
       UPDATE savings_goals 
       SET current_amount = CAST((CAST(current_amount AS REAL) + ?) AS TEXT),
           updated_at = ?
       WHERE id = ?
     `);
-    
+
     stmt.run(parseFloat(amount), timestamp, goalId);
   }
 
   private processGoalWithdraw(data: any, timestamp: number): void {
     const goalId = data.goal_id || data[0];
     const amount = data.amount || data[1];
-    
+
     const stmt = this.db.prepare(`
       UPDATE savings_goals 
       SET current_amount = CAST((CAST(current_amount AS REAL) - ?) AS TEXT),
           updated_at = ?
       WHERE id = ?
     `);
-    
+
     stmt.run(parseFloat(amount), timestamp, goalId);
   }
 
@@ -215,12 +328,12 @@ export class EventProcessor {
       (id, owner, name, amount, due_date, recurring, frequency_days, paid, created_at, paid_at, schedule_id, tags, updated_at)
       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
-    
+
     stmt.run(
       data.bill_id || data[0],
       data.owner || data[1],
-      data.name || data[2] || 'Unnamed Bill',
-      data.amount || data[3] || '0',
+      data.name || data[2] || "Unnamed Bill",
+      data.amount || data[3] || "0",
       data.due_date || data[4] || 0,
       data.recurring || data[5] || 0,
       data.frequency_days || 0,
@@ -228,20 +341,20 @@ export class EventProcessor {
       timestamp,
       null,
       null,
-      '[]',
-      timestamp
+      "[]",
+      timestamp,
     );
   }
 
   private processBillPaid(data: any, timestamp: number): void {
     const billId = data.bill_id || data[0];
-    
+
     const stmt = this.db.prepare(`
       UPDATE bills 
       SET paid = 1, paid_at = ?, updated_at = ?
       WHERE id = ?
     `);
-    
+
     stmt.run(timestamp, timestamp, billId);
   }
 
@@ -251,20 +364,20 @@ export class EventProcessor {
       (id, owner, name, coverage_type, monthly_premium, coverage_amount, active, next_payment_date, schedule_id, tags, created_at, updated_at)
       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
-    
+
     stmt.run(
       data.policy_id || data[0],
       data.owner || data[1],
-      data.name || data[2] || 'Unnamed Policy',
-      data.coverage_type || data[3] || 'General',
-      data.monthly_premium || data[4] || '0',
-      data.coverage_amount || data[5] || '0',
+      data.name || data[2] || "Unnamed Policy",
+      data.coverage_type || data[3] || "General",
+      data.monthly_premium || data[4] || "0",
+      data.coverage_amount || data[5] || "0",
       1,
       data.next_payment_date || 0,
       null,
-      '[]',
+      "[]",
       timestamp,
-      timestamp
+      timestamp,
     );
   }
 
@@ -274,73 +387,87 @@ export class EventProcessor {
       (id, owner, name, total_amount, recipients, executed, created_at, executed_at, updated_at)
       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
-    
+
     stmt.run(
       data.split_id || data[0],
       data.owner || data[1],
-      data.name || data[2] || 'Unnamed Split',
-      data.total_amount || data[3] || '0',
+      data.name || data[2] || "Unnamed Split",
+      data.total_amount || data[3] || "0",
       JSON.stringify(data.recipients || []),
       0,
       timestamp,
       null,
-      timestamp
+      timestamp,
     );
   }
 
   private processSplitExecuted(data: any, timestamp: number): void {
     const splitId = data.split_id || data[0];
-    
+
     const stmt = this.db.prepare(`
       UPDATE remittance_splits 
       SET executed = 1, executed_at = ?, updated_at = ?
       WHERE id = ?
     `);
-    
+
     stmt.run(timestamp, timestamp, splitId);
   }
 
-  private processTagsAdded(contractAddress: string, data: any, timestamp: number): void {
+  private processTagsAdded(
+    contractAddress: string,
+    data: any,
+    timestamp: number,
+  ): void {
     const entityId = data.entity_id || data[0];
     const tags = data.tags || data[2] || [];
-    
+
     const table = this.getTableForContract(contractAddress);
     if (!table) return;
 
-    const current = this.db.prepare(`SELECT tags FROM ${table} WHERE id = ?`).get(entityId) as any;
+    const current = this.db
+      .prepare(`SELECT tags FROM ${table} WHERE id = ?`)
+      .get(entityId) as any;
     if (!current) return;
 
-    const currentTags = JSON.parse(current.tags || '[]');
+    const currentTags = JSON.parse(current.tags || "[]");
     const updatedTags = [...currentTags, ...tags];
-    
+
     const stmt = this.db.prepare(`
       UPDATE ${table} 
       SET tags = ?, updated_at = ?
       WHERE id = ?
     `);
-    
+
     stmt.run(JSON.stringify(updatedTags), timestamp, entityId);
   }
 
-  private processTagsRemoved(contractAddress: string, data: any, timestamp: number): void {
+  private processTagsRemoved(
+    contractAddress: string,
+    data: any,
+    timestamp: number,
+  ): void {
     const entityId = data.entity_id || data[0];
     const tagsToRemove = data.tags || data[2] || [];
-    
+
     const table = this.getTableForContract(contractAddress);
     if (!table) return;
 
-    const current = this.db.prepare(`SELECT tags FROM ${table} WHERE id = ?`).get(entityId) as any;
+    const current = this.db
+      .prepare(`SELECT tags FROM ${table} WHERE id = ?`)
+      .get(entityId) as any;
     if (!current) return;
 
-    const currentTags = JSON.parse(current.tags || '[]');
-    const updatedTags = currentTags.filter((tag: string) => !tagsToRemove.includes(tag));
-    
+    const currentTags = JSON.parse(current.tags || "[]");
+    const updatedTags = currentTags.filter(
+      (tag: string) => !tagsToRemove.includes(tag),
+    );
+
     const stmt = this.db.prepare(`
       UPDATE ${table} 
       SET tags = ?, updated_at = ?
       WHERE id = ?
     `);
-    
+
     stmt.run(JSON.stringify(updatedTags), timestamp, entityId);
   }
 
@@ -351,10 +478,388 @@ export class EventProcessor {
     const goalsContract = process.env.SAVINGS_GOALS_CONTRACT;
     const insuranceContract = process.env.INSURANCE_CONTRACT;
 
-    if (contractAddress === billsContract) return 'bills';
-    if (contractAddress === goalsContract) return 'savings_goals';
-    if (contractAddress === insuranceContract) return 'insurance_policies';
-    
+    if (contractAddress === billsContract) return "bills";
+    if (contractAddress === goalsContract) return "savings_goals";
+    if (contractAddress === insuranceContract) return "insurance_policies";
+
     return null;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Family Wallet event processors
+  // Topics: member, limit, em_prop, archived
+  // ---------------------------------------------------------------------------
+
+  private processFamilyWalletMember(
+    contractAddress: string,
+    eventType: string,
+    data: any,
+    timestamp: number,
+    ledger: number,
+    txHash: string,
+  ): void {
+    const stmt = this.db.prepare(`
+      INSERT INTO family_wallet_events
+        (event_type, contract_address, member, role, spending_limit, timestamp, ledger, tx_hash, raw_data)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+    stmt.run(
+      eventType,
+      contractAddress,
+      data.member || data[0] || null,
+      data.role !== undefined ? String(data.role) : null,
+      data.spending_limit !== undefined ? String(data.spending_limit) : null,
+      timestamp,
+      ledger,
+      txHash,
+      JSON.stringify(data),
+    );
+  }
+
+  private processFamilyWalletLimit(
+    contractAddress: string,
+    eventType: string,
+    data: any,
+    timestamp: number,
+    ledger: number,
+    txHash: string,
+  ): void {
+    const stmt = this.db.prepare(`
+      INSERT INTO family_wallet_events
+        (event_type, contract_address, member, limit_amount, timestamp, ledger, tx_hash, raw_data)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+    stmt.run(
+      eventType,
+      contractAddress,
+      data.member || data[0] || null,
+      data.new_limit !== undefined
+        ? String(data.new_limit)
+        : data[1] !== undefined
+          ? String(data[1])
+          : null,
+      timestamp,
+      ledger,
+      txHash,
+      JSON.stringify(data),
+    );
+  }
+
+  private processFamilyWalletEmProp(
+    contractAddress: string,
+    eventType: string,
+    data: any,
+    timestamp: number,
+    ledger: number,
+    txHash: string,
+  ): void {
+    const stmt = this.db.prepare(`
+      INSERT INTO family_wallet_events
+        (event_type, contract_address, proposer, recipient, amount, timestamp, ledger, tx_hash, raw_data)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+    stmt.run(
+      eventType,
+      contractAddress,
+      data.proposer || data[0] || null,
+      data.recipient || data[1] || null,
+      data.amount !== undefined
+        ? String(data.amount)
+        : data[2] !== undefined
+          ? String(data[2])
+          : null,
+      timestamp,
+      ledger,
+      txHash,
+      JSON.stringify(data),
+    );
+  }
+
+  private processFamilyWalletArchived(
+    contractAddress: string,
+    eventType: string,
+    data: any,
+    timestamp: number,
+    ledger: number,
+    txHash: string,
+  ): void {
+    const stmt = this.db.prepare(`
+      INSERT INTO family_wallet_events
+        (event_type, contract_address, tx_id, timestamp, ledger, tx_hash, raw_data)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `);
+    stmt.run(
+      eventType,
+      contractAddress,
+      data.tx_id !== undefined
+        ? String(data.tx_id)
+        : data[0] !== undefined
+          ? String(data[0])
+          : null,
+      timestamp,
+      ledger,
+      txHash,
+      JSON.stringify(data),
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Orchestrator event processors
+  // Topics: flow_ok, flow_fail
+  // ---------------------------------------------------------------------------
+
+  private processOrchestratorFlowOk(
+    contractAddress: string,
+    data: any,
+    timestamp: number,
+    ledger: number,
+    txHash: string,
+  ): void {
+    const stmt = this.db.prepare(`
+      INSERT INTO orchestrator_events
+        (event_type, contract_address, executor, amount, timestamp, ledger, tx_hash, raw_data)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+    // flow_ok payload: (executor: Address, amount: i128)
+    const executor =
+      data[0] !== undefined ? String(data[0]) : data.executor || null;
+    const amount =
+      data[1] !== undefined
+        ? String(data[1])
+        : data.amount !== undefined
+          ? String(data.amount)
+          : null;
+    stmt.run(
+      "flow_ok",
+      contractAddress,
+      executor,
+      amount,
+      timestamp,
+      ledger,
+      txHash,
+      JSON.stringify(data),
+    );
+  }
+
+  private processOrchestratorFlowFail(
+    contractAddress: string,
+    data: any,
+    timestamp: number,
+    ledger: number,
+    txHash: string,
+  ): void {
+    const stmt = this.db.prepare(`
+      INSERT INTO orchestrator_events
+        (event_type, contract_address, executor, error_code, timestamp, ledger, tx_hash, raw_data)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+    // flow_fail payload: (executor: Address, error_code: u32)
+    const executor =
+      data[0] !== undefined ? String(data[0]) : data.executor || null;
+    const errorCode =
+      data[1] !== undefined
+        ? Number(data[1])
+        : data.error_code !== undefined
+          ? Number(data.error_code)
+          : null;
+    stmt.run(
+      "flow_fail",
+      contractAddress,
+      executor,
+      errorCode,
+      timestamp,
+      ledger,
+      txHash,
+      JSON.stringify(data),
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Emergency Killswitch event processors
+  // Topics: paused, unpaused, f_paused, m_paused
+  // These events drive alerting hooks — alert_sent is set to 0 on insert
+  // and updated to 1 by the alerting subsystem after notification is sent.
+  // ---------------------------------------------------------------------------
+
+  private processKillswitchPaused(
+    contractAddress: string,
+    data: any,
+    timestamp: number,
+    ledger: number,
+    txHash: string,
+  ): void {
+    // paused payload: (scope: Symbol, timestamp: u64)
+    const scope =
+      data[0] !== undefined ? String(data[0]) : data.scope || "GLOBAL";
+    this.insertKillswitchEvent(
+      "paused",
+      contractAddress,
+      scope,
+      null,
+      null,
+      timestamp,
+      ledger,
+      txHash,
+      data,
+    );
+    this.triggerKillswitchAlert(
+      "paused",
+      contractAddress,
+      scope,
+      null,
+      null,
+      timestamp,
+    );
+  }
+
+  private processKillswitchUnpaused(
+    contractAddress: string,
+    data: any,
+    timestamp: number,
+    ledger: number,
+    txHash: string,
+  ): void {
+    // unpaused payload: (scope: Symbol, timestamp: u64)
+    const scope =
+      data[0] !== undefined ? String(data[0]) : data.scope || "GLOBAL";
+    this.insertKillswitchEvent(
+      "unpaused",
+      contractAddress,
+      scope,
+      null,
+      null,
+      timestamp,
+      ledger,
+      txHash,
+      data,
+    );
+  }
+
+  private processKillswitchFunctionPaused(
+    contractAddress: string,
+    data: any,
+    timestamp: number,
+    ledger: number,
+    txHash: string,
+  ): void {
+    // f_paused payload: (module_id: Symbol, func: Symbol, timestamp: u64)
+    const moduleId =
+      data[0] !== undefined ? String(data[0]) : data.module_id || null;
+    const funcName =
+      data[1] !== undefined ? String(data[1]) : data.func_name || null;
+    this.insertKillswitchEvent(
+      "f_paused",
+      contractAddress,
+      null,
+      moduleId,
+      funcName,
+      timestamp,
+      ledger,
+      txHash,
+      data,
+    );
+    this.triggerKillswitchAlert(
+      "f_paused",
+      contractAddress,
+      null,
+      moduleId,
+      funcName,
+      timestamp,
+    );
+  }
+
+  private processKillswitchModulePaused(
+    contractAddress: string,
+    data: any,
+    timestamp: number,
+    ledger: number,
+    txHash: string,
+  ): void {
+    // m_paused payload: (module_id: Symbol, timestamp: u64)
+    const moduleId =
+      data[0] !== undefined ? String(data[0]) : data.module_id || null;
+    this.insertKillswitchEvent(
+      "m_paused",
+      contractAddress,
+      null,
+      moduleId,
+      null,
+      timestamp,
+      ledger,
+      txHash,
+      data,
+    );
+    this.triggerKillswitchAlert(
+      "m_paused",
+      contractAddress,
+      null,
+      moduleId,
+      null,
+      timestamp,
+    );
+  }
+
+  private insertKillswitchEvent(
+    eventType: string,
+    contractAddress: string,
+    scope: string | null,
+    moduleId: string | null,
+    funcName: string | null,
+    timestamp: number,
+    ledger: number,
+    txHash: string,
+    data: any,
+  ): void {
+    const stmt = this.db.prepare(`
+      INSERT INTO killswitch_events
+        (event_type, contract_address, scope, module_id, func_name, timestamp, ledger, tx_hash, raw_data, alert_sent)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0)
+    `);
+    stmt.run(
+      eventType,
+      contractAddress,
+      scope,
+      moduleId,
+      funcName,
+      timestamp,
+      ledger,
+      txHash,
+      JSON.stringify(data),
+    );
+  }
+
+  /**
+   * Trigger an alerting hook for killswitch/emergency events.
+   *
+   * In production this would call an external alerting service (PagerDuty,
+   * Slack webhook, etc.). The implementation here logs to stderr so that
+   * process supervisors (systemd, Docker) can capture and route the output.
+   * The `alert_sent` column is updated to 1 after the alert is dispatched.
+   */
+  private triggerKillswitchAlert(
+    eventType: string,
+    contractAddress: string,
+    scope: string | null,
+    moduleId: string | null,
+    funcName: string | null,
+    timestamp: number,
+  ): void {
+    const detail = funcName
+      ? `module=${moduleId} func=${funcName}`
+      : moduleId
+        ? `module=${moduleId}`
+        : `scope=${scope}`;
+
+    console.error(
+      `[ALERT] killswitch event: type=${eventType} contract=${contractAddress} ${detail} ts=${timestamp}`,
+    );
+
+    // Mark the most recently inserted row as alerted
+    this.db
+      .prepare(
+        `UPDATE killswitch_events SET alert_sent = 1
+         WHERE id = (SELECT MAX(id) FROM killswitch_events WHERE event_type = ? AND contract_address = ?)`,
+      )
+      .run(eventType, contractAddress);
   }
 }

--- a/indexer/src/types.ts
+++ b/indexer/src/types.ts
@@ -111,3 +111,74 @@ export interface TagsRemovedEvent {
   owner: string;
   tags: string[];
 }
+
+// Family Wallet event types
+export interface FamilyWalletMemberEvent {
+  event_type: "member_added" | "member_removed" | "limit_updated";
+  member: string;
+  role?: string;
+  spending_limit?: string;
+  timestamp: number;
+}
+
+export interface FamilyWalletLimitEvent {
+  event_type: "limit";
+  member: string;
+  limit_amount: string;
+  timestamp: number;
+}
+
+export interface FamilyWalletEmergencyProposalEvent {
+  event_type: "em_prop";
+  proposer: string;
+  recipient: string;
+  amount: string;
+  timestamp: number;
+}
+
+export interface FamilyWalletArchivedEvent {
+  event_type: "archived";
+  tx_id: string;
+  timestamp: number;
+}
+
+// Orchestrator event types
+export interface OrchestratorFlowOkEvent {
+  event_type: "flow_ok";
+  executor: string;
+  amount: string;
+  timestamp: number;
+}
+
+export interface OrchestratorFlowFailEvent {
+  event_type: "flow_fail";
+  executor: string;
+  error_code: number;
+  timestamp: number;
+}
+
+// Emergency Killswitch event types
+export interface KillswitchPausedEvent {
+  event_type: "paused";
+  scope: string;
+  timestamp: number;
+}
+
+export interface KillswitchUnpausedEvent {
+  event_type: "unpaused";
+  scope: string;
+  timestamp: number;
+}
+
+export interface KillswitchFunctionPausedEvent {
+  event_type: "f_paused";
+  module_id: string;
+  func_name: string;
+  timestamp: number;
+}
+
+export interface KillswitchModulePausedEvent {
+  event_type: "m_paused";
+  module_id: string;
+  timestamp: number;
+}

--- a/indexer/tests/eventProcessor.test.ts
+++ b/indexer/tests/eventProcessor.test.ts
@@ -10,21 +10,21 @@
  * Run with: npm test
  */
 
-import { EventProcessor } from '../src/eventProcessor';
-import { initializeDatabase } from '../src/db/schema';
-import Database from 'better-sqlite3';
+import { EventProcessor } from "../src/eventProcessor";
+import { initializeDatabase } from "../src/db/schema";
+import Database from "better-sqlite3";
 
-describe('EventProcessor', () => {
+describe("EventProcessor", () => {
   let db: Database.Database;
   let processor: EventProcessor;
 
   beforeEach(() => {
     // Create in-memory database for testing
-    db = new Database(':memory:');
-    db.pragma('journal_mode = WAL');
-    
+    db = new Database(":memory:");
+    db.pragma("journal_mode = WAL");
+
     // Initialize schema
-    const { initializeDatabase: init } = require('../src/db/schema');
+    const { initializeDatabase: init } = require("../src/db/schema");
     // Manually create tables for testing
     db.exec(`
       CREATE TABLE events (
@@ -67,8 +67,53 @@ describe('EventProcessor', () => {
         tags TEXT NOT NULL DEFAULT '[]',
         updated_at INTEGER NOT NULL
       );
+
+      CREATE TABLE family_wallet_events (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        event_type TEXT NOT NULL,
+        contract_address TEXT NOT NULL,
+        member TEXT,
+        role TEXT,
+        spending_limit TEXT,
+        limit_amount TEXT,
+        tx_id TEXT,
+        proposer TEXT,
+        recipient TEXT,
+        amount TEXT,
+        timestamp INTEGER NOT NULL,
+        ledger INTEGER NOT NULL,
+        tx_hash TEXT NOT NULL,
+        raw_data TEXT NOT NULL
+      );
+
+      CREATE TABLE orchestrator_events (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        event_type TEXT NOT NULL,
+        contract_address TEXT NOT NULL,
+        executor TEXT,
+        amount TEXT,
+        error_code INTEGER,
+        timestamp INTEGER NOT NULL,
+        ledger INTEGER NOT NULL,
+        tx_hash TEXT NOT NULL,
+        raw_data TEXT NOT NULL
+      );
+
+      CREATE TABLE killswitch_events (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        event_type TEXT NOT NULL,
+        contract_address TEXT NOT NULL,
+        scope TEXT,
+        module_id TEXT,
+        func_name TEXT,
+        timestamp INTEGER NOT NULL,
+        ledger INTEGER NOT NULL,
+        tx_hash TEXT NOT NULL,
+        raw_data TEXT NOT NULL,
+        alert_sent INTEGER NOT NULL DEFAULT 0
+      );
     `);
-    
+
     processor = new EventProcessor(db);
   });
 
@@ -76,17 +121,17 @@ describe('EventProcessor', () => {
     db.close();
   });
 
-  describe('Goal Events', () => {
-    test('should process goal_created event', () => {
+  describe("Goal Events", () => {
+    test("should process goal_created event", () => {
       const mockEvent = {
-        topic: ['savings', 'goal_created'],
+        topic: ["savings", "goal_created"],
         body: {
           v0: {
             data: {
               goal_id: 1,
-              owner: 'GXXXXXXX',
-              name: 'Emergency Fund',
-              target_amount: '10000',
+              owner: "GXXXXXXX",
+              name: "Emergency Fund",
+              target_amount: "10000",
               target_date: 1735689600,
             },
           },
@@ -95,32 +140,36 @@ describe('EventProcessor', () => {
 
       processor.processEvent(
         1000,
-        'tx123',
-        'contract123',
+        "tx123",
+        "contract123",
         mockEvent,
-        1700000000
+        1700000000,
       );
 
-      const goal = db.prepare('SELECT * FROM savings_goals WHERE id = ?').get(1);
+      const goal = db
+        .prepare("SELECT * FROM savings_goals WHERE id = ?")
+        .get(1);
       expect(goal).toBeDefined();
-      expect(goal.name).toBe('Emergency Fund');
+      expect(goal.name).toBe("Emergency Fund");
     });
 
-    test('should process goal_deposit event', () => {
+    test("should process goal_deposit event", () => {
       // First create a goal
-      db.prepare(`
+      db.prepare(
+        `
         INSERT INTO savings_goals 
         (id, owner, name, target_amount, current_amount, target_date, locked, tags, created_at, updated_at)
         VALUES (1, 'GXXXXXXX', 'Test Goal', '10000', '0', 1735689600, 0, '[]', 1700000000, 1700000000)
-      `).run();
+      `,
+      ).run();
 
       const mockEvent = {
-        topic: ['savings', 'goal_deposit'],
+        topic: ["savings", "goal_deposit"],
         body: {
           v0: {
             data: {
               goal_id: 1,
-              amount: '1000',
+              amount: "1000",
             },
           },
         },
@@ -128,28 +177,30 @@ describe('EventProcessor', () => {
 
       processor.processEvent(
         1001,
-        'tx124',
-        'contract123',
+        "tx124",
+        "contract123",
         mockEvent,
-        1700000100
+        1700000100,
       );
 
-      const goal = db.prepare('SELECT * FROM savings_goals WHERE id = ?').get(1);
+      const goal = db
+        .prepare("SELECT * FROM savings_goals WHERE id = ?")
+        .get(1);
       expect(parseFloat(goal.current_amount)).toBe(1000);
     });
   });
 
-  describe('Bill Events', () => {
-    test('should process bill_created event', () => {
+  describe("Bill Events", () => {
+    test("should process bill_created event", () => {
       const mockEvent = {
-        topic: ['bills', 'bill_created'],
+        topic: ["bills", "bill_created"],
         body: {
           v0: {
             data: {
               bill_id: 1,
-              owner: 'GXXXXXXX',
-              name: 'Electricity',
-              amount: '150',
+              owner: "GXXXXXXX",
+              name: "Electricity",
+              amount: "150",
               due_date: 1735689600,
               recurring: true,
             },
@@ -159,28 +210,30 @@ describe('EventProcessor', () => {
 
       processor.processEvent(
         1000,
-        'tx123',
-        'contract456',
+        "tx123",
+        "contract456",
         mockEvent,
-        1700000000
+        1700000000,
       );
 
-      const bill = db.prepare('SELECT * FROM bills WHERE id = ?').get(1);
+      const bill = db.prepare("SELECT * FROM bills WHERE id = ?").get(1);
       expect(bill).toBeDefined();
-      expect(bill.name).toBe('Electricity');
+      expect(bill.name).toBe("Electricity");
       expect(bill.paid).toBe(0);
     });
 
-    test('should process bill_paid event', () => {
+    test("should process bill_paid event", () => {
       // First create a bill
-      db.prepare(`
+      db.prepare(
+        `
         INSERT INTO bills 
         (id, owner, name, amount, due_date, recurring, frequency_days, paid, created_at, tags, updated_at)
         VALUES (1, 'GXXXXXXX', 'Test Bill', '100', 1735689600, 0, 0, 0, 1700000000, '[]', 1700000000)
-      `).run();
+      `,
+      ).run();
 
       const mockEvent = {
-        topic: ['bills', 'bill_paid'],
+        topic: ["bills", "bill_paid"],
         body: {
           v0: {
             data: {
@@ -192,41 +245,533 @@ describe('EventProcessor', () => {
 
       processor.processEvent(
         1001,
-        'tx124',
-        'contract456',
+        "tx124",
+        "contract456",
         mockEvent,
-        1700000100
+        1700000100,
       );
 
-      const bill = db.prepare('SELECT * FROM bills WHERE id = ?').get(1);
+      const bill = db.prepare("SELECT * FROM bills WHERE id = ?").get(1);
       expect(bill.paid).toBe(1);
       expect(bill.paid_at).toBe(1700000100);
     });
   });
 
-  describe('Raw Event Storage', () => {
-    test('should store raw events', () => {
+  describe("Raw Event Storage", () => {
+    test("should store raw events", () => {
       const mockEvent = {
-        topic: ['test', 'event'],
+        topic: ["test", "event"],
         body: {
           v0: {
-            data: { test: 'data' },
+            data: { test: "data" },
           },
         },
       };
 
       processor.processEvent(
         1000,
-        'tx123',
-        'contract123',
+        "tx123",
+        "contract123",
         mockEvent,
-        1700000000
+        1700000000,
       );
 
-      const events = db.prepare('SELECT * FROM events').all();
+      const events = db.prepare("SELECT * FROM events").all();
       expect(events.length).toBeGreaterThan(0);
       expect(events[0].ledger).toBe(1000);
-      expect(events[0].tx_hash).toBe('tx123');
+      expect(events[0].tx_hash).toBe("tx123");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Family Wallet Events
+  // ---------------------------------------------------------------------------
+
+  describe("Family Wallet Events", () => {
+    test("should process member event (member added)", () => {
+      const mockEvent = {
+        topic: ["family", "member"],
+        body: {
+          v0: {
+            data: {
+              member: "GXXXXXXX",
+              role: 3,
+              spending_limit: "1000000000",
+            },
+          },
+        },
+      };
+
+      processor.processEvent(
+        1000,
+        "tx100",
+        "fw_contract",
+        mockEvent,
+        1700000000,
+      );
+
+      const row = db
+        .prepare(
+          "SELECT * FROM family_wallet_events WHERE event_type = 'member'",
+        )
+        .get() as any;
+      expect(row).toBeDefined();
+      expect(row.member).toBe("GXXXXXXX");
+      expect(row.role).toBe("3");
+      expect(row.contract_address).toBe("fw_contract");
+      expect(row.ledger).toBe(1000);
+      expect(row.tx_hash).toBe("tx100");
+    });
+
+    test("should process limit event (spending limit updated)", () => {
+      const mockEvent = {
+        topic: ["family", "limit"],
+        body: {
+          v0: {
+            data: {
+              member: "GXXXXXXX",
+              new_limit: "2000000000",
+            },
+          },
+        },
+      };
+
+      processor.processEvent(
+        1001,
+        "tx101",
+        "fw_contract",
+        mockEvent,
+        1700000100,
+      );
+
+      const row = db
+        .prepare(
+          "SELECT * FROM family_wallet_events WHERE event_type = 'limit'",
+        )
+        .get() as any;
+      expect(row).toBeDefined();
+      expect(row.member).toBe("GXXXXXXX");
+      expect(row.limit_amount).toBe("2000000000");
+    });
+
+    test("should process em_prop event (emergency proposal)", () => {
+      const mockEvent = {
+        topic: ["family", "em_prop"],
+        body: {
+          v0: {
+            data: {
+              proposer: "GPROPOSER",
+              recipient: "GRECIPIENT",
+              amount: "5000000000",
+            },
+          },
+        },
+      };
+
+      processor.processEvent(
+        1002,
+        "tx102",
+        "fw_contract",
+        mockEvent,
+        1700000200,
+      );
+
+      const row = db
+        .prepare(
+          "SELECT * FROM family_wallet_events WHERE event_type = 'em_prop'",
+        )
+        .get() as any;
+      expect(row).toBeDefined();
+      expect(row.proposer).toBe("GPROPOSER");
+      expect(row.recipient).toBe("GRECIPIENT");
+      expect(row.amount).toBe("5000000000");
+    });
+
+    test("should process archived event (transaction archived)", () => {
+      const mockEvent = {
+        topic: ["family", "archived"],
+        body: {
+          v0: {
+            data: {
+              tx_id: 42,
+            },
+          },
+        },
+      };
+
+      processor.processEvent(
+        1003,
+        "tx103",
+        "fw_contract",
+        mockEvent,
+        1700000300,
+      );
+
+      const row = db
+        .prepare(
+          "SELECT * FROM family_wallet_events WHERE event_type = 'archived'",
+        )
+        .get() as any;
+      expect(row).toBeDefined();
+      expect(row.tx_id).toBe("42");
+    });
+
+    test("should store multiple family wallet event types independently", () => {
+      const fixtures = [
+        { topic: ["family", "member"], data: { member: "G1", role: 3 } },
+        {
+          topic: ["family", "limit"],
+          data: { member: "G1", new_limit: "500" },
+        },
+        {
+          topic: ["family", "em_prop"],
+          data: { proposer: "G1", recipient: "G2", amount: "100" },
+        },
+        { topic: ["family", "archived"], data: { tx_id: 1 } },
+      ];
+
+      fixtures.forEach((e, i) => {
+        processor.processEvent(
+          2000 + i,
+          `tx2${i}`,
+          "fw_contract",
+          {
+            topic: e.topic,
+            body: { v0: { data: e.data } },
+          },
+          1700000000 + i,
+        );
+      });
+
+      const rows = db.prepare("SELECT * FROM family_wallet_events").all();
+      expect(rows.length).toBe(4);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Orchestrator Events
+  // ---------------------------------------------------------------------------
+
+  describe("Orchestrator Events", () => {
+    test("should process flow_ok event", () => {
+      const mockEvent = {
+        topic: ["orch", "flow_ok"],
+        body: {
+          v0: {
+            data: ["GEXECUTOR", "10000000000"],
+          },
+        },
+      };
+
+      processor.processEvent(
+        3000,
+        "tx300",
+        "orch_contract",
+        mockEvent,
+        1700001000,
+      );
+
+      const row = db
+        .prepare(
+          "SELECT * FROM orchestrator_events WHERE event_type = 'flow_ok'",
+        )
+        .get() as any;
+      expect(row).toBeDefined();
+      expect(row.executor).toBe("GEXECUTOR");
+      expect(row.amount).toBe("10000000000");
+      expect(row.contract_address).toBe("orch_contract");
+      expect(row.ledger).toBe(3000);
+    });
+
+    test("should process flow_fail event", () => {
+      const mockEvent = {
+        topic: ["orch", "flow_fail"],
+        body: {
+          v0: {
+            data: ["GEXECUTOR", 2],
+          },
+        },
+      };
+
+      processor.processEvent(
+        3001,
+        "tx301",
+        "orch_contract",
+        mockEvent,
+        1700001100,
+      );
+
+      const row = db
+        .prepare(
+          "SELECT * FROM orchestrator_events WHERE event_type = 'flow_fail'",
+        )
+        .get() as any;
+      expect(row).toBeDefined();
+      expect(row.executor).toBe("GEXECUTOR");
+      expect(row.error_code).toBe(2);
+    });
+
+    test("should process flow_ok with object-style data", () => {
+      const mockEvent = {
+        topic: ["orch", "flow_ok"],
+        body: {
+          v0: {
+            data: { executor: "GEXEC2", amount: "500" },
+          },
+        },
+      };
+
+      processor.processEvent(
+        3002,
+        "tx302",
+        "orch_contract",
+        mockEvent,
+        1700001200,
+      );
+
+      const row = db
+        .prepare("SELECT * FROM orchestrator_events WHERE ledger = 3002")
+        .get() as any;
+      expect(row).toBeDefined();
+      expect(row.executor).toBe("GEXEC2");
+      expect(row.amount).toBe("500");
+    });
+
+    test("should store both flow_ok and flow_fail events", () => {
+      processor.processEvent(
+        3010,
+        "tx310",
+        "orch_contract",
+        {
+          topic: ["orch", "flow_ok"],
+          body: { v0: { data: ["GEXEC", "100"] } },
+        },
+        1700002000,
+      );
+
+      processor.processEvent(
+        3011,
+        "tx311",
+        "orch_contract",
+        {
+          topic: ["orch", "flow_fail"],
+          body: { v0: { data: ["GEXEC", 3] } },
+        },
+        1700002100,
+      );
+
+      const rows = db
+        .prepare("SELECT * FROM orchestrator_events WHERE ledger >= 3010")
+        .all();
+      expect(rows.length).toBe(2);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Emergency Killswitch Events
+  // ---------------------------------------------------------------------------
+
+  describe("Emergency Killswitch Events", () => {
+    test("should process paused event and set alert_sent = 1", () => {
+      const mockEvent = {
+        topic: ["emergency", "paused"],
+        body: {
+          v0: {
+            data: ["GLOBAL", 1700000000],
+          },
+        },
+      };
+
+      processor.processEvent(
+        4000,
+        "tx400",
+        "ks_contract",
+        mockEvent,
+        1700000000,
+      );
+
+      const row = db
+        .prepare("SELECT * FROM killswitch_events WHERE event_type = 'paused'")
+        .get() as any;
+      expect(row).toBeDefined();
+      expect(row.scope).toBe("GLOBAL");
+      expect(row.contract_address).toBe("ks_contract");
+      expect(row.ledger).toBe(4000);
+      expect(row.alert_sent).toBe(1);
+    });
+
+    test("should process unpaused event with alert_sent = 0", () => {
+      const mockEvent = {
+        topic: ["emergency", "unpaused"],
+        body: {
+          v0: {
+            data: ["GLOBAL", 1700000100],
+          },
+        },
+      };
+
+      processor.processEvent(
+        4001,
+        "tx401",
+        "ks_contract",
+        mockEvent,
+        1700000100,
+      );
+
+      const row = db
+        .prepare(
+          "SELECT * FROM killswitch_events WHERE event_type = 'unpaused'",
+        )
+        .get() as any;
+      expect(row).toBeDefined();
+      expect(row.scope).toBe("GLOBAL");
+      expect(row.alert_sent).toBe(0);
+    });
+
+    test("should process f_paused event and set alert_sent = 1", () => {
+      const mockEvent = {
+        topic: ["emergency", "f_paused"],
+        body: {
+          v0: {
+            data: ["remittance", "distribute", 1700000200],
+          },
+        },
+      };
+
+      processor.processEvent(
+        4002,
+        "tx402",
+        "ks_contract",
+        mockEvent,
+        1700000200,
+      );
+
+      const row = db
+        .prepare(
+          "SELECT * FROM killswitch_events WHERE event_type = 'f_paused'",
+        )
+        .get() as any;
+      expect(row).toBeDefined();
+      expect(row.module_id).toBe("remittance");
+      expect(row.func_name).toBe("distribute");
+      expect(row.alert_sent).toBe(1);
+    });
+
+    test("should process m_paused event and set alert_sent = 1", () => {
+      const mockEvent = {
+        topic: ["emergency", "m_paused"],
+        body: {
+          v0: {
+            data: ["insurance", 1700000300],
+          },
+        },
+      };
+
+      processor.processEvent(
+        4003,
+        "tx403",
+        "ks_contract",
+        mockEvent,
+        1700000300,
+      );
+
+      const row = db
+        .prepare(
+          "SELECT * FROM killswitch_events WHERE event_type = 'm_paused'",
+        )
+        .get() as any;
+      expect(row).toBeDefined();
+      expect(row.module_id).toBe("insurance");
+      expect(row.func_name).toBeNull();
+      expect(row.alert_sent).toBe(1);
+    });
+
+    test("should process f_paused with object-style data", () => {
+      const mockEvent = {
+        topic: ["emergency", "f_paused"],
+        body: {
+          v0: {
+            data: { module_id: "savings", func_name: "withdraw" },
+          },
+        },
+      };
+
+      processor.processEvent(
+        4004,
+        "tx404",
+        "ks_contract",
+        mockEvent,
+        1700000400,
+      );
+
+      const row = db
+        .prepare("SELECT * FROM killswitch_events WHERE ledger = 4004")
+        .get() as any;
+      expect(row).toBeDefined();
+      expect(row.module_id).toBe("savings");
+      expect(row.func_name).toBe("withdraw");
+    });
+
+    test("should store all four killswitch event types", () => {
+      const fixtures = [
+        { topic: ["emergency", "paused"], data: ["GLOBAL", 0] },
+        { topic: ["emergency", "unpaused"], data: ["GLOBAL", 0] },
+        { topic: ["emergency", "f_paused"], data: ["mod", "fn", 0] },
+        { topic: ["emergency", "m_paused"], data: ["mod", 0] },
+      ];
+
+      fixtures.forEach((f, i) => {
+        processor.processEvent(
+          5000 + i,
+          `tx5${i}`,
+          "ks_contract",
+          {
+            topic: f.topic,
+            body: { v0: { data: f.data } },
+          },
+          1700010000 + i,
+        );
+      });
+
+      const rows = db
+        .prepare("SELECT * FROM killswitch_events WHERE ledger >= 5000")
+        .all() as any[];
+      expect(rows.length).toBe(4);
+
+      const types = rows.map((r) => r.event_type);
+      expect(types).toContain("paused");
+      expect(types).toContain("unpaused");
+      expect(types).toContain("f_paused");
+      expect(types).toContain("m_paused");
+    });
+
+    test("paused, f_paused, m_paused events should all have alert_sent = 1", () => {
+      const alertingFixtures = [
+        { topic: ["emergency", "paused"], data: ["GLOBAL", 0] },
+        { topic: ["emergency", "f_paused"], data: ["mod", "fn", 0] },
+        { topic: ["emergency", "m_paused"], data: ["mod", 0] },
+      ];
+
+      alertingFixtures.forEach((f, i) => {
+        processor.processEvent(
+          6000 + i,
+          `tx6${i}`,
+          "ks_contract",
+          {
+            topic: f.topic,
+            body: { v0: { data: f.data } },
+          },
+          1700020000 + i,
+        );
+      });
+
+      const rows = db
+        .prepare("SELECT * FROM killswitch_events WHERE ledger >= 6000")
+        .all() as any[];
+      expect(rows.length).toBe(3);
+      rows.forEach((row) => {
+        expect(row.alert_sent).toBe(1);
+      });
     });
   });
 });

--- a/remitwise-common/src/lib.rs
+++ b/remitwise-common/src/lib.rs
@@ -140,9 +140,11 @@ impl RemitwiseEvents {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use soroban_sdk::testutils::storage::Instance as InstanceStorage;
+    use soroban_sdk::testutils::{Ledger, LedgerInfo};
     use soroban_sdk::{
-        contract, contractimpl, symbol_short, testutils::Events, Address, Env, Symbol, TryFromVal,
-        Val, Vec,
+        contract, contractimpl, symbol_short, testutils::Events, Address, Env, IntoVal, Symbol,
+        TryFromVal, Val, Vec,
     };
 
     #[contract]
@@ -858,6 +860,397 @@ mod tests {
         let _ = a; // Still usable — proves Copy
         assert_eq!(b.to_u32(), 2);
     }
+
+    // -----------------------------------------------------------------------
+    // Round-trip encode/decode tests (IntoVal / TryFromVal)
+    //
+    // These tests prove that every variant of the three shared #[contracttype]
+    // enums survives a full Val round-trip without loss.  A silent encoding
+    // change (e.g. renumbering a discriminant) would corrupt cross-contract
+    // data stored in Soroban persistent/instance storage and event payloads
+    // such as PolicyCreatedEvent.coverage_type.
+    //
+    // Stability guarantee: the discriminant values are pinned by the
+    // `*_discriminants` tests above AND by these round-trip tests.  Both
+    // must pass for a change to be considered safe.
+    // -----------------------------------------------------------------------
+
+    /// Helper: round-trip a contracttype value through Val inside a contract
+    /// context, then assert the decoded value equals the original.
+    fn roundtrip_val<T>(env: &Env, contract_id: &Address, value: T) -> T
+    where
+        T: soroban_sdk::IntoVal<Env, Val>
+            + soroban_sdk::TryFromVal<Env, Val>
+            + Clone
+            + core::fmt::Debug,
+        <T as soroban_sdk::TryFromVal<Env, Val>>::Error: core::fmt::Debug,
+    {
+        // IntoVal must be called inside a contract context for contracttype
+        // enums because the SDK uses the host environment for encoding.
+        let encoded: Val = env.as_contract(contract_id, || value.clone().into_val(env));
+        let decoded: T = env
+            .as_contract(contract_id, || T::try_from_val(env, &encoded))
+            .expect("TryFromVal must succeed for a valid contracttype variant");
+        decoded
+    }
+
+    // --- Category ---
+
+    #[test]
+    fn category_spending_roundtrip() {
+        let (env, contract_id) = setup_event_env();
+        let original = Category::Spending;
+        let decoded = roundtrip_val(&env, &contract_id, original);
+        assert_eq!(decoded, Category::Spending);
+    }
+
+    #[test]
+    fn category_savings_roundtrip() {
+        let (env, contract_id) = setup_event_env();
+        let decoded = roundtrip_val(&env, &contract_id, Category::Savings);
+        assert_eq!(decoded, Category::Savings);
+    }
+
+    #[test]
+    fn category_bills_roundtrip() {
+        let (env, contract_id) = setup_event_env();
+        let decoded = roundtrip_val(&env, &contract_id, Category::Bills);
+        assert_eq!(decoded, Category::Bills);
+    }
+
+    #[test]
+    fn category_insurance_roundtrip() {
+        let (env, contract_id) = setup_event_env();
+        let decoded = roundtrip_val(&env, &contract_id, Category::Insurance);
+        assert_eq!(decoded, Category::Insurance);
+    }
+
+    #[test]
+    fn category_all_variants_roundtrip() {
+        let (env, contract_id) = setup_event_env();
+        let variants = [
+            Category::Spending,
+            Category::Savings,
+            Category::Bills,
+            Category::Insurance,
+        ];
+        for variant in variants {
+            let decoded = roundtrip_val(&env, &contract_id, variant);
+            assert_eq!(
+                decoded, variant,
+                "Category::{:?} must survive Val round-trip",
+                variant
+            );
+        }
+    }
+
+    #[test]
+    fn category_roundtrip_preserves_discriminant() {
+        let (env, contract_id) = setup_event_env();
+        let pairs = [
+            (Category::Spending, 1u32),
+            (Category::Savings, 2u32),
+            (Category::Bills, 3u32),
+            (Category::Insurance, 4u32),
+        ];
+        for (variant, expected_disc) in pairs {
+            let decoded = roundtrip_val(&env, &contract_id, variant);
+            assert_eq!(
+                decoded as u32, expected_disc,
+                "Category discriminant must be stable after round-trip"
+            );
+        }
+    }
+
+    // --- CoverageType ---
+
+    #[test]
+    fn coverage_type_health_roundtrip() {
+        let (env, contract_id) = setup_event_env();
+        let decoded = roundtrip_val(&env, &contract_id, CoverageType::Health);
+        assert_eq!(decoded, CoverageType::Health);
+    }
+
+    #[test]
+    fn coverage_type_life_roundtrip() {
+        let (env, contract_id) = setup_event_env();
+        let decoded = roundtrip_val(&env, &contract_id, CoverageType::Life);
+        assert_eq!(decoded, CoverageType::Life);
+    }
+
+    #[test]
+    fn coverage_type_property_roundtrip() {
+        let (env, contract_id) = setup_event_env();
+        let decoded = roundtrip_val(&env, &contract_id, CoverageType::Property);
+        assert_eq!(decoded, CoverageType::Property);
+    }
+
+    #[test]
+    fn coverage_type_auto_roundtrip() {
+        let (env, contract_id) = setup_event_env();
+        let decoded = roundtrip_val(&env, &contract_id, CoverageType::Auto);
+        assert_eq!(decoded, CoverageType::Auto);
+    }
+
+    #[test]
+    fn coverage_type_liability_roundtrip() {
+        let (env, contract_id) = setup_event_env();
+        let decoded = roundtrip_val(&env, &contract_id, CoverageType::Liability);
+        assert_eq!(decoded, CoverageType::Liability);
+    }
+
+    #[test]
+    fn coverage_type_all_variants_roundtrip() {
+        let (env, contract_id) = setup_event_env();
+        let variants = [
+            CoverageType::Health,
+            CoverageType::Life,
+            CoverageType::Property,
+            CoverageType::Auto,
+            CoverageType::Liability,
+        ];
+        for variant in variants {
+            let decoded = roundtrip_val(&env, &contract_id, variant);
+            assert_eq!(
+                decoded, variant,
+                "CoverageType::{:?} must survive Val round-trip",
+                variant
+            );
+        }
+    }
+
+    #[test]
+    fn coverage_type_roundtrip_preserves_discriminant() {
+        let (env, contract_id) = setup_event_env();
+        let pairs = [
+            (CoverageType::Health, 1u32),
+            (CoverageType::Life, 2u32),
+            (CoverageType::Property, 3u32),
+            (CoverageType::Auto, 4u32),
+            (CoverageType::Liability, 5u32),
+        ];
+        for (variant, expected_disc) in pairs {
+            let decoded = roundtrip_val(&env, &contract_id, variant);
+            assert_eq!(
+                decoded as u32, expected_disc,
+                "CoverageType discriminant must be stable after round-trip"
+            );
+        }
+    }
+
+    // --- FamilyRole ---
+
+    #[test]
+    fn family_role_owner_roundtrip() {
+        let (env, contract_id) = setup_event_env();
+        let decoded = roundtrip_val(&env, &contract_id, FamilyRole::Owner);
+        assert_eq!(decoded, FamilyRole::Owner);
+    }
+
+    #[test]
+    fn family_role_admin_roundtrip() {
+        let (env, contract_id) = setup_event_env();
+        let decoded = roundtrip_val(&env, &contract_id, FamilyRole::Admin);
+        assert_eq!(decoded, FamilyRole::Admin);
+    }
+
+    #[test]
+    fn family_role_member_roundtrip() {
+        let (env, contract_id) = setup_event_env();
+        let decoded = roundtrip_val(&env, &contract_id, FamilyRole::Member);
+        assert_eq!(decoded, FamilyRole::Member);
+    }
+
+    #[test]
+    fn family_role_viewer_roundtrip() {
+        let (env, contract_id) = setup_event_env();
+        let decoded = roundtrip_val(&env, &contract_id, FamilyRole::Viewer);
+        assert_eq!(decoded, FamilyRole::Viewer);
+    }
+
+    #[test]
+    fn family_role_all_variants_roundtrip() {
+        let (env, contract_id) = setup_event_env();
+        let variants = [
+            FamilyRole::Owner,
+            FamilyRole::Admin,
+            FamilyRole::Member,
+            FamilyRole::Viewer,
+        ];
+        for variant in variants {
+            let decoded = roundtrip_val(&env, &contract_id, variant);
+            assert_eq!(
+                decoded, variant,
+                "FamilyRole::{:?} must survive Val round-trip",
+                variant
+            );
+        }
+    }
+
+    #[test]
+    fn family_role_roundtrip_preserves_discriminant() {
+        let (env, contract_id) = setup_event_env();
+        let pairs = [
+            (FamilyRole::Owner, 1u32),
+            (FamilyRole::Admin, 2u32),
+            (FamilyRole::Member, 3u32),
+            (FamilyRole::Viewer, 4u32),
+        ];
+        for (variant, expected_disc) in pairs {
+            let decoded = roundtrip_val(&env, &contract_id, variant);
+            assert_eq!(
+                decoded as u32, expected_disc,
+                "FamilyRole discriminant must be stable after round-trip"
+            );
+        }
+    }
+
+    #[test]
+    fn family_role_roundtrip_preserves_ordering() {
+        // After a round-trip the ordering invariant must still hold.
+        let (env, contract_id) = setup_event_env();
+        let owner = roundtrip_val(&env, &contract_id, FamilyRole::Owner);
+        let admin = roundtrip_val(&env, &contract_id, FamilyRole::Admin);
+        let member = roundtrip_val(&env, &contract_id, FamilyRole::Member);
+        let viewer = roundtrip_val(&env, &contract_id, FamilyRole::Viewer);
+        assert!(owner < admin);
+        assert!(admin < member);
+        assert!(member < viewer);
+    }
+
+    // --- Cross-type: round-trip inside a storage-like tuple payload ---
+
+    #[test]
+    fn coverage_type_roundtrip_in_event_payload() {
+        // Simulates PolicyCreatedEvent.coverage_type being emitted and decoded.
+        let (env, contract_id) = setup_event_env();
+        let variants = [
+            CoverageType::Health,
+            CoverageType::Life,
+            CoverageType::Property,
+            CoverageType::Auto,
+            CoverageType::Liability,
+        ];
+        for variant in variants {
+            // Encode as part of a tuple (policy_id, coverage_type) — mirrors event payload
+            let payload: (u32, CoverageType) = (42u32, variant);
+            let encoded: Val = env.as_contract(&contract_id, || payload.into_val(&env));
+            let decoded: (u32, CoverageType) = env.as_contract(&contract_id, || {
+                <(u32, CoverageType)>::try_from_val(&env, &encoded)
+                    .expect("tuple round-trip must succeed")
+            });
+            assert_eq!(decoded.0, 42u32);
+            assert_eq!(decoded.1, variant);
+        }
+    }
+
+    #[test]
+    fn family_role_roundtrip_in_role_change_payload() {
+        // Simulates a RoleChange transaction data payload being encoded/decoded.
+        let (env, contract_id) = setup_event_env();
+        let roles = [
+            FamilyRole::Owner,
+            FamilyRole::Admin,
+            FamilyRole::Member,
+            FamilyRole::Viewer,
+        ];
+        for role in roles {
+            let payload: (u32, FamilyRole) = (1u32, role);
+            let encoded: Val = env.as_contract(&contract_id, || payload.into_val(&env));
+            let decoded: (u32, FamilyRole) = env.as_contract(&contract_id, || {
+                <(u32, FamilyRole)>::try_from_val(&env, &encoded)
+                    .expect("tuple round-trip must succeed")
+            });
+            assert_eq!(decoded.1, role);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // TTL helper tests
+    //
+    // Verify that bump_instance, bump_persistent, and bump_archive call
+    // extend_ttl with the correct ordered (threshold, bump) arguments.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn bump_instance_extends_instance_ttl() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, EventProbe);
+
+        // Set ledger sequence so TTL starts low
+        env.ledger().set(LedgerInfo {
+            protocol_version: 20,
+            sequence_number: 100,
+            timestamp: 1000,
+            network_id: [0; 32],
+            base_reserve: 10,
+            min_temp_entry_ttl: 1,
+            min_persistent_entry_ttl: 1,
+            max_entry_ttl: 3_000_000,
+        });
+
+        env.as_contract(&contract_id, || {
+            bump_instance(&env);
+        });
+
+        let ttl = env.as_contract(&contract_id, || env.storage().instance().get_ttl());
+        assert!(
+            ttl >= INSTANCE_BUMP_AMOUNT,
+            "bump_instance must extend TTL to at least INSTANCE_BUMP_AMOUNT ({INSTANCE_BUMP_AMOUNT}), got {ttl}"
+        );
+    }
+
+    #[test]
+    fn bump_archive_extends_instance_ttl_to_archive_amount() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, EventProbe);
+
+        env.ledger().set(LedgerInfo {
+            protocol_version: 20,
+            sequence_number: 100,
+            timestamp: 1000,
+            network_id: [0; 32],
+            base_reserve: 10,
+            min_temp_entry_ttl: 1,
+            min_persistent_entry_ttl: 1,
+            max_entry_ttl: 3_000_000,
+        });
+
+        env.as_contract(&contract_id, || {
+            bump_archive(&env);
+        });
+
+        let ttl = env.as_contract(&contract_id, || env.storage().instance().get_ttl());
+        assert!(
+            ttl >= ARCHIVE_BUMP_AMOUNT,
+            "bump_archive must extend TTL to at least ARCHIVE_BUMP_AMOUNT ({ARCHIVE_BUMP_AMOUNT}), got {ttl}"
+        );
+    }
+
+    #[test]
+    fn bump_instance_threshold_less_than_bump_invariant() {
+        // Sanity-check the constants used by bump_instance at runtime.
+        assert!(
+            INSTANCE_LIFETIME_THRESHOLD < INSTANCE_BUMP_AMOUNT,
+            "bump_instance: threshold ({INSTANCE_LIFETIME_THRESHOLD}) must be < bump ({INSTANCE_BUMP_AMOUNT})"
+        );
+    }
+
+    #[test]
+    fn bump_persistent_threshold_less_than_bump_invariant() {
+        assert!(
+            PERSISTENT_LIFETIME_THRESHOLD < PERSISTENT_BUMP_AMOUNT,
+            "bump_persistent: threshold ({PERSISTENT_LIFETIME_THRESHOLD}) must be < bump ({PERSISTENT_BUMP_AMOUNT})"
+        );
+    }
+
+    #[test]
+    fn bump_archive_threshold_less_than_bump_invariant() {
+        assert!(
+            ARCHIVE_LIFETIME_THRESHOLD < ARCHIVE_BUMP_AMOUNT,
+            "bump_archive: threshold ({ARCHIVE_LIFETIME_THRESHOLD}) must be < bump ({ARCHIVE_BUMP_AMOUNT})"
+        );
+    }
 }
 
 // Standardized TTL Constants (Ledger Counts)
@@ -872,3 +1265,46 @@ pub const PERSISTENT_LIFETIME_THRESHOLD: u32 = 15 * DAY_IN_LEDGERS; // 15 days
 /// Storage TTL for archived contract data (instance/archive bumps).
 pub const ARCHIVE_BUMP_AMOUNT: u32 = 150 * DAY_IN_LEDGERS; // ~150 days
 pub const ARCHIVE_LIFETIME_THRESHOLD: u32 = DAY_IN_LEDGERS; // 1 day
+
+// ---------------------------------------------------------------------------
+// Shared TTL-bump helpers
+//
+// These helpers centralise the canonical (threshold, bump) pairs so that
+// every contract calls `extend_ttl` with the correct ordered arguments.
+// The invariant `threshold < bump` is asserted by the constant tests above.
+// ---------------------------------------------------------------------------
+
+/// Extend the **instance** storage entry TTL using the canonical constants.
+///
+/// Call this on every state-changing operation to keep the contract instance
+/// alive for at least `INSTANCE_BUMP_AMOUNT` ledgers.
+pub fn bump_instance(env: &soroban_sdk::Env) {
+    env.storage()
+        .instance()
+        .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+}
+
+/// Extend a **persistent** storage entry TTL using the canonical constants.
+///
+/// Pass the same `key` that was used to write the persistent entry.
+pub fn bump_persistent<K>(env: &soroban_sdk::Env, key: &K)
+where
+    K: soroban_sdk::IntoVal<soroban_sdk::Env, soroban_sdk::Val>,
+{
+    env.storage().persistent().extend_ttl(
+        key,
+        PERSISTENT_LIFETIME_THRESHOLD,
+        PERSISTENT_BUMP_AMOUNT,
+    );
+}
+
+/// Extend the **instance** storage entry TTL using the archive constants.
+///
+/// Contracts that archive data (e.g. `family_wallet`, `bill_payments`) call
+/// this after writing to their archive maps so the instance entry stays alive
+/// for the longer archive window.
+pub fn bump_archive(env: &soroban_sdk::Env) {
+    env.storage()
+        .instance()
+        .extend_ttl(ARCHIVE_LIFETIME_THRESHOLD, ARCHIVE_BUMP_AMOUNT);
+}


### PR DESCRIPTION

Four independent improvements across the Remitwise contracts workspace and off-chain indexer. All CI checks pass (fmt, clippy, unwrap/expect lint, orchestrator tests, storage key validation, WASM build).

Changes
1. contracttype round-trip tests for Category, CoverageType, FamilyRole

remitwise-common defines these three enums as #[contracttype] #[repr(u32)] shared across all contracts. A silent discriminant change would corrupt on-chain storage and event payloads (e.g. PolicyCreatedEvent.coverage_type) with no compile error. Added 28 tests that encode every variant through IntoVal<Env, Val> and decode it back with TryFromVal, asserting the decoded value and discriminant are unchanged. Also covers tuple payloads that mirror real event structures.

lib.rs
 — 28 new round-trip tests
shared-type-stability.md
 — stability guarantee and rules for adding/removing variants
 
 closes #634
 
2. Shared TTL-bump helpers in remitwise-common

Each contract was calling extend_ttl(threshold, bump) directly with its own local constants, making it easy to swap the argument order (which silently sets a near-zero TTL). Centralised the policy into three helpers: bump_instance, bump_persistent, bump_archive. Each uses the canonical constant pair from remitwise-common, and the threshold < bump invariant is asserted by existing constant tests plus 5 new helper unit tests.

lib.rs
 — bump_instance, bump_persistent, bump_archive + 5 tests
ttl-bump-helpers.md
 — usage guide with examples
STORAGE_LAYOUT.md — TTL helper reference table added to common patterns section

closes #635

3. Family Wallet role expiry documentation and test fix

Role expiry enforcement was already implemented in require_role_at_least and is_owner_or_admin_in_members, covering propose_transaction, sign_transaction, and all admin-gated operations. Fixed a pre-existing compile error in test_add_member_already_exists where try_add_family_member (panics, returns bool) was used instead of try_add_member (returns Result<bool, Error>). Added formal documentation of the expiry semantics, boundary behaviour, and the full enforcement matrix.

test.rs
 — fix type mismatch in test_add_member_already_exists
fw-role-expiry.md
 — role expiry semantics, enforcement points, security notes
 
 closes #646


4. Indexer event processors for Family Wallet, Orchestrator, and Emergency Killswitch

The off-chain indexer only handled savings/bills/insurance/split events. Family Wallet governance events (member, limit, em_prop, archived), Orchestrator flow events (flow_ok, flow_fail), and Emergency Killswitch events (paused, unpaused, f_paused, m_paused) were invisible to dashboards and alerting. Added processors, schema tables, and TypeScript types for all of them. Killswitch pause events (paused, f_paused, m_paused) set alert_sent = 1 immediately and log to stderr so process supervisors can route alerts.

schema.ts
 — 3 new tables: family_wallet_events, orchestrator_events, killswitch_events
eventProcessor.ts
 — processors for all 8 new event types + alerting hook
types.ts
 — TypeScript interfaces for all new event types
eventProcessor.test.ts
 — 20 new Jest tests covering all new event types and alert behaviour





closes #652


