### PR TITLE
test(audit): add ring-eviction and cross-read consistency tests for A…

### DIFF
--- a/docs/fw-access-audit-pagination.md
+++ b/docs/fw-access-audit-pagination.md
@@ -68,6 +68,54 @@ signals that there are no more entries.  Callers should stop iterating when:
 
 ---
 
+## Ring-buffer eviction (bounded trail)
+
+`ACC_AUDIT` is a **bounded ring buffer**, not an unbounded log. Each privileged
+operation appends one entry via `append_access_audit`. When the length exceeds
+`MAX_ACCESS_AUDIT_ENTRIES` (200), the **oldest** entries are evicted so that only
+the most-recent 200 are retained:
+
+- After appending entry number `n` where `n > 200`, entries with insertion
+  positions `0 .. n-200` are dropped and the retained set is **re-indexed from
+  `0`**. The surviving entries keep their relative order (oldest-retained first,
+  newest last).
+- Pagination operates over these **post-eviction indices**. `from_index = 0`
+  always points at the oldest *retained* entry — never at an evicted one — and
+  `total` (revealed by the end-of-log sentinel) is capped at `200`.
+- Consequently, an evicted entry can never reappear on any page, and the cursor
+  stays strictly monotonic across the wrap boundary (no skips, no duplicates).
+
+> **Forensic implication:** the trail is a *rolling window*. Once 200 newer
+> privileged operations have occurred, evidence of the oldest ones is gone.
+> Off-chain consumers that need a permanent record must paginate and persist the
+> trail *before* it wraps. The cap bounds instance-storage rent; it is not a
+> retention guarantee.
+
+### Worked example
+
+Seed 250 operations with ascending timestamps `1000 .. 1249`:
+
+| | Insertion positions | Timestamps | State |
+|---|---|---|---|
+| Evicted | `0 .. 49` | `1000 .. 1049` | dropped |
+| Retained | `50 .. 249` | `1050 .. 1249` | re-indexed to page positions `0 .. 199` |
+
+`get_access_audit_page(caller, 0, 50)` returns the entry with timestamp `1050`
+first; the end-of-log sentinel `next_cursor` reaches `200`.
+
+---
+
+## Relationship to `get_access_audit`
+
+`get_access_audit(limit)` returns the **tail** — the newest
+`min(limit, total)` retained entries, oldest-to-newest. This is exactly the
+**suffix** of the fully-paginated view (paging from index `0` to the sentinel).
+The two read paths are consistent by construction, including across an eviction
+wrap: paging the whole log and taking its last `k` entries yields the same
+entries, in the same order, as `get_access_audit(k)`.
+
+---
+
 ## Iteration example (off-chain pseudo-code)
 
 ```typescript
@@ -123,3 +171,15 @@ Tests live in `family_wallet/src/test.rs` under the
 | `test_audit_page_single_entry_log` | Single-entry log; second call with returned cursor is empty |
 | `test_audit_page_full_iteration_no_skip_no_duplicate` | Full iteration collects every entry exactly once |
 | `test_audit_page_cursor_stable_across_calls` | Same cursor returns identical results on repeated calls |
+
+Ring-eviction, authorization, and cross-read tests live under the
+`// Access-Audit Ring-Eviction & Cross-Read Tests` section:
+
+| Test | What it verifies |
+|------|-----------------|
+| `test_audit_ring_evicts_oldest_retains_newest` | Past the cap, oldest evicted / newest retained; total pinned at 200; evicted prefix never paged |
+| `test_audit_ring_exactly_at_max_evicts_nothing` | Exactly 200 entries → nothing evicted, oldest still present |
+| `test_audit_ring_one_over_max_evicts_single_oldest` | 201 entries → exactly the single oldest evicted |
+| `test_audit_page_post_eviction_no_skip_no_duplicate` | Paging post-eviction with a non-dividing page size is contiguous and monotonic |
+| `test_audit_page_authorization_matches_policy` | Owner/Admin allowed; `Member` and non-member rejected by the role gate |
+| `test_get_access_audit_consistent_with_paginated_view` | `get_access_audit(limit)` equals the tail of the paginated view, across an eviction wrap |

--- a/family_wallet/src/test.rs
+++ b/family_wallet/src/test.rs
@@ -4280,6 +4280,256 @@ fn test_audit_page_cursor_stable_across_calls() {
 }
 
 // ============================================================================
+// Access-Audit Ring-Eviction & Cross-Read Tests
+//
+// These pin the bounded ring-buffer behaviour of the `ACC_AUDIT` log: once it
+// exceeds MAX_ACCESS_AUDIT_ENTRIES (200) the oldest entries are evicted and the
+// retained set is re-indexed from 0. Pagination must reflect that post-eviction
+// state with a monotonic cursor and never surface (or skip) entries. They also
+// pin the documented Admin-only authorization policy and the consistency
+// between `get_access_audit` (tail read) and the paginated full view.
+// ============================================================================
+
+/// Helper: seed `n` audit entries via emergency-mode toggles, advancing the
+/// ledger timestamp by 1 before each append so that entry `i` (0-based in
+/// insertion order) carries `timestamp == base + i`. Unique, monotonically
+/// increasing timestamps let eviction tests identify exactly which entries
+/// survived the ring-buffer wrap.
+fn seed_audit_entries_ts(
+    env: &Env,
+    client: &FamilyWalletClient,
+    owner: &Address,
+    base: u64,
+    n: u32,
+) {
+    for i in 0..n {
+        let mut ledger = env.ledger().get();
+        ledger.timestamp = base + i as u64;
+        env.ledger().set(ledger);
+        client.set_emergency_mode(owner, &(i % 2 == 0));
+    }
+}
+
+/// Helper: page through the entire retained log from index 0 using `page_size`
+/// and return every entry's timestamp in cursor order. Asserts the cursor is
+/// strictly monotonic (no dupes, no skips) as it walks. Returns a Soroban
+/// `Vec<u64>` (this is a `#![no_std]` crate, so `std::vec` is unavailable here).
+fn collect_all_audit_timestamps(
+    env: &Env,
+    client: &FamilyWalletClient,
+    caller: &Address,
+    page_size: u32,
+) -> Vec<u64> {
+    let mut out = Vec::new(env);
+    let mut cursor: u32 = 0;
+    loop {
+        let page = client.get_access_audit_page(caller, &cursor, &page_size);
+        if page.count == 0 {
+            break;
+        }
+        // Cursor must advance by exactly the number of items consumed.
+        assert_eq!(page.next_cursor, cursor + page.count);
+        for idx in 0..page.count {
+            out.push_back(page.items.get(idx).unwrap().timestamp);
+        }
+        cursor = page.next_cursor;
+    }
+    out
+}
+
+/// Fills the trail past the 200-entry cap and asserts the oldest entries are
+/// evicted while the newest are retained: total stays pinned at the cap, the
+/// retained timestamps are exactly the most-recent 200, and the evicted prefix
+/// never appears on any page.
+#[test]
+fn test_audit_ring_evicts_oldest_retains_newest() {
+    let env = Env::default();
+    env.mock_all_auths();
+    // Rebuilding the 200-entry ring on every append is budget-heavy; lift the
+    // default metering so the stress seeding does not hit ExceededLimit.
+    env.budget().reset_unlimited();
+    let contract_id = env.register_contract(None, FamilyWallet);
+    let client = FamilyWalletClient::new(&env, &contract_id);
+    let owner = Address::generate(&env);
+    client.init(&owner, &vec![&env]);
+
+    // Seed 250 entries with timestamps 1000..=1249.
+    let base: u64 = 1000;
+    let seeded: u32 = 250;
+    seed_audit_entries_ts(&env, &client, &owner, base, seeded);
+
+    // The log is capped: the retained set is exactly MAX_ACCESS_AUDIT_ENTRIES.
+    let first_page = client.get_access_audit_page(&owner, &0, &1);
+    // next_cursor on an out-of-range read reveals total; read past the end.
+    let probe = client.get_access_audit_page(&owner, &u32::MAX, &1);
+    assert_eq!(probe.next_cursor, MAX_ACCESS_AUDIT_ENTRIES);
+
+    // Collect every retained timestamp by paging the whole log.
+    let timestamps = collect_all_audit_timestamps(&env, &client, &owner, MAX_AUDIT_PAGE_LIMIT);
+    assert_eq!(timestamps.len(), MAX_ACCESS_AUDIT_ENTRIES);
+
+    // Oldest 50 entries (timestamps 1000..=1049) were evicted; newest retained.
+    let oldest_retained = base + (seeded - MAX_ACCESS_AUDIT_ENTRIES) as u64; // 1050
+    let newest_retained = base + (seeded - 1) as u64; // 1249
+    assert_eq!(timestamps.get(0).unwrap(), oldest_retained);
+    assert_eq!(timestamps.get(timestamps.len() - 1).unwrap(), newest_retained);
+    assert_eq!(first_page.items.get(0).unwrap().timestamp, oldest_retained);
+
+    // Post-eviction state: no page references an evicted entry, and the
+    // retained sequence is strictly increasing (no dupes / no gaps).
+    for i in 0..timestamps.len() {
+        let ts = timestamps.get(i).unwrap();
+        assert!(ts >= oldest_retained, "evicted entry leaked into page");
+        assert_eq!(ts, oldest_retained + i as u64, "non-contiguous retained set");
+    }
+}
+
+/// Exactly at the cap: seeding precisely MAX_ACCESS_AUDIT_ENTRIES evicts
+/// nothing — the full range is retained and the oldest entry is still present.
+#[test]
+fn test_audit_ring_exactly_at_max_evicts_nothing() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.budget().reset_unlimited();
+    let contract_id = env.register_contract(None, FamilyWallet);
+    let client = FamilyWalletClient::new(&env, &contract_id);
+    let owner = Address::generate(&env);
+    client.init(&owner, &vec![&env]);
+
+    let base: u64 = 5000;
+    seed_audit_entries_ts(&env, &client, &owner, base, MAX_ACCESS_AUDIT_ENTRIES);
+
+    let timestamps = collect_all_audit_timestamps(&env, &client, &owner, MAX_AUDIT_PAGE_LIMIT);
+    assert_eq!(timestamps.len(), MAX_ACCESS_AUDIT_ENTRIES);
+    // Nothing evicted: oldest is still the very first entry.
+    assert_eq!(timestamps.get(0).unwrap(), base);
+    assert_eq!(
+        timestamps.get(timestamps.len() - 1).unwrap(),
+        base + (MAX_ACCESS_AUDIT_ENTRIES - 1) as u64
+    );
+}
+
+/// One over the cap: seeding MAX_ACCESS_AUDIT_ENTRIES + 1 evicts exactly the
+/// single oldest entry; the new oldest is `base + 1`.
+#[test]
+fn test_audit_ring_one_over_max_evicts_single_oldest() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.budget().reset_unlimited();
+    let contract_id = env.register_contract(None, FamilyWallet);
+    let client = FamilyWalletClient::new(&env, &contract_id);
+    let owner = Address::generate(&env);
+    client.init(&owner, &vec![&env]);
+
+    let base: u64 = 9000;
+    seed_audit_entries_ts(&env, &client, &owner, base, MAX_ACCESS_AUDIT_ENTRIES + 1);
+
+    let timestamps = collect_all_audit_timestamps(&env, &client, &owner, MAX_AUDIT_PAGE_LIMIT);
+    assert_eq!(timestamps.len(), MAX_ACCESS_AUDIT_ENTRIES);
+    // The single oldest (timestamp == base) was evicted.
+    assert_eq!(timestamps.get(0).unwrap(), base + 1);
+    let mut found_base = false;
+    for i in 0..timestamps.len() {
+        if timestamps.get(i).unwrap() == base {
+            found_base = true;
+        }
+    }
+    assert!(!found_base, "oldest entry should be evicted");
+    assert_eq!(
+        timestamps.get(timestamps.len() - 1).unwrap(),
+        base + MAX_ACCESS_AUDIT_ENTRIES as u64
+    );
+}
+
+/// After eviction, paging across the wrap boundary with a small page size still
+/// yields a monotonic cursor and the exact retained set — proving pagination is
+/// computed over post-eviction indices, not stale absolute positions.
+#[test]
+fn test_audit_page_post_eviction_no_skip_no_duplicate() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.budget().reset_unlimited();
+    let contract_id = env.register_contract(None, FamilyWallet);
+    let client = FamilyWalletClient::new(&env, &contract_id);
+    let owner = Address::generate(&env);
+    client.init(&owner, &vec![&env]);
+
+    let base: u64 = 200_000;
+    seed_audit_entries_ts(&env, &client, &owner, base, 230);
+
+    // Page with size 7 (does not divide 200 evenly) to stress boundary maths.
+    let timestamps = collect_all_audit_timestamps(&env, &client, &owner, 7);
+    assert_eq!(timestamps.len(), MAX_ACCESS_AUDIT_ENTRIES);
+
+    let oldest_retained = base + (230 - MAX_ACCESS_AUDIT_ENTRIES) as u64; // 200_030
+    for i in 0..timestamps.len() {
+        assert_eq!(timestamps.get(i).unwrap(), oldest_retained + i as u64);
+    }
+}
+
+/// Authorization policy: `get_access_audit_page` is Owner/Admin only. Owner and
+/// Admin succeed; a `Member` and a non-member are rejected. (Auth is mocked, so
+/// the rejection comes from the role gate, matching the documented policy.)
+#[test]
+fn test_audit_page_authorization_matches_policy() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, FamilyWallet);
+    let client = FamilyWalletClient::new(&env, &contract_id);
+    let owner = Address::generate(&env);
+    client.init(&owner, &vec![&env]);
+
+    let admin = Address::generate(&env);
+    let member = Address::generate(&env);
+    let stranger = Address::generate(&env);
+    client.add_family_member(&owner, &admin, &FamilyRole::Admin);
+    client.add_family_member(&owner, &member, &FamilyRole::Member);
+
+    // Owner and Admin may read the audit page.
+    assert!(client.try_get_access_audit_page(&owner, &0, &10).is_ok());
+    assert!(client.try_get_access_audit_page(&admin, &0, &10).is_ok());
+
+    // Member and non-member are rejected by the Admin role gate.
+    assert!(client.try_get_access_audit_page(&member, &0, &10).is_err());
+    assert!(client.try_get_access_audit_page(&stranger, &0, &10).is_err());
+}
+
+/// Cross-read consistency: `get_access_audit(limit)` returns the newest `limit`
+/// entries (the tail), which must match the tail of the fully-paginated view —
+/// same entries, same order, including across an eviction wrap.
+#[test]
+fn test_get_access_audit_consistent_with_paginated_view() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.budget().reset_unlimited();
+    let contract_id = env.register_contract(None, FamilyWallet);
+    let client = FamilyWalletClient::new(&env, &contract_id);
+    let owner = Address::generate(&env);
+    client.init(&owner, &vec![&env]);
+
+    // Seed past the cap so the comparison also exercises post-eviction state.
+    let base: u64 = 700_000;
+    seed_audit_entries_ts(&env, &client, &owner, base, 210);
+
+    let full = collect_all_audit_timestamps(&env, &client, &owner, MAX_AUDIT_PAGE_LIMIT);
+    assert_eq!(full.len(), MAX_ACCESS_AUDIT_ENTRIES);
+
+    // For several limits, the tail read must equal the suffix of the page view.
+    for limit in [1u32, 10, MAX_AUDIT_PAGE_LIMIT, MAX_ACCESS_AUDIT_ENTRIES, 1000] {
+        let tail = client.get_access_audit(&limit);
+        let expected_len = limit.min(MAX_ACCESS_AUDIT_ENTRIES);
+        assert_eq!(tail.len(), expected_len);
+        let start = full.len() - expected_len;
+        for j in 0..expected_len {
+            assert_eq!(
+                tail.get(j).unwrap().timestamp,
+                full.get(start + j).unwrap()
+            );
+        }
+    }
+}
+
+// ============================================================================
 // Quorum Re-validation Tests
 //
 // Verify that removing members invalidates in-flight proposals that can no


### PR DESCRIPTION
Closes #781 


Summary

The ACC_AUDIT access-audit trail is the forensic record of privileged operations on a FamilyWallet. It's a bounded ring buffer (MAX_ACCESS_AUDIT_ENTRIES = 200): once full, the oldest entries are evicted and the retained set is re-indexed from 0. The existing test suite pinned cursor and clamping semantics, but eviction, post-eviction pagination, authorization, and cross-read consistency were unpinned — exactly the properties an investigator relies on after a security incident. This PR adds those tests (test-only, no production change) and documen contract.

Motivation

If pagination skips entries whcursor doesn't reflecteviction, investigators lose evidence precisely when they need it. Bounded-buffer
pagination correctness is a see, so it should be locked downby tests rather than left implicit.

Changes

family_wallet/src/test.rs (+250) — new section // Access-Audit Ring-Eviction & Cross-Read
Tests:

Two helpers:
- seed_audit_entries_ts — advances the ledger timestamp by 1 before each append, so every
entry gets a unique, monotonic verified by identity, notjust count.
- collect_all_audit_timestampsasserts the cursor advances byexactly count each step (no skip, no duplicate). Returns a Soroban Vec<u64> (this is a
#![no_std] crate, so std::vec  test module).

Six tests:

Test: test_audit_ring_evicts_o
Property pinned: Seed 250 → total capped at 200; oldest 50 evicted, newest retained;
  evicted prefix never appearstrictly contiguous
────────────────────────────────────────
Test: test_audit_ring_exactly_
Property pinned: Exactly 200 entries → nothing evicted, oldest still present
──────────────────────────────
Test: test_audit_ring_one_over_max_evicts_single_oldest
Property pinned: 201 entries →victed
────────────────────────────────────────
Test: test_audit_page_post_evi
Property pinned: Page size 7 (non-dividing) across the wrap → monotonic cursor over
  post-eviction indices
────────────────────────────────────────
Test: test_audit_page_authoriz
Property pinned: Owner/Admin allowed; Member and non-member rejected by the role gate
──────────────────────────────
Test: test_get_access_audit_consistent_with_paginated_view
Property pinned: get_access_ausuffix) of the paginated view,
  across an eviction wrap

Each seeding-heavy test calls env.budget().reset_unlimited() (existing repo convention) —
rebuilding the 200-entry ring ips Budget/ExceededLimit inthe metered test host.

docs/fw-access-audit-pagination.md (+60):
- New Ring-buffer eviction secforensic "rolling window / nota retention guarantee" caveat, and a worked 250-entry example (timestamps 1000–1049
evicted, 1050–1249 retained).
- New Relationship to get_access_audit section: the tail read is the suffix of the
paginated view, consistent by
- Extended the test-coverage table with the six new tests.

Edge cases covered

Exactly at MAX_ACCESS_AUDIT_ENTRIES (200), one over (201), well over (230/250), cursor
past end, page size that doesn, and limit beyondMAX_AUDIT_PAGE_LIMIT (via the cross-read test's limit sweep [1, 10, 50, 200, 1000]).
These complement the pre-existd u32::MAX-offset tests.

Testing

cargo test -p family_wallet aued (6 new)
cargo clippy -p family_wallet --tests  # exit 0; no new warnings

The ~29 inconsistent_digit_grouping clippy warnings are all pre-existing (lines
1150–2308); none originate fro

Notes / observation

No eviction or pagination bug on behaves correctly, so thisis test + docs only.

One discrepancy surfaced and is now documented (not changed, as it's outside this
test-only scope): get_access_at get_access_audit (the simpler tail read) has no authorization check. Flagging for a maintainer decision on whether the
tail read should also require
