### PR TITLE
feat(family-wallet): enforce quorum re-validation when membership changes invalidate in-flight proposals

### DIFF
--- a/family_wallet/src/lib.rs
+++ b/family_wallet/src/lib.rs
@@ -193,6 +193,14 @@ pub struct SpendingLimitUpdatedEvent {
 
 #[contracttype]
 #[derive(Clone)]
+pub struct ProposalInvalidatedEvent {
+    pub tx_id: u64,
+    pub reason: Symbol,
+    pub timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone)]
 pub struct ArchivedTransaction {
     pub tx_id: u64,
     pub tx_type: TransactionType,
@@ -279,6 +287,7 @@ pub enum Error {
     InvalidPrecisionConfig = 20,
     InvalidProposalExpiry = 21,
     MemberAlreadyExists = 22,
+    QuorumUnachievable = 23,
 }
 
 #[contractimpl]
@@ -1178,6 +1187,10 @@ impl FamilyWallet {
             .instance()
             .set(&symbol_short!("MEMBERS"), &members);
 
+        // Re-validate in-flight proposals: strip signatures from the removed
+        // member and invalidate any proposal that can no longer reach quorum.
+        Self::revalidate_proposals_after_membership_change(&env);
+
         Self::append_access_audit(&env, symbol_short!("rem_mem"), &caller, Some(member), true);
         true
     }
@@ -2054,6 +2067,11 @@ impl FamilyWallet {
             .instance()
             .set(&symbol_short!("MEMBERS"), &members_map);
         Self::update_storage_stats(&env);
+
+        // Re-validate in-flight proposals after batch removal: strip signatures
+        // from removed members and invalidate proposals that can no longer reach quorum.
+        Self::revalidate_proposals_after_membership_change(&env);
+
         count
     }
 
@@ -2148,9 +2166,147 @@ impl FamilyWallet {
         }
     }
 
+    /// Manually trigger quorum re-validation for all in-flight proposals.
+    ///
+    /// This is useful after any membership or multisig-config change to ensure
+    /// proposals that can no longer reach quorum are invalidated immediately.
+    ///
+    /// # Authorization
+    /// Owner or Admin only.
+    ///
+    /// # Returns
+    /// The number of proposals that were invalidated (expired early).
+    pub fn revalidate_proposals(env: Env, caller: Address) -> u32 {
+        caller.require_auth();
+        Self::require_not_paused(&env);
+        if !Self::is_owner_or_admin(&env, &caller) {
+            panic_with_error!(&env, Error::Unauthorized);
+        }
+        Self::extend_instance_ttl(&env);
+        Self::revalidate_proposals_after_membership_change(&env)
+    }
+
     // -----------------------------------------------------------------------
     // Internal helpers
     // -----------------------------------------------------------------------
+
+    /// Re-validate every in-flight proposal against the current membership and
+    /// multisig configuration.
+    ///
+    /// For each pending proposal this function:
+    /// 1. Strips signatures from addresses that are no longer active members.
+    /// 2. Checks whether the remaining eligible signers in the multisig config
+    ///    can still satisfy the threshold.
+    /// 3. If quorum is unachievable, the proposal is invalidated by setting its
+    ///    `expires_at` to the current ledger timestamp (effectively expired) and
+    ///    emitting a `ProposalInvalidatedEvent`.
+    ///
+    /// Returns the count of proposals that were invalidated.
+    fn revalidate_proposals_after_membership_change(env: &Env) -> u32 {
+        let members: Map<Address, FamilyMember> = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("MEMBERS"))
+            .unwrap_or_else(|| Map::new(env));
+
+        let mut pending_txs: Map<u64, PendingTransaction> = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("PEND_TXS"))
+            .unwrap_or_else(|| Map::new(env));
+
+        let now = env.ledger().timestamp();
+        let mut invalidated_count = 0u32;
+        let mut updated_txs: Vec<(u64, PendingTransaction)> = Vec::new(env);
+
+        for (tx_id, mut tx) in pending_txs.iter() {
+            // Skip already-expired proposals — they will be cleaned up separately.
+            if tx.expires_at <= now {
+                continue;
+            }
+
+            // --- Step 1: strip signatures from addresses no longer in the wallet ---
+            let mut valid_sigs: Vec<Address> = Vec::new(env);
+            for sig in tx.signatures.iter() {
+                if members.get(sig.clone()).is_some()
+                    && !Self::role_has_expired(env, &sig)
+                {
+                    valid_sigs.push_back(sig);
+                }
+            }
+            tx.signatures = valid_sigs;
+
+            // --- Step 2: count eligible signers in the multisig config ---
+            let config_key = Self::get_config_key(tx.tx_type);
+            let config: MultiSigConfig = match env.storage().instance().get(&config_key) {
+                Some(c) => c,
+                None => {
+                    // No config means the proposal can never execute — invalidate it.
+                    tx.expires_at = now;
+                    invalidated_count += 1;
+                    RemitwiseEvents::emit(
+                        env,
+                        EventCategory::System,
+                        EventPriority::High,
+                        symbol_short!("inv_prop"),
+                        ProposalInvalidatedEvent {
+                            tx_id,
+                            reason: symbol_short!("no_cfg"),
+                            timestamp: now,
+                        },
+                    );
+                    updated_txs.push_back((tx_id, tx));
+                    continue;
+                }
+            };
+
+            // Count how many configured signers are still active members.
+            let mut eligible_signers = 0u32;
+            for signer in config.signers.iter() {
+                if members.get(signer.clone()).is_some()
+                    && !Self::role_has_expired(env, &signer)
+                {
+                    eligible_signers += 1;
+                }
+            }
+
+            // --- Step 3: invalidate if quorum is now unachievable ---
+            // Quorum is unachievable when the total number of eligible signers
+            // (including those who already signed) is less than the threshold.
+            // We use `eligible_signers` from the config list because only
+            // configured signers are allowed to sign (see `sign_transaction`).
+            if eligible_signers < config.threshold {
+                tx.expires_at = now;
+                invalidated_count += 1;
+                RemitwiseEvents::emit(
+                    env,
+                    EventCategory::System,
+                    EventPriority::High,
+                    symbol_short!("inv_prop"),
+                    ProposalInvalidatedEvent {
+                        tx_id,
+                        reason: symbol_short!("no_qrm"),
+                        timestamp: now,
+                    },
+                );
+            }
+
+            updated_txs.push_back((tx_id, tx));
+        }
+
+        // Persist all modified proposals back to storage.
+        for i in 0..updated_txs.len() {
+            if let Some((tx_id, tx)) = updated_txs.get(i) {
+                pending_txs.set(tx_id, tx);
+            }
+        }
+
+        env.storage()
+            .instance()
+            .set(&symbol_short!("PEND_TXS"), &pending_txs);
+
+        invalidated_count
+    }
 
     /// Enforces the emergency transfer daily volume cap and persists the updated `EM_VOL`.
     ///

--- a/family_wallet/src/test.rs
+++ b/family_wallet/src/test.rs
@@ -3262,3 +3262,230 @@ fn test_audit_page_cursor_stable_across_calls() {
         assert_eq!(a.timestamp, b.timestamp);
     }
 }
+
+// ============================================================================
+// Quorum Re-validation Tests
+//
+// Verify that removing members invalidates in-flight proposals that can no
+// longer reach their required signature threshold, and that valid proposals
+// survive when quorum is still achievable after membership changes.
+// ============================================================================
+
+/// Removing the only signer from a pending proposal must invalidate it
+/// immediately by setting expires_at to the current ledger timestamp.
+#[test]
+fn test_remove_sole_signer_invalidates_proposal() {
+    let env = Env::default();
+    env.mock_all_auths();
+    set_ledger_time(&env, 100, 1_000);
+
+    let contract_id = env.register_contract(None, FamilyWallet);
+    let client = FamilyWalletClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let signer = Address::generate(&env);
+
+    client.init(&owner, &vec![&env, signer.clone()]);
+
+    // Configure multisig: threshold=1, only `signer` is authorised.
+    let signers = vec![&env, signer.clone()];
+    client.configure_multisig(&owner, &TransactionType::RoleChange, &1, &signers, &0);
+
+    // Propose a role change — proposal is now in-flight.
+    let tx_id = client.propose_role_change(&owner, &signer, &FamilyRole::Admin);
+    assert!(tx_id > 0);
+
+    // Sanity: proposal is live before removal.
+    let before = client.get_pending_transaction(&tx_id).unwrap();
+    assert!(before.expires_at > 1_000);
+
+    // Remove the sole configured signer.
+    client.remove_family_member(&owner, &signer);
+
+    // The proposal must now be expired (expires_at == ledger timestamp).
+    let after = client.get_pending_transaction(&tx_id).unwrap();
+    assert_eq!(
+        after.expires_at, 1_000,
+        "Proposal must be invalidated (expires_at set to now) after sole signer removed"
+    );
+
+    // Attempting to sign the invalidated proposal must fail.
+    let result = client.try_sign_transaction(&owner, &tx_id);
+    assert!(result.is_err(), "Signing an invalidated proposal must fail");
+}
+
+/// Removing one signer when remaining eligible signers still meet the
+/// threshold must leave the proposal active and signable.
+#[test]
+fn test_remove_one_signer_proposal_survives_when_quorum_still_met() {
+    let env = Env::default();
+    env.mock_all_auths();
+    set_ledger_time(&env, 100, 1_000);
+
+    let contract_id = env.register_contract(None, FamilyWallet);
+    let client = FamilyWalletClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let signer_a = Address::generate(&env);
+    let signer_b = Address::generate(&env);
+    let signer_c = Address::generate(&env);
+
+    client.init(
+        &owner,
+        &vec![&env, signer_a.clone(), signer_b.clone(), signer_c.clone()],
+    );
+
+    // threshold=2, three signers — removing one still leaves two eligible.
+    let signers = vec![&env, signer_a.clone(), signer_b.clone(), signer_c.clone()];
+    client.configure_multisig(&owner, &TransactionType::RoleChange, &2, &signers, &0);
+
+    let tx_id = client.propose_role_change(&owner, &signer_a, &FamilyRole::Admin);
+    assert!(tx_id > 0);
+
+    let original_expiry = client.get_pending_transaction(&tx_id).unwrap().expires_at;
+
+    // Remove signer_c — two eligible signers remain, threshold still reachable.
+    client.remove_family_member(&owner, &signer_c);
+
+    let after = client.get_pending_transaction(&tx_id).unwrap();
+    assert_eq!(
+        after.expires_at, original_expiry,
+        "Proposal expiry must be unchanged when quorum is still achievable"
+    );
+}
+
+/// Batch-removing members that collectively drop eligible signers below the
+/// threshold must invalidate all affected proposals in a single pass.
+#[test]
+fn test_batch_remove_invalidates_proposals_below_quorum() {
+    let env = Env::default();
+    env.mock_all_auths();
+    set_ledger_time(&env, 100, 2_000);
+
+    let contract_id = env.register_contract(None, FamilyWallet);
+    let client = FamilyWalletClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let s1 = Address::generate(&env);
+    let s2 = Address::generate(&env);
+    let s3 = Address::generate(&env);
+
+    client.init(&owner, &vec![&env, s1.clone(), s2.clone(), s3.clone()]);
+
+    // threshold=3 — all three signers required.
+    let signers = vec![&env, s1.clone(), s2.clone(), s3.clone()];
+    client.configure_multisig(&owner, &TransactionType::RoleChange, &3, &signers, &0);
+
+    let tx_id = client.propose_role_change(&owner, &s1, &FamilyRole::Admin);
+    assert!(tx_id > 0);
+
+    // Batch-remove two of the three signers — only one remains, threshold=3 unachievable.
+    let to_remove = vec![&env, s2.clone(), s3.clone()];
+    let removed = client.batch_remove_family_members(&owner, &to_remove);
+    assert_eq!(removed, 2);
+
+    let after = client.get_pending_transaction(&tx_id).unwrap();
+    assert_eq!(
+        after.expires_at, 2_000,
+        "Proposal must be invalidated after batch removal drops eligible signers below threshold"
+    );
+}
+
+/// Signatures from a removed member must be stripped from the proposal.
+/// If the remaining signatures plus remaining eligible signers can still
+/// reach quorum, the proposal stays active.
+#[test]
+fn test_removed_member_signature_stripped_from_proposal() {
+    let env = Env::default();
+    env.mock_all_auths();
+    set_ledger_time(&env, 100, 1_000);
+
+    let contract_id = env.register_contract(None, FamilyWallet);
+    let client = FamilyWalletClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let signer_a = Address::generate(&env);
+    let signer_b = Address::generate(&env);
+
+    client.init(
+        &owner,
+        &vec![&env, signer_a.clone(), signer_b.clone()],
+    );
+
+    // threshold=2, two signers.
+    let signers = vec![&env, signer_a.clone(), signer_b.clone()];
+    client.configure_multisig(&owner, &TransactionType::RoleChange, &2, &signers, &0);
+
+    // signer_a proposes — their signature is automatically added.
+    let tx_id = client.propose_role_change(&signer_a, &signer_a, &FamilyRole::Admin);
+    assert!(tx_id > 0);
+
+    // Verify signer_a's signature is present.
+    let before = client.get_pending_transaction(&tx_id).unwrap();
+    assert_eq!(before.signatures.len(), 1);
+
+    // Remove signer_a — their signature should be stripped and quorum becomes
+    // unachievable (only signer_b remains, threshold=2).
+    client.remove_family_member(&owner, &signer_a);
+
+    let after = client.get_pending_transaction(&tx_id).unwrap();
+    // Signature stripped.
+    assert_eq!(
+        after.signatures.len(),
+        0,
+        "Removed member's signature must be stripped from the proposal"
+    );
+    // Quorum unachievable: 1 eligible signer < threshold 2 → invalidated.
+    assert_eq!(
+        after.expires_at, 1_000,
+        "Proposal must be invalidated when stripped signatures make quorum unreachable"
+    );
+}
+
+/// The public `revalidate_proposals` function must be callable by Owner/Admin,
+/// return the correct invalidation count, and reject calls from regular members.
+#[test]
+fn test_revalidate_proposals_public_entry_point() {
+    let env = Env::default();
+    env.mock_all_auths();
+    set_ledger_time(&env, 100, 5_000);
+
+    let contract_id = env.register_contract(None, FamilyWallet);
+    let client = FamilyWalletClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let signer = Address::generate(&env);
+    let regular = Address::generate(&env);
+
+    client.init(&owner, &vec![&env, signer.clone(), regular.clone()]);
+
+    // Configure with threshold=1, sole signer.
+    let signers = vec![&env, signer.clone()];
+    client.configure_multisig(&owner, &TransactionType::RoleChange, &1, &signers, &0);
+
+    // Create two in-flight proposals.
+    let tx1 = client.propose_role_change(&owner, &signer, &FamilyRole::Admin);
+    let tx2 = client.propose_role_change(&owner, &regular, &FamilyRole::Admin);
+    assert!(tx1 > 0 && tx2 > 0);
+
+    // Manually remove signer from storage without triggering auto-revalidation
+    // by reconfiguring multisig to an empty-ish state isn't possible, so instead
+    // we remove the signer and then call revalidate_proposals explicitly to test
+    // the public entry point independently.
+    client.remove_family_member(&owner, &signer);
+
+    // Both proposals should already be invalidated by remove_family_member.
+    // Call revalidate_proposals again — it should return 0 (nothing new to invalidate).
+    let count = client.revalidate_proposals(&owner);
+    assert_eq!(
+        count, 0,
+        "Re-running revalidation on already-invalidated proposals must return 0"
+    );
+
+    // Regular member must not be able to call revalidate_proposals.
+    let result = client.try_revalidate_proposals(&regular);
+    assert!(
+        result.is_err(),
+        "Regular member must not be allowed to call revalidate_proposals"
+    );
+}


### PR DESCRIPTION
When a family member is removed from the wallet, any pending multisig proposals that can no longer reach their required signature threshold are now automatically invalidated. This closes a correctness gap where a removed member's signature could remain counted toward quorum, or where quorum could become permanently unachievable with no way to detect it on-chain.

Problem
Previously, remove_family_member and batch_remove_family_members only updated the members map. They had no effect on pending proposals, which meant:

closes #619

A removed member's signature stayed on a proposal and continued to count toward the threshold.
If enough signers were removed to make the threshold unreachable, the proposal would sit in storage until it naturally expired — with no signal to the wallet that it was dead.
There was no way for an admin to proactively detect or clean up these stale proposals without waiting for the expiry window.
Changes
lib.rs

Added QuorumUnachievable = 23 to the Error enum for use in future call-site error returns.
Added ProposalInvalidatedEvent contract type — emitted whenever a proposal is invalidated by membership change, carrying tx_id, reason (no_qrm = quorum lost, no_cfg = config missing), and timestamp.
Added private helper revalidate_proposals_after_membership_change:
Iterates all non-expired pending proposals.
Strips signatures from addresses that are no longer active, non-expired members.
Counts eligible signers remaining in the multisig config for each proposal's transaction type.
If eligible signers < threshold, sets expires_at = now (immediate expiry) and emits ProposalInvalidatedEvent.
Wired the helper into remove_family_member — called after the member is removed from storage.
Wired the helper into batch_remove_family_members — called after the full batch is removed.
Added public revalidate_proposals(caller) — Owner/Admin callable function to manually trigger re-validation at any time (useful after configure_multisig changes or set_role_expiry calls).



closes #637