### PR TITLE
test(orchestrator): pin signed-flow deadline window boundaries

### DIFF
--- a/EVENTS.md
+++ b/EVENTS.md
@@ -789,6 +789,12 @@ pub struct EmergencyModeEvent {
 **Primary Topic Prefix:** `"orch"` for direct events, `"Remitwise"` for categorized events  
 **Documentation:** [docs/orchestrator-events.md](docs/orchestrator-events.md)
 
+> **Note:** Signed flows (`execute_remittance_flow_signed`) only emit the `flow`
+> lifecycle events below after passing the deadline-window and nonce checks. A
+> request rejected for an expired/out-of-window deadline returns
+> `DeadlineExpired` before emitting any flow event. See
+> [docs/orchestrator-deadline-window.md](docs/orchestrator-deadline-window.md).
+
 ### Event: Flow Started
 
 **Topic:** `("Remitwise", EventCategory::Transaction, EventPriority::High, "flow")`  

--- a/docs/orchestrator-deadline-window.md
+++ b/docs/orchestrator-deadline-window.md
@@ -1,0 +1,77 @@
+# Orchestrator: Signed-Flow Deadline Window Semantics
+
+## Overview
+`Orchestrator::execute_remittance_flow_signed` (orchestrator/src/lib.rs) accepts
+a signed authorization that is valid only for a bounded window after the ledger
+timestamp at submission. The window bounds how long a signed flow authorization
+remains exploitable if a signature leaks, limiting the blast radius of a captured
+signature. The bound is enforced in `require_nonce_hardened` together with the
+per-address nonce replay protection.
+
+## Constants
+- `MAX_DEADLINE_WINDOW_SECS` = 3,600 (1 hour)
+
+## Deadline Validation Rules
+The check is performed before the execution lock is taken and before any
+`ExecutionStats` mutation:
+
+```rust
+let now = env.ledger().timestamp();
+if deadline <= now {
+    return Err(OrchestratorError::DeadlineExpired);
+}
+if deadline > now + MAX_DEADLINE_WINDOW_SECS {
+    return Err(OrchestratorError::DeadlineExpired);
+}
+```
+
+| Condition                                       | Result            |
+|-------------------------------------------------|-------------------|
+| `deadline < now`                                | `DeadlineExpired` |
+| `deadline == now`                               | `DeadlineExpired` |
+| `deadline == now + 1`                           | Accepted          |
+| `deadline == now + MAX_DEADLINE_WINDOW_SECS`    | Accepted (edge)   |
+| `deadline == now + MAX_DEADLINE_WINDOW_SECS + 1`| `DeadlineExpired` |
+
+**Inclusive upper edge:** the window comparison is strictly
+`deadline > now + MAX_DEADLINE_WINDOW_SECS`, so a deadline exactly at
+`now + MAX_DEADLINE_WINDOW_SECS` is **accepted**. The lower bound is strict
+(`deadline <= now` rejected), so `now` and any past timestamp are rejected.
+
+## Security Properties
+- A deadline-rejected call returns `DeadlineExpired` **before** the execution
+  lock is set, before the nonce advances, and before `ExecutionStats` is touched.
+  Rejected calls therefore leave both the nonce counter and the stats counters
+  unchanged.
+- The deadline window operates alongside the nonce replay protection: even a
+  signature whose deadline is still in-window cannot be replayed once its nonce
+  has been consumed — the advanced per-address counter rejects the stale nonce
+  with `InvalidNonce`. See [orchestrator-nonce.md](orchestrator-nonce.md).
+- The deadline is one of the fields folded into the request hash binding, so a
+  captured signature cannot be re-pointed at a different deadline without
+  breaking the hash check.
+
+## Replay Window
+A signed request is valid for at most 1 hour from the ledger timestamp at
+submission. Requests with deadlines beyond this window are rejected as
+`DeadlineExpired` to prevent unbounded replay windows.
+
+## Test Coverage
+Boundary semantics are pinned in
+[orchestrator/src/test.rs](../orchestrator/src/test.rs):
+
+- `test_signed_deadline_at_window_edge_accepted` — inclusive upper edge accepted
+- `test_signed_deadline_one_past_window_rejected` — one second beyond rejected
+- `test_signed_deadline_in_past_rejected` — past deadline rejected
+- `test_signed_in_window_replay_with_used_nonce_rejected` — nonce uniqueness
+  enforced alongside the still-valid deadline
+- `test_signed_deadline_rejected_does_not_mutate_stats` — no `ExecutionStats`
+  mutation on a deadline-rejected call
+
+Pre-existing related tests: `test_execute_flow_deadline_expired`,
+`test_execute_flow_deadline_too_far`, `test_deadline_window_prevents_old_requests`.
+
+## Events
+The deadline check runs before the `flow` lifecycle event is emitted, so a
+deadline-rejected signed call emits no flow events. See the orchestrator entries
+in [EVENTS.md](../EVENTS.md) and [orchestrator-events.md](orchestrator-events.md).

--- a/orchestrator/src/test.rs
+++ b/orchestrator/src/test.rs
@@ -602,3 +602,171 @@ fn test_deadline_window_prevents_old_requests() {
         "Request with deadline too far in future should fail"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Signed-flow deadline window boundary tests
+//
+// The signed entrypoint `execute_remittance_flow_signed` bounds the validity
+// of a signed authorization to `MAX_DEADLINE_WINDOW_SECS` (1 hour) past the
+// ledger timestamp. The boundary semantics enforced by
+// `require_nonce_hardened` (orchestrator/src/lib.rs) are:
+//
+//   deadline <  now                          -> DeadlineExpired (past)
+//   deadline == now                          -> DeadlineExpired (not strictly future)
+//   deadline == now + 1                      -> Accepted
+//   deadline == now + MAX_DEADLINE_..SECS    -> Accepted  (inclusive upper edge)
+//   deadline == now + MAX_DEADLINE_..SECS+1  -> DeadlineExpired (beyond window)
+//
+// The comparisons are `deadline <= now` (reject) and
+// `deadline > now + MAX_DEADLINE_WINDOW_SECS` (reject), so the upper edge is
+// inclusive. These tests pin each edge exactly so an off-by-one regression in
+// either comparison is caught. See docs/orchestrator-deadline-window.md.
+// ---------------------------------------------------------------------------
+
+/// A signed deadline exactly at `now + MAX_DEADLINE_WINDOW_SECS` is the
+/// inclusive upper edge of the window and MUST be accepted: the window check is
+/// `deadline > now + MAX_DEADLINE_WINDOW_SECS`, so equality passes through.
+#[test]
+fn test_signed_deadline_at_window_edge_accepted() {
+    let (env, owner) = setup_test();
+    let client = register_orchestrator(&env);
+    init_orchestrator(&env, &client, &owner);
+
+    // Use a non-zero ledger time so the edge arithmetic is unambiguous.
+    env.ledger().set_timestamp(1_000);
+    let executor = Address::generate(&env);
+
+    let now = env.ledger().timestamp();
+    let deadline = now + MAX_DEADLINE_WINDOW_SECS; // exactly at the edge
+    let hash = compute_test_hash(&env, symbol_short!("flow"), 0, 1000, deadline);
+
+    let result =
+        client.try_execute_remittance_flow_signed(&executor, &1000, &0, &deadline, &hash);
+
+    assert_eq!(
+        result,
+        Ok(Ok(true)),
+        "deadline == now + MAX_DEADLINE_WINDOW_SECS is the inclusive edge and must be accepted"
+    );
+    // Nonce advanced, confirming the flow actually executed (not silently no-op'd).
+    assert_eq!(client.get_nonce(&executor), 1);
+}
+
+/// One second beyond the window edge MUST be rejected with the typed
+/// `DeadlineExpired` error and MUST NOT advance the nonce.
+#[test]
+fn test_signed_deadline_one_past_window_rejected() {
+    let (env, owner) = setup_test();
+    let client = register_orchestrator(&env);
+    init_orchestrator(&env, &client, &owner);
+
+    env.ledger().set_timestamp(1_000);
+    let executor = Address::generate(&env);
+
+    let now = env.ledger().timestamp();
+    let deadline = now + MAX_DEADLINE_WINDOW_SECS + 1; // one second too far
+    let hash = compute_test_hash(&env, symbol_short!("flow"), 0, 1000, deadline);
+
+    let result =
+        client.try_execute_remittance_flow_signed(&executor, &1000, &0, &deadline, &hash);
+
+    assert_eq!(
+        result,
+        Err(Ok(OrchestratorError::DeadlineExpired)),
+        "deadline one second beyond the window must be rejected with DeadlineExpired"
+    );
+    // A rejected call must leave the nonce counter untouched.
+    assert_eq!(client.get_nonce(&executor), 0);
+}
+
+/// A deadline strictly in the past MUST be rejected with `DeadlineExpired`.
+#[test]
+fn test_signed_deadline_in_past_rejected() {
+    let (env, owner) = setup_test();
+    let client = register_orchestrator(&env);
+    init_orchestrator(&env, &client, &owner);
+
+    env.ledger().set_timestamp(5_000);
+    let executor = Address::generate(&env);
+
+    let now = env.ledger().timestamp();
+    let deadline = now - 1; // strictly in the past
+    let hash = compute_test_hash(&env, symbol_short!("flow"), 0, 1000, deadline);
+
+    let result =
+        client.try_execute_remittance_flow_signed(&executor, &1000, &0, &deadline, &hash);
+
+    assert_eq!(
+        result,
+        Err(Ok(OrchestratorError::DeadlineExpired)),
+        "deadline in the past must be rejected with DeadlineExpired"
+    );
+    assert_eq!(client.get_nonce(&executor), 0);
+}
+
+/// The signed flow enforces nonce uniqueness alongside the deadline check: a
+/// signature that is still inside its deadline window cannot be replayed once
+/// its nonce has been consumed. After a successful execution the per-address
+/// counter advances, so re-submitting the identical (still-in-window) request
+/// is rejected even though the deadline itself remains valid.
+#[test]
+fn test_signed_in_window_replay_with_used_nonce_rejected() {
+    let (env, owner) = setup_test();
+    let client = register_orchestrator(&env);
+    init_orchestrator(&env, &client, &owner);
+
+    env.ledger().set_timestamp(1_000);
+    let executor = Address::generate(&env);
+
+    let now = env.ledger().timestamp();
+    let deadline = now + MAX_DEADLINE_WINDOW_SECS; // valid, in-window
+    let hash = compute_test_hash(&env, symbol_short!("flow"), 0, 1000, deadline);
+
+    // First call succeeds and consumes nonce 0.
+    let first =
+        client.try_execute_remittance_flow_signed(&executor, &1000, &0, &deadline, &hash);
+    assert_eq!(first, Ok(Ok(true)));
+    assert_eq!(client.get_nonce(&executor), 1);
+
+    // Replay the identical request while the deadline is still in-window. The
+    // deadline check passes, but the advanced counter rejects the stale nonce.
+    let replay =
+        client.try_execute_remittance_flow_signed(&executor, &1000, &0, &deadline, &hash);
+    assert_eq!(
+        replay,
+        Err(Ok(OrchestratorError::InvalidNonce)),
+        "in-window replay of a consumed nonce must be rejected"
+    );
+    // The counter does not advance again on the rejected replay.
+    assert_eq!(client.get_nonce(&executor), 1);
+}
+
+/// A deadline-rejected signed call MUST NOT mutate `ExecutionStats`. The stats
+/// counters are only touched after the validation gate in
+/// `require_nonce_hardened` passes, so a deadline rejection (which returns
+/// before the lock/execute path) must leave every counter untouched.
+#[test]
+fn test_signed_deadline_rejected_does_not_mutate_stats() {
+    let (env, owner) = setup_test();
+    let client = register_orchestrator(&env);
+    init_orchestrator(&env, &client, &owner);
+
+    env.ledger().set_timestamp(1_000);
+    let executor = Address::generate(&env);
+
+    let before = client.get_execution_stats().unwrap();
+
+    // Beyond-window deadline -> DeadlineExpired before any stats mutation.
+    let now = env.ledger().timestamp();
+    let deadline = now + MAX_DEADLINE_WINDOW_SECS + 1;
+    let hash = compute_test_hash(&env, symbol_short!("flow"), 0, 1000, deadline);
+    let result =
+        client.try_execute_remittance_flow_signed(&executor, &1000, &0, &deadline, &hash);
+    assert_eq!(result, Err(Ok(OrchestratorError::DeadlineExpired)));
+
+    let after = client.get_execution_stats().unwrap();
+    assert_eq!(
+        before, after,
+        "deadline-rejected signed call must not mutate ExecutionStats"
+    );
+}


### PR DESCRIPTION
## Summary

Pins the deadline-window boundary for the signed entrypoint `Orchestrator::execute_remittance_flow_signed`. The deadline window (`MAX_DEADLINE_WINDOW_SECS` = 3600s / 1 hour) bounds how long a signed flow authorization stays valid, limiting the blast radius of a leaked signature. The nonce-replay path had tests, but the deadline boundary — the exact window edge, a past deadline, and a deadline beyond the max future window — was not pinned for the signed call.

The boundary was already fail-closed, so this is **test-only + documentation** (no behavior change required).

## Boundary semantics (verified in `require_nonce_hardened`)

The checks are `deadline <= now` (reject) and `deadline > now + MAX_DEADLINE_WINDOW_SECS` (reject):

| Deadline | Result |
|---|---|
| `< now` / `== now` | `DeadlineExpired` |
| `now + 1` … `now + MAX_DEADLINE_WINDOW_SECS` | Accepted |
| `now + MAX_DEADLINE_WINDOW_SECS` (edge) | **Accepted** (inclusive upper edge) |
| `now + MAX_DEADLINE_WINDOW_SECS + 1` | `DeadlineExpired` |

## Tests added (`orchestrator/src/test.rs`)

- `test_signed_deadline_at_window_edge_accepted` — exact edge accepted (documented edge); confirms nonce advanced
- `test_signed_deadline_one_past_window_rejected` — one second beyond → `DeadlineExpired`; nonce untouched
- `test_signed_deadline_in_past_rejected` — past deadline → `DeadlineExpired`
- `test_signed_in_window_replay_with_used_nonce_rejected` — nonce uniqueness enforced even while deadline is still valid (replay → `InvalidNonce`)
- `test_signed_deadline_rejected_does_not_mutate_stats` — `ExecutionStats` unchanged on a deadline-rejected call

## Docs

- New `docs/orchestrator-deadline-window.md` documenting the deadline-window contract (validation-rules table, security properties, replay window, test coverage)
- `EVENTS.md` cross-reference noting deadline-rejected signed calls emit no flow events

## Verification

- `cargo test -p orchestrator`: **27 passed, 0 failed** (5 new)
- `cargo clippy -p orchestrator --tests`: **0 errors**

Closes #770
