### PR TITLE
test(common): add clamp_limit property tests and document contract

### DIFF
--- a/docs/pagination-limit-contract.md
+++ b/docs/pagination-limit-contract.md
@@ -1,0 +1,16 @@
+# Pagination Limit Contract
+
+`remitwise-common::clamp_limit` is the canonical normalizer for caller-supplied
+pagination limits used by paginated reads across the Remitwise contracts.
+
+The contract is:
+
+- `0` maps to `DEFAULT_PAGE_LIMIT` (`20`).
+- `1..=MAX_PAGE_LIMIT` passes through unchanged.
+- Values greater than `MAX_PAGE_LIMIT` clamp to `MAX_PAGE_LIMIT` (`50`).
+- The normalized output is always in `1..=MAX_PAGE_LIMIT`.
+- Normalization is idempotent: `clamp_limit(clamp_limit(x)) == clamp_limit(x)`.
+- `u32::MAX` and other oversized inputs clamp directly without overflow.
+
+Callers should import and use this helper instead of duplicating pagination limit
+logic locally.

--- a/remitwise-common/Cargo.toml
+++ b/remitwise-common/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 soroban-sdk = "=21.7.7"
 
 [dev-dependencies]
+proptest = "1"
 soroban-sdk = { version = "=21.7.7", features = ["testutils"] }
 
 [lib]

--- a/remitwise-common/src/lib.rs
+++ b/remitwise-common/src/lib.rs
@@ -104,12 +104,17 @@ pub const CONTRACT_VERSION: u32 = 1;
 /// Maximum batch size for operations
 pub const MAX_BATCH_SIZE: u32 = 50;
 
-/// Clamps a pagination limit to ensure it falls within the allowed boundaries.
+/// Normalizes caller-supplied pagination limits for all shared paginated reads.
 ///
-/// # Behavior
+/// # Contract
 /// - `0` is treated as a request for the default limit and returns `DEFAULT_PAGE_LIMIT`.
 /// - Values between `1` and `MAX_PAGE_LIMIT` (inclusive) are passed through unchanged.
 /// - Values greater than `MAX_PAGE_LIMIT` are capped at `MAX_PAGE_LIMIT`.
+/// - The returned value is always in `1..=MAX_PAGE_LIMIT`.
+/// - The function is idempotent: applying it to an already-normalized value returns
+///   the same value.
+/// - Extremely large inputs, including `u32::MAX`, clamp without arithmetic and
+///   cannot overflow.
 pub fn clamp_limit(limit: u32) -> u32 {
     if limit == 0 {
         DEFAULT_PAGE_LIMIT

--- a/remitwise-common/src/tests.rs
+++ b/remitwise-common/src/tests.rs
@@ -16,6 +16,7 @@
 extern crate std;
 
 use super::*;
+use proptest::prelude::*;
 use soroban_sdk::{Env, String, Vec};
 
 // helper: build a single-element tag Vec
@@ -292,4 +293,38 @@ fn test_clamp_limit_one_above_max_clamped() {
 #[test]
 fn test_clamp_limit_u32_max_clamped() {
     assert_eq!(clamp_limit(u32::MAX), MAX_PAGE_LIMIT);
+}
+
+proptest! {
+    /// Property test for the shared pagination limit normalizer.
+    ///
+    /// This pins the full contract consumed by paginated reads across contracts:
+    /// zero selects the default, oversized limits clamp to the maximum, in-range
+    /// values pass through, output remains bounded, and normalization is idempotent.
+    #[test]
+    fn proptest_clamp_limit_contract(limit in any::<u32>()) {
+        let clamped = clamp_limit(limit);
+
+        if limit == 0 {
+            prop_assert_eq!(clamped, DEFAULT_PAGE_LIMIT);
+        } else if limit > MAX_PAGE_LIMIT {
+            prop_assert_eq!(clamped, MAX_PAGE_LIMIT);
+        } else {
+            prop_assert_eq!(clamped, limit);
+        }
+
+        prop_assert!((1..=MAX_PAGE_LIMIT).contains(&clamped));
+        prop_assert_eq!(clamp_limit(clamped), clamped);
+    }
+}
+
+/// Explicit regression pin for the largest u32 input: it must clamp without
+/// overflow or special-case caller handling.
+#[test]
+fn test_clamp_limit_u32_max_contract_regression() {
+    let clamped = clamp_limit(u32::MAX);
+
+    assert_eq!(clamped, MAX_PAGE_LIMIT);
+    assert!((1..=MAX_PAGE_LIMIT).contains(&clamped));
+    assert_eq!(clamp_limit(clamped), clamped);
 }


### PR DESCRIPTION
Closes #774

### Summary

- Added property-based tests for `clamp_limit`
- Verified zero maps to `DEFAULT_PAGE_LIMIT`
- Verified values above `MAX_PAGE_LIMIT` clamp to `MAX_PAGE_LIMIT`
- Verified in-range values pass through unchanged
- Asserted bounded output and idempotency
- Added explicit `u32::MAX` regression coverage
- Documented the shared pagination limit contract

### Testing
- `git diff --check` passed
- `cargo test` and `cargo clippy` could not be run in this environment because `cargo` was unavailable on `PATH