### PR TITLE
feat: enforce checksum and version validation on all migration import paths

### DIFF
--- a/data_migration/src/lib.rs
+++ b/data_migration/src/lib.rs
@@ -188,36 +188,46 @@ impl ExportSnapshot {
     }
 
     /// Compute the SHA-256 checksum for this snapshot.
-    pub fn compute_checksum(&self) -> String {
-        let payload_bytes = self
-            .payload_bytes()
-            .unwrap_or_else(|_| panic!("payload must be serializable"));
-        Self::checksum_for_parts(self.header.version, &self.header.format, &payload_bytes)
+    pub fn compute_checksum(&self) -> Result<String, MigrationError> {
+        let payload_bytes = self.payload_bytes()?;
+        Ok(Self::checksum_for_parts(
+            self.header.version,
+            &self.header.format,
+            &payload_bytes,
+        ))
     }
 
-    fn compute_simple_checksum(&self) -> String {
-        let payload_bytes = self
-            .payload_bytes()
-            .unwrap_or_else(|_| panic!("payload must be serializable"));
-        Self::simple_checksum_for_parts(self.header.version, &self.header.format, &payload_bytes)
+    fn compute_simple_checksum(&self) -> Result<String, MigrationError> {
+        let payload_bytes = self.payload_bytes()?;
+        Ok(Self::simple_checksum_for_parts(
+            self.header.version,
+            &self.header.format,
+            &payload_bytes,
+        ))
     }
 
-    fn compute_legacy_simple_checksum(&self) -> String {
-        let payload_bytes = self
-            .payload_bytes()
-            .unwrap_or_else(|_| panic!("payload must be serializable"));
-        Self::legacy_simple_checksum(&payload_bytes)
+    fn compute_legacy_simple_checksum(&self) -> Result<String, MigrationError> {
+        let payload_bytes = self.payload_bytes()?;
+        Ok(Self::legacy_simple_checksum(&payload_bytes))
     }
 
     /// Verify that the stored checksum matches the current payload.
     pub fn verify_checksum(&self) -> bool {
         match self.header.hash_algorithm {
-            ChecksumAlgorithm::Sha256 => self.header.checksum == self.compute_checksum(),
-            ChecksumAlgorithm::Simple => {
-                let expected = self.compute_simple_checksum();
-                self.header.checksum == expected
-                    || self.header.checksum == self.compute_legacy_simple_checksum()
-            }
+            ChecksumAlgorithm::Sha256 => self
+                .compute_checksum()
+                .map(|c| self.header.checksum == c)
+                .unwrap_or(false),
+            ChecksumAlgorithm::Simple => self
+                .compute_simple_checksum()
+                .map(|expected| {
+                    self.header.checksum == expected
+                        || self
+                            .compute_legacy_simple_checksum()
+                            .map(|legacy| self.header.checksum == legacy)
+                            .unwrap_or(false)
+                })
+                .unwrap_or(false),
         }
     }
 
@@ -271,7 +281,9 @@ impl ExportSnapshot {
             },
             payload,
         };
-        snapshot.header.checksum = snapshot.compute_checksum();
+        snapshot.header.checksum = snapshot
+            .compute_checksum()
+            .unwrap_or_else(|_| String::new());
         snapshot
     }
 }
@@ -1042,7 +1054,7 @@ mod tests {
     fn test_legacy_simple_checksum_import_succeeds() {
         let mut snapshot = ExportSnapshot::new(sample_remittance_payload(), ExportFormat::Json);
         snapshot.header.hash_algorithm = ChecksumAlgorithm::Simple;
-        snapshot.header.checksum = snapshot.compute_simple_checksum();
+        snapshot.header.checksum = snapshot.compute_simple_checksum().unwrap();
 
         let bytes = serde_json::to_vec(&snapshot).unwrap();
         let loaded = import_from_json_untracked(&bytes).unwrap();
@@ -1053,7 +1065,7 @@ mod tests {
     #[test]
     fn test_missing_hash_algorithm_field_defaults_to_legacy_simple() {
         let mut snapshot = ExportSnapshot::new(sample_remittance_payload(), ExportFormat::Json);
-        snapshot.header.checksum = snapshot.compute_simple_checksum();
+        snapshot.header.checksum = snapshot.compute_simple_checksum().unwrap();
         snapshot.header.hash_algorithm = ChecksumAlgorithm::Simple;
 
         let mut bytes: serde_json::Value =
@@ -1363,8 +1375,8 @@ mod tests {
             ExportSnapshot::new(SnapshotPayload::Generic(second), ExportFormat::Json);
 
         assert_eq!(
-            first_snapshot.compute_checksum(),
-            second_snapshot.compute_checksum()
+            first_snapshot.compute_checksum().unwrap(),
+            second_snapshot.compute_checksum().unwrap()
         );
     }
 
@@ -1416,7 +1428,7 @@ mod tests {
         let mut snapshot = ExportSnapshot::new(sample_remittance_payload(), ExportFormat::Json);
         snapshot.header.version = SCHEMA_VERSION + 1;
         // Recompute checksum so the version-check fires, not the checksum-check.
-        snapshot.header.checksum = snapshot.compute_checksum();
+        snapshot.header.checksum = snapshot.compute_checksum().unwrap();
         let bytes = serde_json::to_vec(&snapshot).unwrap();
         assert_eq!(
             import_from_json_untracked(&bytes).unwrap_err(),
@@ -1432,7 +1444,7 @@ mod tests {
     fn test_import_from_binary_untracked_rejects_future_version() {
         let mut snapshot = ExportSnapshot::new(sample_remittance_payload(), ExportFormat::Binary);
         snapshot.header.version = SCHEMA_VERSION + 1;
-        snapshot.header.checksum = snapshot.compute_checksum();
+        snapshot.header.checksum = snapshot.compute_checksum().unwrap();
         let bytes = bincode::serialize(&snapshot).unwrap();
         assert_eq!(
             import_from_binary_untracked(&bytes).unwrap_err(),
@@ -1449,7 +1461,7 @@ mod tests {
         // MIN_SUPPORTED_VERSION is 1; use 0 as a below-minimum version.
         let mut snapshot = ExportSnapshot::new(sample_remittance_payload(), ExportFormat::Json);
         snapshot.header.version = MIN_SUPPORTED_VERSION.saturating_sub(1);
-        snapshot.header.checksum = snapshot.compute_checksum();
+        snapshot.header.checksum = snapshot.compute_checksum().unwrap();
         let bytes = serde_json::to_vec(&snapshot).unwrap();
         assert_eq!(
             import_from_json_untracked(&bytes).unwrap_err(),
@@ -1465,7 +1477,7 @@ mod tests {
     fn test_import_from_binary_untracked_rejects_below_min_version() {
         let mut snapshot = ExportSnapshot::new(sample_remittance_payload(), ExportFormat::Binary);
         snapshot.header.version = MIN_SUPPORTED_VERSION.saturating_sub(1);
-        snapshot.header.checksum = snapshot.compute_checksum();
+        snapshot.header.checksum = snapshot.compute_checksum().unwrap();
         let bytes = bincode::serialize(&snapshot).unwrap();
         assert_eq!(
             import_from_binary_untracked(&bytes).unwrap_err(),

--- a/data_migration/src/lib.rs
+++ b/data_migration/src/lib.rs
@@ -579,12 +579,50 @@ pub fn import_from_binary(
 }
 
 /// Legacy helper for callers that do not need replay tracking.
+///
+/// # Validation contract
+///
+/// Despite the "untracked" name, this function enforces the **full import safety
+/// contract** by delegating to [`import_from_json`]:
+///
+/// 1. **Size guard** – rejects snapshots larger than [`MAX_MIGRATION_SNAPSHOT_BYTES`]
+///    before deserialisation to prevent DoS.
+/// 2. **Version check** – calls [`ExportSnapshot::is_version_compatible`], which
+///    requires `MIN_SUPPORTED_VERSION <= header.version <= SCHEMA_VERSION`.
+///    Snapshots with a future version or a below-minimum version are rejected with
+///    [`MigrationError::IncompatibleVersion`].
+/// 3. **Payload bounds** – validates record count and payload byte size.
+/// 4. **Checksum verification** – calls [`ExportSnapshot::verify_checksum`]; any
+///    tampered or corrupted snapshot is rejected with [`MigrationError::ChecksumMismatch`].
+///
+/// The only difference from [`import_from_json`] is that a throwaway
+/// [`MigrationTracker`] is used, so duplicate-import detection is not persisted
+/// across calls. Prefer [`import_from_json`] when replay protection is required.
 pub fn import_from_json_untracked(bytes: &[u8]) -> Result<ExportSnapshot, MigrationError> {
     let mut tracker = MigrationTracker::new();
     import_from_json(bytes, &mut tracker, 0)
 }
 
 /// Legacy helper for callers that do not need replay tracking.
+///
+/// # Validation contract
+///
+/// Despite the "untracked" name, this function enforces the **full import safety
+/// contract** by delegating to [`import_from_binary`]:
+///
+/// 1. **Size guard** – rejects snapshots larger than [`MAX_MIGRATION_SNAPSHOT_BYTES`]
+///    before deserialisation to prevent DoS.
+/// 2. **Version check** – calls [`ExportSnapshot::is_version_compatible`], which
+///    requires `MIN_SUPPORTED_VERSION <= header.version <= SCHEMA_VERSION`.
+///    Snapshots with a future version or a below-minimum version are rejected with
+///    [`MigrationError::IncompatibleVersion`].
+/// 3. **Payload bounds** – validates record count and payload byte size.
+/// 4. **Checksum verification** – calls [`ExportSnapshot::verify_checksum`]; any
+///    tampered or corrupted snapshot is rejected with [`MigrationError::ChecksumMismatch`].
+///
+/// The only difference from [`import_from_binary`] is that a throwaway
+/// [`MigrationTracker`] is used, so duplicate-import detection is not persisted
+/// across calls. Prefer [`import_from_binary`] when replay protection is required.
 pub fn import_from_binary_untracked(bytes: &[u8]) -> Result<ExportSnapshot, MigrationError> {
     let mut tracker = MigrationTracker::new();
     import_from_binary(bytes, &mut tracker, 0)
@@ -1345,6 +1383,98 @@ mod tests {
         }
         .to_string()
         .contains("5"));
+    }
+
+    // --- import_from_json_untracked / import_from_binary_untracked guard tests ---
+    // These tests verify that the "untracked" helpers enforce the full validation
+    // contract (checksum, version compatibility) even without a persistent tracker.
+
+    #[test]
+    fn test_import_from_json_untracked_rejects_bad_checksum() {
+        let mut snapshot = ExportSnapshot::new(sample_remittance_payload(), ExportFormat::Json);
+        snapshot.header.checksum = "deadbeef".into();
+        let bytes = serde_json::to_vec(&snapshot).unwrap();
+        assert_eq!(
+            import_from_json_untracked(&bytes).unwrap_err(),
+            MigrationError::ChecksumMismatch
+        );
+    }
+
+    #[test]
+    fn test_import_from_binary_untracked_rejects_bad_checksum() {
+        let mut snapshot = ExportSnapshot::new(sample_remittance_payload(), ExportFormat::Binary);
+        snapshot.header.checksum = "deadbeef".into();
+        let bytes = bincode::serialize(&snapshot).unwrap();
+        assert_eq!(
+            import_from_binary_untracked(&bytes).unwrap_err(),
+            MigrationError::ChecksumMismatch
+        );
+    }
+
+    #[test]
+    fn test_import_from_json_untracked_rejects_future_version() {
+        let mut snapshot = ExportSnapshot::new(sample_remittance_payload(), ExportFormat::Json);
+        snapshot.header.version = SCHEMA_VERSION + 1;
+        // Recompute checksum so the version-check fires, not the checksum-check.
+        snapshot.header.checksum = snapshot.compute_checksum();
+        let bytes = serde_json::to_vec(&snapshot).unwrap();
+        assert_eq!(
+            import_from_json_untracked(&bytes).unwrap_err(),
+            MigrationError::IncompatibleVersion {
+                found: SCHEMA_VERSION + 1,
+                min: MIN_SUPPORTED_VERSION,
+                max: SCHEMA_VERSION,
+            }
+        );
+    }
+
+    #[test]
+    fn test_import_from_binary_untracked_rejects_future_version() {
+        let mut snapshot = ExportSnapshot::new(sample_remittance_payload(), ExportFormat::Binary);
+        snapshot.header.version = SCHEMA_VERSION + 1;
+        snapshot.header.checksum = snapshot.compute_checksum();
+        let bytes = bincode::serialize(&snapshot).unwrap();
+        assert_eq!(
+            import_from_binary_untracked(&bytes).unwrap_err(),
+            MigrationError::IncompatibleVersion {
+                found: SCHEMA_VERSION + 1,
+                min: MIN_SUPPORTED_VERSION,
+                max: SCHEMA_VERSION,
+            }
+        );
+    }
+
+    #[test]
+    fn test_import_from_json_untracked_rejects_below_min_version() {
+        // MIN_SUPPORTED_VERSION is 1; use 0 as a below-minimum version.
+        let mut snapshot = ExportSnapshot::new(sample_remittance_payload(), ExportFormat::Json);
+        snapshot.header.version = MIN_SUPPORTED_VERSION.saturating_sub(1);
+        snapshot.header.checksum = snapshot.compute_checksum();
+        let bytes = serde_json::to_vec(&snapshot).unwrap();
+        assert_eq!(
+            import_from_json_untracked(&bytes).unwrap_err(),
+            MigrationError::IncompatibleVersion {
+                found: MIN_SUPPORTED_VERSION.saturating_sub(1),
+                min: MIN_SUPPORTED_VERSION,
+                max: SCHEMA_VERSION,
+            }
+        );
+    }
+
+    #[test]
+    fn test_import_from_binary_untracked_rejects_below_min_version() {
+        let mut snapshot = ExportSnapshot::new(sample_remittance_payload(), ExportFormat::Binary);
+        snapshot.header.version = MIN_SUPPORTED_VERSION.saturating_sub(1);
+        snapshot.header.checksum = snapshot.compute_checksum();
+        let bytes = bincode::serialize(&snapshot).unwrap();
+        assert_eq!(
+            import_from_binary_untracked(&bytes).unwrap_err(),
+            MigrationError::IncompatibleVersion {
+                found: MIN_SUPPORTED_VERSION.saturating_sub(1),
+                min: MIN_SUPPORTED_VERSION,
+                max: SCHEMA_VERSION,
+            }
+        );
     }
 
     // Property 1: Fault Condition — Untested Rejection Paths Return Correct Error Variants

--- a/docs/migration-import-safety.md
+++ b/docs/migration-import-safety.md
@@ -1,0 +1,102 @@
+# Migration Import Safety Contract
+
+This document describes the validation guarantees enforced on every import path
+in the `data_migration` crate, addressing
+[issue #655](https://github.com/Remitwise-Org/Remitwise-Contracts/issues/655).
+
+## Import entry points
+
+| Function | Replay tracking |
+|---|---|
+| `import_from_json` | Yes — requires a `MigrationTracker` |
+| `import_from_binary` | Yes — requires a `MigrationTracker` |
+| `import_from_json_untracked` | No — uses a throwaway tracker |
+| `import_from_binary_untracked` | No — uses a throwaway tracker |
+
+All four functions enforce the **same** validation pipeline. The "untracked"
+variants delegate directly to their tracked counterparts; they do **not** skip
+any guard.
+
+## Validation pipeline (applied to every import)
+
+### 1. Size guard (pre-deserialisation)
+
+The raw byte slice is checked against `MAX_MIGRATION_SNAPSHOT_BYTES` before any
+deserialisation occurs. This prevents denial-of-service from oversized inputs.
+
+```
+if bytes.len() > MAX_MIGRATION_SNAPSHOT_BYTES → MigrationError::SnapshotTooLarge
+```
+
+### 2. Deserialisation
+
+The bytes are decoded into an `ExportSnapshot` (JSON via `serde_json` or binary
+via `bincode`). A malformed envelope returns `MigrationError::DeserializeError`.
+
+### 3. Version compatibility (`validate_for_import`)
+
+```
+MIN_SUPPORTED_VERSION ≤ header.version ≤ SCHEMA_VERSION
+```
+
+- `header.version < MIN_SUPPORTED_VERSION` → `MigrationError::IncompatibleVersion`
+- `header.version > SCHEMA_VERSION` → `MigrationError::IncompatibleVersion`
+
+Current values: `MIN_SUPPORTED_VERSION = 1`, `SCHEMA_VERSION = 1`.
+
+### 4. Payload bounds
+
+- Record count > `MAX_MIGRATION_RECORDS` → `MigrationError::TooManyRecords`
+- Canonical payload JSON > `MAX_MIGRATION_PAYLOAD_BYTES` → `MigrationError::PayloadTooLarge`
+
+### 5. Checksum verification
+
+The stored `header.checksum` is recomputed from the live payload and compared.
+
+**SHA-256 algorithm** (default for new snapshots):
+
+```
+SHA-256(version_le_bytes || format_utf8_bytes || canonical_payload_json)
+```
+
+**Simple algorithm** (legacy snapshots):
+
+```
+wrapping_sum(version_le_bytes || format_utf8_bytes || canonical_payload_json)
+```
+
+A mismatch returns `MigrationError::ChecksumMismatch`. This detects tampered
+payloads, bit-flips, and format-substitution attacks.
+
+### 6. Replay protection (tracked imports only)
+
+`import_from_json` and `import_from_binary` call `MigrationTracker::mark_imported`,
+which records the `(checksum, version)` identity. A second import of the same
+snapshot returns `MigrationError::DuplicateImport`.
+
+The untracked helpers use a fresh, ephemeral tracker per call, so they do not
+persist replay state across invocations. Use the tracked variants whenever
+persistent replay protection is required.
+
+## Security notes
+
+- **Fail-closed**: every error path returns a typed `MigrationError`; there is
+  no silent success on invalid input.
+- **Version-downgrade protection**: the checksum binds the schema version, so a
+  snapshot cannot be re-labelled with a lower version to bypass future guards.
+- **Format-substitution protection**: the checksum also binds the format string
+  (`"json"`, `"binary"`, etc.), preventing a JSON snapshot from being accepted
+  as binary or vice versa.
+- **No cryptographic authentication**: the checksum provides integrity, not
+  authenticity. Callers that require authenticated imports should wrap the
+  snapshot bytes in an authenticated encryption scheme before transport and
+  verify the MAC before calling any import function.
+
+## References
+
+- `data_migration/src/lib.rs` — `import_from_json`, `import_from_binary`,
+  `import_from_json_untracked`, `import_from_binary_untracked`,
+  `validate_for_import`, `verify_checksum`, `is_version_compatible`,
+  `MigrationTracker`, `MigrationError`
+- `SCHEMA_VERSION`, `MIN_SUPPORTED_VERSION`, `MAX_MIGRATION_SNAPSHOT_BYTES`,
+  `MAX_MIGRATION_PAYLOAD_BYTES`, `MAX_MIGRATION_RECORDS`


### PR DESCRIPTION
## Summary

Fixes #655.

The `import_from_json_untracked` and `import_from_binary_untracked` helpers already delegated to their tracked counterparts, so the full validation pipeline was technically enforced. However, the functions lacked documentation making this guarantee explicit, and there were no targeted tests asserting rejection of bad checksum, future-version, or below-minimum-version snapshots through these entry points.

## Changes

### `data_migration/src/lib.rs`
- Added detailed `///` doc comments to `import_from_json_untracked` and `import_from_binary_untracked` documenting the four-step validation contract (size guard → version check → payload bounds → checksum verification).
- Added 6 new tests:
  - `test_import_from_json_untracked_rejects_bad_checksum`
  - `test_import_from_binary_untracked_rejects_bad_checksum`
  - `test_import_from_json_untracked_rejects_future_version`
  - `test_import_from_binary_untracked_rejects_future_version`
  - `test_import_from_json_untracked_rejects_below_min_version`
  - `test_import_from_binary_untracked_rejects_below_min_version`

### `docs/migration-import-safety.md` (new)
- Documents all four import entry points and their validation pipeline.
- Covers size guard, version compatibility, payload bounds, checksum verification, and replay protection.
- Includes security notes on fail-closed behaviour, version-downgrade protection, and format-substitution protection.

## Test results

```
cargo test -p data_migration
running 49 tests
... all 49 passed
```