### PR TITLE
 Add a shared tag/charset canonicalization helper 

### DIFF
--- a/bill_payments/src/lib.rs
+++ b/bill_payments/src/lib.rs
@@ -1045,45 +1045,14 @@ impl BillPayments {
     // Tag management
     // -----------------------------------------------------------------------
 
-    /// Validates a tag batch for metadata operations.
+    /// Validates and canonicalizes a tag batch for metadata operations.
     ///
-    /// Requirements:
-    /// - At least one tag must be provided.
-    /// - Each tag length must be between 1 and 32 characters.
-    /// - Allowed charset: [a-z0-9-_]. Uppercase is normalized to lowercase.
+    /// Delegates to the shared [`remitwise_common::canonicalize_tags`] helper.
+    /// Invalid characters are reported as [`BillPaymentsError::InvalidTagContent`].
     fn validate_and_normalize_tags(env: &Env, tags: &Vec<String>) -> Vec<String> {
-        if tags.is_empty() {
-            panic!("Tags cannot be empty");
-        }
-        let mut normalized_tags = Vec::new(env);
-        for tag in tags.iter() {
-            let len = tag.len();
-            if len == 0 || len > 32 {
-                panic!("Tag must be between 1 and 32 characters");
-            }
-            let mut buf = [0u8; 32];
-            tag.copy_into_slice(&mut buf[..len as usize]);
-
-            for c in buf.iter_mut().take(len as usize) {
-                if c.is_ascii_uppercase() {
-                    *c += b'a' - b'A';
-                }
-                let c_val = *c;
-                if !(c_val.is_ascii_lowercase()
-                    || c_val.is_ascii_digit()
-                    || c_val == b'-'
-                    || c_val == b'_')
-                {
-                    soroban_sdk::panic_with_error!(env, BillPaymentsError::InvalidTagContent);
-                }
-            }
-            let s = match core::str::from_utf8(&buf[..len as usize]) {
-                Ok(v) => v,
-                Err(_) => soroban_sdk::panic_with_error!(env, BillPaymentsError::InvalidTagContent),
-            };
-            normalized_tags.push_back(String::from_str(env, s));
-        }
-        normalized_tags
+        remitwise_common::canonicalize_tags(env, tags, || {
+            soroban_sdk::panic_with_error!(env, BillPaymentsError::InvalidTagContent)
+        })
     }
 
     /// Adds tags to a bill's metadata.

--- a/insurance/src/lib.rs
+++ b/insurance/src/lib.rs
@@ -70,6 +70,8 @@ pub enum InsuranceError {
     PolicyLimitExceeded = 3,
     InvalidExternalRef = 4,
     DuplicateExternalRef = 5,
+    /// Tag content contains invalid characters (must be [a-z0-9-_])
+    InvalidTagContent = 6,
 }
 
 pub const EVT_POLICY_CREATED: Symbol = symbol_short!("created");
@@ -127,6 +129,7 @@ pub struct InsurancePolicy {
     pub coverage_amount: i128,
     pub active: bool,
     pub next_payment_date: u64,
+    pub tags: Vec<String>,
 }
 
 #[contracttype]
@@ -141,6 +144,7 @@ pub struct ArchivedPolicy {
     pub coverage_amount: i128,
     pub archived_at: u64,
     pub next_payment_date: u64,
+    pub tags: Vec<String>,
 }
 
 #[contracttype]
@@ -373,6 +377,7 @@ impl Insurance {
                 .ledger()
                 .timestamp()
                 .saturating_add(PAYMENT_PERIOD_SECONDS),
+            tags: Vec::new(&env),
         };
 
         Self::bind_external_ref(&env, &owner, next_id, &external_ref);
@@ -712,6 +717,7 @@ impl Insurance {
                 coverage_amount: policy.coverage_amount,
                 archived_at: env.ledger().timestamp(),
                 next_payment_date: policy.next_payment_date,
+                tags: policy.tags,
             },
         );
         policies.remove(policy_id);
@@ -775,6 +781,7 @@ impl Insurance {
                 coverage_amount: record.coverage_amount,
                 active: true,
                 next_payment_date: record.next_payment_date,
+                tags: record.tags,
             },
         );
         archived.remove(policy_id);
@@ -984,6 +991,129 @@ impl Insurance {
     pub fn get_storage_stats(env: Env) -> StorageStats {
         Self::extend_instance_ttl(&env);
         Self::read_stats(&env)
+    }
+
+    // -----------------------------------------------------------------------
+    // Tag management
+    // -----------------------------------------------------------------------
+
+    /// Validates and canonicalizes a tag batch for metadata operations.
+    ///
+    /// Delegates to the shared [`remitwise_common::canonicalize_tags`] helper.
+    /// Invalid characters are reported as [`InsuranceError::InvalidTagContent`].
+    fn validate_and_normalize_tags(env: &Env, tags: &Vec<String>) -> Vec<String> {
+        remitwise_common::canonicalize_tags(env, tags, || {
+            soroban_sdk::panic_with_error!(env, InsuranceError::InvalidTagContent)
+        })
+    }
+
+    /// Adds tags to a policy's metadata.
+    ///
+    /// Security:
+    /// - `caller` must authorize the invocation.
+    /// - Only the policy owner can add tags.
+    ///
+    /// Notes:
+    /// - Tags are validated and normalized (lowercase, trimmed charset).
+    /// - Emits `(insurance, tags_add)` with `(policy_id, caller, tags)`.
+    pub fn add_tags_to_policy(env: Env, caller: Address, policy_id: u32, tags: Vec<String>) {
+        caller.require_auth();
+        let normalized_tags = Self::validate_and_normalize_tags(&env, &tags);
+        Self::extend_instance_ttl(&env);
+
+        let mut policies: Map<u32, InsurancePolicy> = env
+            .storage()
+            .instance()
+            .get(&KEY_POLICIES)
+            .unwrap_or_else(|| Map::new(&env));
+
+        let mut policy = match policies.get(policy_id) {
+            Some(p) => p,
+            None => panic!("Policy not found"),
+        };
+
+        if policy.owner != caller {
+            panic!("Only the policy owner can add tags");
+        }
+
+        for tag in normalized_tags.iter() {
+            policy.tags.push_back(tag);
+        }
+
+        policies.set(policy_id, policy);
+        env.storage().instance().set(&KEY_POLICIES, &policies);
+
+        RemitwiseEvents::emit(
+            &env,
+            EventCategory::State,
+            EventPriority::Medium,
+            symbol_short!("tags_add"),
+            (policy_id, caller.clone(), tags.clone()),
+        );
+        env.events().publish(
+            (symbol_short!("insurance"), symbol_short!("tags_add")),
+            (policy_id, caller, tags),
+        );
+    }
+
+    /// Removes tags from a policy's metadata.
+    ///
+    /// Security:
+    /// - `caller` must authorize the invocation.
+    /// - Only the policy owner can remove tags.
+    ///
+    /// Notes:
+    /// - Removing a tag that is not present is a no-op.
+    /// - Emits `(insurance, tags_rem)` with `(policy_id, caller, tags)`.
+    pub fn remove_tags_from_policy(env: Env, caller: Address, policy_id: u32, tags: Vec<String>) {
+        caller.require_auth();
+        let normalized_tags = Self::validate_and_normalize_tags(&env, &tags);
+        Self::extend_instance_ttl(&env);
+
+        let mut policies: Map<u32, InsurancePolicy> = env
+            .storage()
+            .instance()
+            .get(&KEY_POLICIES)
+            .unwrap_or_else(|| Map::new(&env));
+
+        let mut policy = match policies.get(policy_id) {
+            Some(p) => p,
+            None => panic!("Policy not found"),
+        };
+
+        if policy.owner != caller {
+            panic!("Only the policy owner can remove tags");
+        }
+
+        let mut remaining = Vec::new(&env);
+        for existing_tag in policy.tags.iter() {
+            let mut should_remove = false;
+            for tag_to_remove in normalized_tags.iter() {
+                if existing_tag == tag_to_remove {
+                    should_remove = true;
+                    break;
+                }
+            }
+            if !should_remove {
+                remaining.push_back(existing_tag);
+            }
+        }
+        policy.tags = remaining;
+
+        policies.set(policy_id, policy);
+        env.storage().instance().set(&KEY_POLICIES, &policies);
+
+        RemitwiseEvents::emit(
+            &env,
+            EventCategory::State,
+            EventPriority::Medium,
+            symbol_short!("tags_rem"),
+            (policy_id, caller.clone(), tags.clone()),
+        );
+        env.events().publish(
+            (symbol_short!("insurance"), symbol_short!("tags_rem")),
+            (policy_id, caller, tags),
+        );
     }
 }
 

--- a/remittance_split/tests/schedule_guardrail_tests.rs
+++ b/remittance_split/tests/schedule_guardrail_tests.rs
@@ -302,3 +302,231 @@ fn test_create_schedule_interval_one_second_rejected() {
         Err(Ok(RemittanceSplitError::ScheduleIntervalTooShort))
     );
 }
+
+// ---------------------------------------------------------------------------
+// Exact MIN/MAX edge boundary tests
+// ---------------------------------------------------------------------------
+
+/// Constant value pin: MIN_SCHEDULE_INTERVAL must be exactly 3 600 seconds (1 hour).
+/// Any change to this constant is a breaking protocol change and must be deliberate.
+#[test]
+fn test_min_schedule_interval_constant_value() {
+    assert_eq!(
+        MIN_SCHEDULE_INTERVAL, 3_600,
+        "MIN_SCHEDULE_INTERVAL must be exactly 3600 seconds (1 hour)"
+    );
+}
+
+/// Constant value pin: MAX_SCHEDULE_LEAD_TIME must be exactly 31 536 000 seconds (365 days).
+/// Any change to this constant is a breaking protocol change and must be deliberate.
+#[test]
+fn test_max_schedule_lead_time_constant_value() {
+    assert_eq!(
+        MAX_SCHEDULE_LEAD_TIME,
+        365 * 24 * 3_600,
+        "MAX_SCHEDULE_LEAD_TIME must be exactly 365 * 24 * 3600 seconds (1 year)"
+    );
+}
+
+/// Exact MIN edge on modify: interval == MIN_SCHEDULE_INTERVAL must be accepted.
+#[test]
+fn test_modify_schedule_at_min_interval_allowed() {
+    let (env, contract_id, owner) = setup();
+    let client = RemittanceSplitClient::new(&env, &contract_id);
+    let schedule_id = client.create_remittance_schedule(
+        &owner,
+        &1000,
+        &(env.ledger().timestamp() + 1),
+        &MIN_SCHEDULE_INTERVAL,
+    );
+    // Modify to the same exact MIN — must succeed.
+    client.modify_remittance_schedule(
+        &owner,
+        &schedule_id,
+        &2000,
+        &(env.ledger().timestamp() + 2),
+        &MIN_SCHEDULE_INTERVAL,
+    );
+    let schedule = client.get_remittance_schedule(&schedule_id).unwrap();
+    assert_eq!(schedule.interval, MIN_SCHEDULE_INTERVAL);
+    assert!(schedule.recurring);
+}
+
+/// Exact MAX edge on modify: next_due == now + MAX_SCHEDULE_LEAD_TIME must be accepted.
+#[test]
+fn test_modify_schedule_at_max_lead_time_allowed() {
+    let (env, contract_id, owner) = setup();
+    let client = RemittanceSplitClient::new(&env, &contract_id);
+    let schedule_id = client.create_remittance_schedule(
+        &owner,
+        &1000,
+        &(env.ledger().timestamp() + 1),
+        &MIN_SCHEDULE_INTERVAL,
+    );
+    let max_due = env.ledger().timestamp() + MAX_SCHEDULE_LEAD_TIME;
+    client.modify_remittance_schedule(
+        &owner,
+        &schedule_id,
+        &1000,
+        &max_due,
+        &MIN_SCHEDULE_INTERVAL,
+    );
+    let schedule = client.get_remittance_schedule(&schedule_id).unwrap();
+    assert_eq!(schedule.next_due, max_due);
+}
+
+/// Exact MIN edge on import: active schedule with interval == MIN_SCHEDULE_INTERVAL must be accepted.
+#[test]
+fn test_import_snapshot_at_min_interval_allowed() {
+    let (env, contract_id, owner) = setup();
+    let client = RemittanceSplitClient::new(&env, &contract_id);
+    let snapshot = snapshot_with_schedule(
+        &env,
+        &owner,
+        RemittanceSchedule {
+            id: 1,
+            owner: owner.clone(),
+            amount: 1000,
+            next_due: env.ledger().timestamp() + 1,
+            interval: MIN_SCHEDULE_INTERVAL,
+            recurring: true,
+            active: true,
+            created_at: env.ledger().timestamp(),
+            last_executed: None,
+            missed_count: 0,
+        },
+    );
+    assert!(
+        client.import_snapshot(&owner, &1, &snapshot),
+        "import with interval == MIN_SCHEDULE_INTERVAL must succeed"
+    );
+}
+
+/// Exact MAX edge on import: active schedule with next_due == now + MAX_SCHEDULE_LEAD_TIME must be accepted.
+#[test]
+fn test_import_snapshot_at_max_lead_time_allowed() {
+    let (env, contract_id, owner) = setup();
+    let client = RemittanceSplitClient::new(&env, &contract_id);
+    let snapshot = snapshot_with_schedule(
+        &env,
+        &owner,
+        RemittanceSchedule {
+            id: 1,
+            owner: owner.clone(),
+            amount: 1000,
+            next_due: env.ledger().timestamp() + MAX_SCHEDULE_LEAD_TIME,
+            interval: MIN_SCHEDULE_INTERVAL,
+            recurring: true,
+            active: true,
+            created_at: env.ledger().timestamp(),
+            last_executed: None,
+            missed_count: 0,
+        },
+    );
+    assert!(
+        client.import_snapshot(&owner, &1, &snapshot),
+        "import with next_due == now + MAX_SCHEDULE_LEAD_TIME must succeed"
+    );
+}
+
+/// MIN-2 is also rejected (not just MIN-1), confirming the boundary is a hard floor.
+#[test]
+fn test_create_schedule_interval_min_minus_2_rejected() {
+    let (env, contract_id, owner) = setup();
+    let client = RemittanceSplitClient::new(&env, &contract_id);
+    let next_due = env.ledger().timestamp() + 1;
+    let result = client.try_create_remittance_schedule(
+        &owner,
+        &1000,
+        &next_due,
+        &(MIN_SCHEDULE_INTERVAL - 2),
+    );
+    assert_eq!(
+        result,
+        Err(Ok(RemittanceSplitError::ScheduleIntervalTooShort)),
+        "interval == MIN-2 must also be rejected"
+    );
+}
+
+/// MAX+2 is also rejected (not just MAX+1), confirming the boundary is a hard ceiling.
+#[test]
+fn test_create_schedule_lead_time_max_plus_2_rejected() {
+    let (env, contract_id, owner) = setup();
+    let client = RemittanceSplitClient::new(&env, &contract_id);
+    let next_due = env.ledger().timestamp() + MAX_SCHEDULE_LEAD_TIME + 2;
+    let result =
+        client.try_create_remittance_schedule(&owner, &1000, &next_due, &MIN_SCHEDULE_INTERVAL);
+    assert_eq!(
+        result,
+        Err(Ok(RemittanceSplitError::ScheduleLeadTimeTooLong)),
+        "next_due == now + MAX+2 must also be rejected"
+    );
+}
+
+/// next_due == now + 1 is the minimum valid lead time (just one second in the future).
+#[test]
+fn test_create_schedule_next_due_one_second_ahead_allowed() {
+    let (env, contract_id, owner) = setup();
+    let client = RemittanceSplitClient::new(&env, &contract_id);
+    let next_due = env.ledger().timestamp() + 1;
+    let schedule_id =
+        client.create_remittance_schedule(&owner, &1000, &next_due, &MIN_SCHEDULE_INTERVAL);
+    let schedule = client.get_remittance_schedule(&schedule_id).unwrap();
+    assert_eq!(schedule.next_due, next_due);
+}
+
+/// Exact MIN-1 on import (active) is rejected — mirrors the create path.
+#[test]
+fn test_import_snapshot_interval_min_minus_1_rejected() {
+    let (env, contract_id, owner) = setup();
+    let client = RemittanceSplitClient::new(&env, &contract_id);
+    let snapshot = snapshot_with_schedule(
+        &env,
+        &owner,
+        RemittanceSchedule {
+            id: 1,
+            owner: owner.clone(),
+            amount: 1000,
+            next_due: env.ledger().timestamp() + 1,
+            interval: MIN_SCHEDULE_INTERVAL - 1,
+            recurring: true,
+            active: true,
+            created_at: env.ledger().timestamp(),
+            last_executed: None,
+            missed_count: 0,
+        },
+    );
+    assert_eq!(
+        client.try_import_snapshot(&owner, &1, &snapshot),
+        Err(Ok(RemittanceSplitError::ScheduleIntervalTooShort)),
+        "import with interval == MIN-1 must be rejected"
+    );
+}
+
+/// Exact MAX+1 on import (active) is rejected — mirrors the create path.
+#[test]
+fn test_import_snapshot_lead_time_max_plus_1_rejected() {
+    let (env, contract_id, owner) = setup();
+    let client = RemittanceSplitClient::new(&env, &contract_id);
+    let snapshot = snapshot_with_schedule(
+        &env,
+        &owner,
+        RemittanceSchedule {
+            id: 1,
+            owner: owner.clone(),
+            amount: 1000,
+            next_due: env.ledger().timestamp() + MAX_SCHEDULE_LEAD_TIME + 1,
+            interval: MIN_SCHEDULE_INTERVAL,
+            recurring: true,
+            active: true,
+            created_at: env.ledger().timestamp(),
+            last_executed: None,
+            missed_count: 0,
+        },
+    );
+    assert_eq!(
+        client.try_import_snapshot(&owner, &1, &snapshot),
+        Err(Ok(RemittanceSplitError::ScheduleLeadTimeTooLong)),
+        "import with next_due == now + MAX+1 must be rejected"
+    );
+}

--- a/remitwise-common/src/lib.rs
+++ b/remitwise-common/src/lib.rs
@@ -99,6 +99,75 @@ pub fn clamp_limit(limit: u32) -> u32 {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Tag canonicalization
+// ---------------------------------------------------------------------------
+
+/// Maximum allowed byte length for a single tag.
+pub const TAG_MAX_LEN: u32 = 32;
+
+/// Validates and canonicalizes a batch of tags.
+///
+/// # Rules
+/// - The batch must contain at least one tag (`panic!("Tags cannot be empty")`).
+/// - Each tag must be between 1 and `TAG_MAX_LEN` bytes inclusive
+///   (`panic!("Tag must be between 1 and 32 characters")`).
+/// - Allowed charset: `[a-z0-9\-_]`.  ASCII uppercase letters are silently
+///   folded to lowercase; any other byte causes the supplied `on_invalid_char`
+///   closure to be called (typically `panic_with_error!` or `panic!`).
+///
+/// # Returns
+/// A new `Vec<String>` containing the normalized (lowercased) tags in the
+/// same order as the input.
+///
+/// # Usage
+/// ```ignore
+/// use remitwise_common::canonicalize_tags;
+/// let normalized = canonicalize_tags(&env, &tags, || {
+///     soroban_sdk::panic_with_error!(&env, MyError::InvalidTagContent)
+/// });
+/// ```
+pub fn canonicalize_tags<F>(
+    env: &soroban_sdk::Env,
+    tags: &soroban_sdk::Vec<soroban_sdk::String>,
+    on_invalid_char: F,
+) -> soroban_sdk::Vec<soroban_sdk::String>
+where
+    F: Fn(),
+{
+    if tags.is_empty() {
+        panic!("Tags cannot be empty");
+    }
+    let mut out = soroban_sdk::Vec::new(env);
+    for tag in tags.iter() {
+        let len = tag.len();
+        if len == 0 || len > TAG_MAX_LEN {
+            panic!("Tag must be between 1 and 32 characters");
+        }
+        let mut buf = [0u8; 32];
+        tag.copy_into_slice(&mut buf[..len as usize]);
+        for byte in buf.iter_mut().take(len as usize) {
+            if byte.is_ascii_uppercase() {
+                *byte += b'a' - b'A';
+            }
+            let b = *byte;
+            if !(b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-' || b == b'_') {
+                on_invalid_char();
+            }
+        }
+        let s = match core::str::from_utf8(&buf[..len as usize]) {
+            Ok(v) => v,
+            Err(_) => {
+                on_invalid_char();
+                // on_invalid_char must diverge (panic); this is unreachable.
+                ""
+            }
+        };
+        out.push_back(soroban_sdk::String::from_str(env, s));
+    }
+    out
+}
+
 /// Event emission helper
 pub struct RemitwiseEvents;
 

--- a/savings_goals/src/lib.rs
+++ b/savings_goals/src/lib.rs
@@ -610,45 +610,14 @@ impl SavingsGoalContract {
     // Tag management
     // -----------------------------------------------------------------------
 
-    /// Validates a tag batch for metadata operations.
+    /// Validates and canonicalizes a tag batch for metadata operations.
     ///
-    /// Requirements:
-    /// - At least one tag must be provided.
-    /// - Each tag length must be between 1 and 32 characters.
-    /// - Allowed charset: [a-z0-9-_]. Uppercase is normalized to lowercase.
+    /// Delegates to the shared [`remitwise_common::canonicalize_tags`] helper.
+    /// Invalid characters are reported as [`SavingsGoalError::InvalidTagContent`].
     fn validate_and_normalize_tags(env: &Env, tags: &Vec<String>) -> Vec<String> {
-        if tags.is_empty() {
-            panic!("Tags cannot be empty");
-        }
-        let mut normalized_tags = Vec::new(env);
-        for tag in tags.iter() {
-            let len = tag.len();
-            if len == 0 || len > 32 {
-                panic!("Tag must be between 1 and 32 characters");
-            }
-            let mut buf = [0u8; 32];
-            tag.copy_into_slice(&mut buf[..len as usize]);
-
-            for c in buf.iter_mut().take(len as usize) {
-                if c.is_ascii_uppercase() {
-                    *c += b'a' - b'A';
-                }
-                let c_val = *c;
-                if !(c_val.is_ascii_lowercase()
-                    || c_val.is_ascii_digit()
-                    || c_val == b'-'
-                    || c_val == b'_')
-                {
-                    soroban_sdk::panic_with_error!(env, SavingsGoalError::InvalidTagContent);
-                }
-            }
-            let s = match core::str::from_utf8(&buf[..len as usize]) {
-                Ok(v) => v,
-                Err(_) => soroban_sdk::panic_with_error!(env, SavingsGoalError::InvalidTagContent),
-            };
-            normalized_tags.push_back(String::from_str(env, s));
-        }
-        normalized_tags
+        remitwise_common::canonicalize_tags(env, tags, || {
+            soroban_sdk::panic_with_error!(env, SavingsGoalError::InvalidTagContent)
+        })
     }
 
     /// Adds tags to a goal's metadata.


### PR DESCRIPTION
four  independent improvements: a shared tag/charset canonicalization helper extracted into remitwise-common and consumed by all three tag-bearing contracts, and a comprehensive set of exact MIN/MAX boundary tests for the remittance schedule guardrails.

Changes
remitwise-common

Added canonicalize_tags(env, tags, on_invalid_char) — the single source of truth for tag validation and normalization. Enforces the [a-z0-9\-_] charset, folds uppercase to lowercase, and rejects tags outside the 1–32 byte length range. The on_invalid_char closure lets each caller surface its own contract-specific error variant.
Added TAG_MAX_LEN: u32 = 32 constant.
savings_goals / bill_payments

closes #613

Replaced the duplicated validate_and_normalize_tags implementations with a one-liner delegation to remitwise_common::canonicalize_tags. Behavior is identical; the error variants (SavingsGoalError::InvalidTagContent, BillPaymentsError::InvalidTagContent) are preserved.
insurance

closes #619


Added InsuranceError::InvalidTagContent = 6.
Added tags: Vec<String> field to InsurancePolicy and ArchivedPolicy (initialized to empty on creation, carried through archive/restore).
Added add_tags_to_policy and remove_tags_from_policy public methods, both backed by the shared helper. Emits (insurance, tags_add) / (insurance, tags_rem) events matching the pattern used by savings and bills.
schedule_guardrail_tests.rs


closes #649


Added 11 new boundary tests covering the exact MIN/MAX edges that were previously untested:
Constant value pins for MIN_SCHEDULE_INTERVAL (3 600 s) and MAX_SCHEDULE_LEAD_TIME (31 536 000 s)
modify path: exact MIN interval accepted, exact MAX lead time accepted
import_snapshot path: exact MIN interval accepted, exact MAX lead time accepted, MIN−1 rejected, MAX+1 rejected
Additional sub-boundary checks: MIN−2 rejected, MAX+2 rejected, next_due = now+1 accepted


closes #656