### PR TITLE
docs: document health score calculation and weights (#717)

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ To run an example, use `cargo run --example <example_name>`:
 ## Documentation
 
 - [Family Wallet Design (as implemented)](docs/family-wallet-design.md)
+- [Financial Health Score Model](docs/HEALTH_SCORE.md) - HealthScore component weights, inputs, clamping, and worked examples
 - [Frontend Integration Notes](docs/frontend-integration.md)
 - [Storage Layout Reference](STORAGE_LAYOUT.md)
 - [Event Indexer](indexer/README.md) - Off-chain event indexing and querying

--- a/docs/HEALTH_SCORE.md
+++ b/docs/HEALTH_SCORE.md
@@ -1,0 +1,186 @@
+# Financial Health Score
+
+This document specifies the algorithm behind `HealthScore`, the headline number
+produced by the `reporting` contract. It is the authoritative reference for
+reviewers auditing the math and for integrators explaining the number to end
+users.
+
+> **Source of truth:** `reporting/src/lib.rs` — `ReportingContract::calculate_health_score`
+> and the private helpers `calculate_savings_score`, `calculate_bills_score`,
+> `calculate_insurance_score`, and `clamp_score`. This document is written to
+> match that code exactly. If the code and this document ever disagree, the code
+> is correct and this document is a bug.
+
+## Overview
+
+`calculate_health_score(user, total_remittance) -> Result<HealthScore, ReportingError>`
+returns a score in the range **0..=100**, composed of three independently
+computed, weighted components:
+
+| Component   | Weight (max points) | Input it consumes                                                        |
+| ----------- | ------------------- | ------------------------------------------------------------------------ |
+| Savings     | **0–40**            | Aggregate savings-goal completion: `total_saved / total_target`          |
+| Bills       | **0–40**            | Bill-payment compliance: presence of unpaid and of overdue unpaid bills  |
+| Insurance   | **0–20**            | Existence of at least one active insurance policy (binary)               |
+| **Total**   | **0–100**           | `clamp(savings + bills + insurance, 0, 100)`                             |
+
+The maximum attainable component scores sum to exactly `40 + 40 + 20 = 100`, so
+the final clamp to `0..=100` is a defensive guarantee rather than a value that is
+normally reached by saturation.
+
+> **Note on the `total_remittance` argument:** it is accepted for API/signature
+> stability but is **currently unused** (`_total_remittance` in the source). It
+> does not affect the score.
+
+## Components
+
+### Savings score (0–40)
+
+Source: `calculate_savings_score`.
+
+1. Fetch all of the user's goals via the savings_goals contract
+   (`get_all_goals`).
+2. For each goal, clamp the amounts defensively before summing:
+   - `target = clamp(goal.target_amount, 0, i128::MAX / 2)`
+   - `saved  = clamp(goal.current_amount, 0, target)`
+   - Accumulate `total_target` and `total_saved` using **saturating** addition.
+3. **Default case — `total_target == 0`** (the user has no goals, or every goal
+   has a zero target): return **20** (a neutral half-of-max default).
+4. Otherwise compute completion percentage, clamped to `0..=100`:
+   - If `total_saved >= total_target` → `progress = 100`.
+   - Else `progress = min((total_saved * 100) / total_target, 100)`, using
+     saturating multiply and checked division (division failure → `0`).
+5. Convert to points: `score = (progress * 40) / 100`, then `min(score, 40)`.
+
+So at 0% completion the savings score is `0`; at 80% it is `32`; at 100% it is
+`40`. With no goals configured it is the default `20`.
+
+### Bills score (0–40)
+
+Source: `calculate_bills_score`.
+
+1. Fetch the user's unpaid bills via the bill_payments contract
+   (`get_unpaid_bills(user, 0, 1000)` — up to 1000 unpaid bills are inspected).
+2. Decide the score by tier:
+
+| Condition                                  | Score |
+| ------------------------------------------ | ----- |
+| No unpaid bills at all                     | **40** |
+| Has unpaid bills, but **none** are overdue | **35** |
+| Has at least one **overdue** unpaid bill   | **20** |
+
+A bill is "overdue" when `bill.due_date < env.ledger().timestamp()`.
+
+This is a **tiered** model (40 / 35 / 20), not a continuous compliance
+percentage. A user with no bills receives the perfect-compliance score of 40.
+
+### Insurance score (0–20)
+
+Source: `calculate_insurance_score`.
+
+This is **binary**:
+
+| Condition                         | Score |
+| --------------------------------- | ----- |
+| At least one active policy exists | **20** |
+| No active policies                | **0**  |
+
+It checks only existence (`get_active_policies(user, 0, 1)` — a single-item
+page), not coverage amount, premium, or the `coverage_to_premium_ratio` that the
+`InsuranceReport` struct exposes elsewhere.
+
+## Clamping
+
+The total is `clamp_score(savings_score + bills_score + insurance_score, 0, 100)`,
+where `clamp_score` returns `min` if below `min`, `max` if above `max`, else the
+value unchanged. Each component is also independently capped at its own maximum
+inside its helper (savings `min(_, 40)`; bills and insurance return fixed
+constants), so the components are guaranteed to be in `0..=40`, `0..=40`, and
+`0..=20` respectively, and the total in `0..=100`.
+
+## Data availability: Partial / Missing behavior
+
+The `reporting` contract exposes a `DataAvailability` enum (`Complete`,
+`Partial`, `Missing`) on several report structs (e.g. `BillComplianceReport`,
+`InsuranceReport`) to signal incomplete cross-contract data.
+
+**`HealthScore` does not carry or consult a `DataAvailability` value.**
+`calculate_health_score` calls the downstream contracts directly through their
+clients and derives each component from the raw results. Consequently:
+
+- **Addresses not configured:** if the reporting contract has no stored
+  `ContractAddresses`, `calculate_health_score` returns
+  `Err(ReportingError::AddressesNotConfigured)` and produces **no** score. This
+  is the only "missing data" outcome the function models explicitly.
+- **A downstream contract has no data for the user:** this is treated as a
+  legitimate, non-error state and maps to each component's default:
+  - no savings goals → savings `20`
+  - no unpaid bills → bills `40`
+  - no active policies → insurance `0`
+
+  As a result, a brand-new user with no goals, no bills, and no insurance scores
+  `20 + 40 + 0 = 60`.
+- **A downstream call fails/panics:** the cross-contract call propagates the
+  failure and the whole `calculate_health_score` invocation reverts; there is no
+  silent `Partial` degradation of the score. If callers need a degradation
+  signal, they should read the dedicated report endpoints
+  (`get_bill_compliance_report`, `get_insurance_report`, …) which surface
+  `DataAvailability`.
+
+## Worked examples
+
+### Typical profile
+
+A user with:
+
+- savings goals at **80%** aggregate completion → `(80 * 40) / 100 = 32`
+- unpaid bills present but **none overdue** → `35`
+- at least one **active** insurance policy → `20`
+
+**Total:** `32 + 35 + 20 = 87`.
+
+(This is exactly the case asserted in `reporting`'s
+`test_calculate_health_score`: `savings_score = 32`, `bills_score = 35`,
+`insurance_score = 20`, `score = 87`.)
+
+### Edge profiles
+
+| Profile                                                        | Savings | Bills | Insurance | Total |
+| -------------------------------------------------------------- | ------- | ----- | --------- | ----- |
+| **Full marks** — 100% savings, no unpaid bills, active policy  | 40      | 40    | 20        | 100   |
+| **Brand-new / empty** — no goals, no bills, no policy          | 20      | 40    | 0         | 60    |
+| **At-risk** — 0% savings, an overdue bill, no policy           | 0       | 20    | 0         | 20    |
+| **All-default** — goals all zero-target, no bills, no policy   | 20      | 40    | 0         | 60    |
+
+The "empty" and "all-default" rows both land at `60` because an absence of
+bills counts as perfect compliance (40) and an absence of goals yields the
+neutral savings default (20).
+
+## Soroban SDK note for integrators
+
+These contracts target **Soroban SDK `21.7.7`**. `HealthScore` is a
+`#[contracttype]` struct; its four fields are `u32`:
+
+```rust
+pub struct HealthScore {
+    pub score: u32,           // 0..=100
+    pub savings_score: u32,   // 0..=40
+    pub bills_score: u32,     // 0..=40
+    pub insurance_score: u32, // 0..=20
+}
+```
+
+When decoding cross-contract or off-chain (e.g. via the indexer), expect all
+four fields as unsigned 32-bit integers in the ranges above. The component
+fields always sum to `score` under normal operation because the per-component
+caps already keep the sum at or below `100`.
+
+## Verification
+
+```bash
+# Build the docs for the reporting crate and confirm the doc comments compile
+cargo doc -p reporting --no-deps
+
+# Re-run the scoring tests that pin the worked example
+cargo test -p reporting calculate_health_score
+```

--- a/reporting/README.md
+++ b/reporting/README.md
@@ -11,6 +11,10 @@ Aggregates financial health data from the remittance_split, savings_goals, bill_
 
 ## Financial Health Score
 
+> **Authoritative spec:** [`docs/HEALTH_SCORE.md`](../docs/HEALTH_SCORE.md) documents
+> the exact component weights, the input each consumes, the clamping to `0..=100`,
+> the `DataAvailability` (Partial/Missing) behavior, and worked examples.
+
 The contract calculates a comprehensive financial health score (0-100) based on three components:
 
 ### Score Components

--- a/reporting/src/lib.rs
+++ b/reporting/src/lib.rs
@@ -36,13 +36,25 @@ pub const DEP_PAGE_LIMIT: u32 = 50;
 /// Maximum number of items included in top-N reports.
 pub const MAX_ITEMS_PER_REPORT: u32 = 10;
 
-/// Financial health score (0-100)
+/// Financial health score (0-100), composed of three weighted components.
+///
+/// - `savings_score`: 0-40, from aggregate savings-goal completion
+/// - `bills_score`: 0-40, from bill-payment compliance (tiered 40/35/20)
+/// - `insurance_score`: 0-20, binary on having an active policy
+/// - `score`: `clamp(savings + bills + insurance, 0, 100)`
+///
+/// See `docs/HEALTH_SCORE.md` (at the repository root) for the full scoring
+/// model, inputs, and worked examples.
 #[contracttype]
 #[derive(Clone)]
 pub struct HealthScore {
+    /// Overall score, clamped to `0..=100`.
     pub score: u32,
+    /// Savings component, `0..=40` (goal completion percentage scaled to 40).
     pub savings_score: u32,
+    /// Bills component, `0..=40` (40 none unpaid, 35 unpaid none overdue, 20 overdue).
     pub bills_score: u32,
+    /// Insurance component, `0..=20` (20 if any active policy, else 0).
     pub insurance_score: u32,
 }
 
@@ -1073,8 +1085,19 @@ impl ReportingContract {
     ///
     /// This function computes a comprehensive financial health score (0-100) based on:
     /// - Savings progress (0-40 points): Based on goal completion percentage
-    /// - Bill payment compliance (0-40 points): Based on unpaid/overdue bills
-    /// - Insurance coverage (0-20 points): Based on active policies
+    /// - Bill payment compliance (0-40 points): tiered 40 (none unpaid) /
+    ///   35 (unpaid, none overdue) / 20 (overdue)
+    /// - Insurance coverage (0-20 points): binary, 20 if any active policy else 0
+    ///
+    /// The final score is `clamp(savings + bills + insurance, 0, 100)`. The
+    /// `_total_remittance` argument is currently unused. When a downstream
+    /// contract has no data the relevant component falls back to its default
+    /// (savings 20, bills 40, insurance 0); if addresses are unconfigured the
+    /// call returns `AddressesNotConfigured` rather than a partial score.
+    ///
+    /// See `docs/HEALTH_SCORE.md` (at the repository root) for the full model,
+    /// the exact input of each component, clamping, the `DataAvailability`
+    /// (Partial/Missing) relationship, and worked examples.
     ///
     /// # Arithmetic Safety
     /// - Uses safe division to prevent overflow


### PR DESCRIPTION
## Description
Documents the `calculate_health_score` logic and component weights to make the algorithm fully auditable for reviewers and integrators. 

## Changes
- **Added `docs/HEALTH_SCORE.md`**: Details component weights (Savings 0-40, Bills 0-40, Insurance 0-20), clamping behavior, and missing report handling, plus worked examples.
- **Inline Rust Docs**: Added summaries to `calculate_health_score` and `HealthScore`.
- **README Updates**: Cross-linked the new documentation from the root and reporting READMEs.
