### PR TITLE
feat: enforce atomic batch membership updates with member cap in fami…

### DIFF
--- a/docs/fw-batch-membership.md
+++ b/docs/fw-batch-membership.md
@@ -1,0 +1,44 @@
+# Family Wallet: Batch Membership Semantics
+
+This document defines the batch behavior for `family_wallet::batch_add_family_members` and `family_wallet::batch_remove_family_members`.
+
+## Contracted Semantics
+
+Both batch entry points are all-or-nothing.
+
+- If every item in the batch is valid, the contract applies every change and returns the number of items processed.
+- If any item is invalid, the whole call aborts and no membership state is changed.
+- Empty batches are valid no-ops and return `0`.
+
+## Validation Rules
+
+### `batch_add_family_members`
+
+- Maximum batch length: `MAX_BATCH_MEMBERS` (`30`).
+- Maximum total family members after the batch: `MAX_FAMILY_MEMBERS` (`30`, including the owner).
+- Every address in the batch must be unique.
+- No batch item may target the owner role.
+- No address may already exist in `MEMBERS`.
+
+### `batch_remove_family_members`
+
+- Maximum batch length: `MAX_BATCH_MEMBERS` (`30`).
+- Every address in the batch must be unique.
+- The owner cannot be removed.
+- Every address must already exist in `MEMBERS`.
+
+## Failure Mode
+
+The contract rejects invalid batches by panicking before any storage mutation is committed. Mixed-validity batches therefore never produce partial membership state.
+
+## Return Values
+
+- `batch_add_family_members` returns the number of members added on success.
+- `batch_remove_family_members` returns the number of members removed on success.
+- Empty batches return `0`.
+
+## Security Notes
+
+- Pre-validation prevents intra-batch duplicates from overwriting a later item.
+- The member cap is enforced against the post-batch total, not just the batch length.
+- Because batch writes are atomic, a failed member-add/remove request cannot leave `MEMBERS` in a partially updated state.

--- a/family_wallet/src/lib.rs
+++ b/family_wallet/src/lib.rs
@@ -26,7 +26,8 @@ const MIN_THRESHOLD: u32 = 1;
 const MAX_SIGNERS: u32 = 20;
 
 // Batch bounds
-const MAX_BATCH_MEMBERS: u32 = 50;
+const MAX_BATCH_MEMBERS: u32 = 30;
+const MAX_FAMILY_MEMBERS: u32 = MAX_BATCH_MEMBERS;
 
 // Access audit bounds
 const MAX_ACCESS_AUDIT_ENTRIES: u32 = 200;
@@ -1959,33 +1960,61 @@ impl FamilyWallet {
         true
     }
 
+    /// Add a batch of family members atomically.
+    ///
+    /// Semantics:
+    /// - The whole batch succeeds or the whole batch fails.
+    /// - Empty batches are accepted and return `0`.
+    /// - Any duplicate address in the batch, pre-existing member, owner-role item,
+    ///   or batch that would exceed the family-member cap aborts the entire call.
+    /// - On success, the return value is the number of members added.
     pub fn batch_add_family_members(
         env: Env,
         caller: Address,
         members: Vec<BatchMemberItem>,
     ) -> u32 {
         caller.require_auth();
-        RemitwiseEvents::emit(
-            &env,
-            EventCategory::Access,
-            EventPriority::Medium,
-            symbol_short!("batch_mem"),
-            members.len(),
-        );
         Self::require_role_at_least(&env, &caller, FamilyRole::Admin);
         Self::require_not_paused(&env);
+        if members.len() > MAX_BATCH_MEMBERS {
+            panic!("Batch too large");
+        }
         Self::extend_instance_ttl(&env);
+
         let mut members_map: Map<Address, FamilyMember> = env
             .storage()
             .instance()
             .get(&symbol_short!("MEMBERS"))
             .unwrap_or_else(|| panic!("Wallet not initialized"));
-        let timestamp = env.ledger().timestamp();
-        let mut count = 0u32;
+
+        let mut current_member_count = 0u32;
+        for _ in members_map.iter() {
+            current_member_count += 1;
+        }
+
+        let mut seen_addrs: Map<Address, bool> = Map::new(&env);
+        let mut additions = 0u32;
         for item in members.iter() {
             if item.role == FamilyRole::Owner {
                 panic!("Cannot add Owner via batch");
             }
+            if seen_addrs.get(item.address.clone()).is_some() {
+                panic!("Duplicate member in batch");
+            }
+            seen_addrs.set(item.address.clone(), true);
+            if members_map.get(item.address.clone()).is_some() {
+                panic!("Member already exists");
+            }
+            additions += 1;
+        }
+
+        if current_member_count + additions > MAX_FAMILY_MEMBERS {
+            panic!("Member cap exceeded");
+        }
+
+        let timestamp = env.ledger().timestamp();
+        let mut count = 0u32;
+        for item in members.iter() {
             members_map.set(
                 item.address.clone(),
                 FamilyMember {
@@ -2008,10 +2037,25 @@ impl FamilyWallet {
         env.storage()
             .instance()
             .set(&symbol_short!("MEMBERS"), &members_map);
+        RemitwiseEvents::emit(
+            &env,
+            EventCategory::Access,
+            EventPriority::Medium,
+            symbol_short!("batch_mem"),
+            count,
+        );
         Self::update_storage_stats(&env);
         count
     }
 
+    /// Remove a batch of family members atomically.
+    ///
+    /// Semantics:
+    /// - The whole batch succeeds or the whole batch fails.
+    /// - Empty batches are accepted and return `0`.
+    /// - Any duplicate address in the batch, missing member, or attempt to remove
+    ///   the owner aborts the entire call.
+    /// - On success, the return value is the number of members removed.
     pub fn batch_remove_family_members(env: Env, caller: Address, addresses: Vec<Address>) -> u32 {
         caller.require_auth();
         Self::require_role_at_least(&env, &caller, FamilyRole::Owner);
@@ -2033,22 +2077,32 @@ impl FamilyWallet {
             .instance()
             .get(&symbol_short!("MEMBERS"))
             .unwrap_or_else(|| panic!("Wallet not initialized"));
-        let mut count = 0u32;
+
+        let mut seen_addrs: Map<Address, bool> = Map::new(&env);
         for addr in addresses.iter() {
             if addr.clone() == owner {
                 panic!("Cannot remove owner");
             }
-            if members_map.get(addr.clone()).is_some() {
-                members_map.remove(addr.clone());
-                Self::append_access_audit(
-                    &env,
-                    symbol_short!("rem_mem"),
-                    &caller,
-                    Some(addr.clone()),
-                    true,
-                );
-                count += 1;
+            if seen_addrs.get(addr.clone()).is_some() {
+                panic!("Duplicate member in batch");
             }
+            seen_addrs.set(addr.clone(), true);
+            if members_map.get(addr.clone()).is_none() {
+                panic!("Member not found");
+            }
+        }
+
+        let mut count = 0u32;
+        for addr in addresses.iter() {
+            members_map.remove(addr.clone());
+            Self::append_access_audit(
+                &env,
+                symbol_short!("rem_mem"),
+                &caller,
+                Some(addr.clone()),
+                true,
+            );
+            count += 1;
         }
         env.storage()
             .instance()

--- a/family_wallet/src/test.rs
+++ b/family_wallet/src/test.rs
@@ -2921,6 +2921,157 @@ fn test_expired_owner_cannot_batch_remove_members() {
     assert!(result.is_err());
 }
 
+fn generate_addresses(env: &Env, count: u32) -> Vec<Address> {
+    let mut addresses = Vec::new(env);
+    for _ in 0..count {
+        addresses.push_back(Address::generate(env));
+    }
+    addresses
+}
+
+#[test]
+fn test_batch_add_family_members_all_valid_and_empty_batch() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, FamilyWallet);
+    let client = FamilyWalletClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let initial_members = vec![&env, Address::generate(&env), Address::generate(&env)];
+    client.init(&owner, &initial_members);
+
+    let member_a = Address::generate(&env);
+    let member_b = Address::generate(&env);
+    let members_to_add = vec![
+        &env,
+        BatchMemberItem {
+            address: member_a.clone(),
+            role: FamilyRole::Member,
+        },
+        BatchMemberItem {
+            address: member_b.clone(),
+            role: FamilyRole::Admin,
+        },
+    ];
+
+    let added = client.batch_add_family_members(&owner, &members_to_add);
+    assert_eq!(added, 2);
+    assert_eq!(client.get_family_member(&member_a).unwrap().role, FamilyRole::Member);
+    assert_eq!(client.get_family_member(&member_b).unwrap().role, FamilyRole::Admin);
+
+    let empty_batch = Vec::new(&env);
+    assert_eq!(client.batch_add_family_members(&owner, &empty_batch), 0);
+}
+
+#[test]
+fn test_batch_add_family_members_rejects_mixed_batch_without_partial_state() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, FamilyWallet);
+    let client = FamilyWalletClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let existing_member = Address::generate(&env);
+    client.init(&owner, &vec![&env, existing_member.clone()]);
+
+    let new_member = Address::generate(&env);
+    let members_to_add = vec![
+        &env,
+        BatchMemberItem {
+            address: new_member.clone(),
+            role: FamilyRole::Member,
+        },
+        BatchMemberItem {
+            address: existing_member.clone(),
+            role: FamilyRole::Admin,
+        },
+    ];
+
+    let result = client.try_batch_add_family_members(&owner, &members_to_add);
+    assert!(result.is_err());
+    assert!(client.get_family_member(&new_member).is_none());
+    assert_eq!(client.get_family_member(&existing_member).unwrap().role, FamilyRole::Member);
+}
+
+#[test]
+fn test_batch_add_family_members_rejects_duplicate_and_cap_excess() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, FamilyWallet);
+    let client = FamilyWalletClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let initial_members = generate_addresses(&env, 28);
+    client.init(&owner, &initial_members);
+
+    let duplicate_member = Address::generate(&env);
+    let duplicate_batch = vec![
+        &env,
+        BatchMemberItem {
+            address: duplicate_member.clone(),
+            role: FamilyRole::Member,
+        },
+        BatchMemberItem {
+            address: duplicate_member.clone(),
+            role: FamilyRole::Admin,
+        },
+    ];
+
+    let duplicate_result = client.try_batch_add_family_members(&owner, &duplicate_batch);
+    assert!(duplicate_result.is_err());
+    assert!(client.get_family_member(&duplicate_member).is_none());
+
+    let cap_member_a = Address::generate(&env);
+    let cap_member_b = Address::generate(&env);
+    let cap_batch = vec![
+        &env,
+        BatchMemberItem {
+            address: cap_member_a.clone(),
+            role: FamilyRole::Member,
+        },
+        BatchMemberItem {
+            address: cap_member_b.clone(),
+            role: FamilyRole::Member,
+        },
+    ];
+
+    let cap_result = client.try_batch_add_family_members(&owner, &cap_batch);
+    assert!(cap_result.is_err());
+    assert!(client.get_family_member(&cap_member_a).is_none());
+    assert!(client.get_family_member(&cap_member_b).is_none());
+}
+
+#[test]
+fn test_batch_remove_family_members_rejects_missing_and_duplicate_without_partial_state() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, FamilyWallet);
+    let client = FamilyWalletClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let member_a = Address::generate(&env);
+    let member_b = Address::generate(&env);
+    client.init(&owner, &vec![&env, member_a.clone(), member_b.clone()]);
+
+    let missing_member = Address::generate(&env);
+    let mixed_remove = vec![&env, member_a.clone(), missing_member.clone()];
+
+    let mixed_result = client.try_batch_remove_family_members(&owner, &mixed_remove);
+    assert!(mixed_result.is_err());
+    assert!(client.get_family_member(&member_a).is_some());
+    assert!(client.get_family_member(&member_b).is_some());
+
+    let duplicate_remove = vec![&env, missing_member.clone(), missing_member.clone()];
+    let duplicate_result = client.try_batch_remove_family_members(&owner, &duplicate_remove);
+    assert!(duplicate_result.is_err());
+
+    let all_invalid = vec![&env, Address::generate(&env), Address::generate(&env)];
+    let invalid_result = client.try_batch_remove_family_members(&owner, &all_invalid);
+    assert!(invalid_result.is_err());
+    assert!(client.get_family_member(&member_a).is_some());
+    assert!(client.get_family_member(&member_b).is_some());
+}
+
 #[test]
 fn test_expired_owner_cannot_set_proposal_expiry() {
     let env = Env::default();


### PR DESCRIPTION
…ly wallet

This PR makes [batch_add_family_members](vscode-file://vscode-app/snap/code/242/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [batch_remove_family_members](vscode-file://vscode-app/snap/code/242/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) fail closed with all-or-nothing semantics. Batch adds now pre-validate duplicates, existing members, owner-role entries, and the post-batch member cap before any storage write occurs. Batch removes now pre-validate duplicates and missing members before mutating state, so mixed-validity batches cannot leave partial membership changes behind.

It also adds explicit batch semantics documentation and regression tests for:

all-valid batches
mixed-validity batches
duplicate entries within the same batch
cap-exceeding batch adds
empty batches
Validation:

cargo +1.89-x86_64-unknown-linux-gnu test -p family_wallet
Closes #644
