### PR TITLE
Add emergency killswitch pause precedence docs and tests

### DIFF
--- a/docs/killswitch-timelock.md
+++ b/docs/killswitch-timelock.md
@@ -49,6 +49,23 @@ stateDiagram-v2
 - `Error::Unauthorized` (1): Returned when the caller is not the admin, or if `unpause()` is called before the scheduled timelock expires.
 - `Error::InvalidSchedule` (5): Returned when `schedule_unpause()` is called with a past-dated timestamp, or when `unpause()` is called without a valid scheduled time.
 
+### E. Pause Precedence and Scope
+The `emergency_killswitch` implements layered pause scopes with the following precedence:
+- `pause()` (global pause) dominates all module and function pause state.
+- `pause_module(module)` pauses every function in the named module.
+- `pause_function(module, fn)` pauses an individual function only.
+
+`is_function_paused(env, module, fn)` returns `true` when any of these conditions are met:
+1. The contract is globally paused.
+2. The module is paused.
+3. The function is individually paused.
+
+Module-level pause is a blanket override but does not clear per-function pause flags. After `unpause_module(module)`, each function returns to its prior individual state:
+- Functions explicitly paused before or during a module pause remain paused.
+- Functions that were not individually paused before the module pause return to unpaused.
+
+These semantics are verified by unit tests in `emergency_killswitch/tests/test_killswitch.rs`.
+
 ---
 
 ## Security Verification and Testing

--- a/emergency_killswitch/tests/test_killswitch.rs
+++ b/emergency_killswitch/tests/test_killswitch.rs
@@ -153,6 +153,93 @@ fn test_per_function_pause() {
     assert!(!client.is_function_paused(&module, &func));
 }
 
+/// Verify that a function pause works independently when its module is not paused.
+#[test]
+fn test_function_pause_independent_when_module_not_paused() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, EmergencyKillswitch);
+    let client = EmergencyKillswitchClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let module = symbol_short!("bill");
+    let paused_fn = symbol_short!("pay");
+    let other_fn = symbol_short!("refund");
+
+    assert!(!client.is_function_paused(&module, &paused_fn));
+    assert!(!client.is_function_paused(&module, &other_fn));
+
+    client.pause_function(&module, &paused_fn);
+
+    assert!(client.is_function_paused(&module, &paused_fn));
+    assert!(!client.is_function_paused(&module, &other_fn));
+
+    client.unpause_function(&module, &paused_fn);
+    assert!(!client.is_function_paused(&module, &paused_fn));
+}
+
+/// Assert that module-level pause overrides function-level flags and that per-function state is preserved across module unpause.
+#[test]
+fn test_module_pause_precedence_over_function_and_restore_on_unpause() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, EmergencyKillswitch);
+    let client = EmergencyKillswitchClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let module = symbol_short!("bill");
+    let paused_fn = symbol_short!("pay");
+    let unpaused_fn = symbol_short!("refund");
+
+    assert!(!client.is_function_paused(&module, &paused_fn));
+    assert!(!client.is_function_paused(&module, &unpaused_fn));
+
+    client.pause_function(&module, &paused_fn);
+    assert!(client.is_function_paused(&module, &paused_fn));
+    assert!(!client.is_function_paused(&module, &unpaused_fn));
+
+    client.pause_module(&module);
+    assert!(client.is_function_paused(&module, &paused_fn));
+    assert!(client.is_function_paused(&module, &unpaused_fn));
+
+    client.unpause_module(&module);
+    assert!(client.is_function_paused(&module, &paused_fn));
+    assert!(!client.is_function_paused(&module, &unpaused_fn));
+}
+
+/// Assert that a global pause dominates both module and function pause scopes.
+#[test]
+fn test_global_pause_dominates_module_and_function_pause() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, EmergencyKillswitch);
+    let client = EmergencyKillswitchClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let module = symbol_short!("bill");
+    let paused_fn = symbol_short!("pay");
+    let other_fn = symbol_short!("refund");
+
+    client.pause_function(&module, &paused_fn);
+    client.pause_module(&module);
+    assert!(client.is_function_paused(&module, &paused_fn));
+    assert!(client.is_function_paused(&module, &other_fn));
+
+    client.pause();
+    assert!(client.is_paused());
+    assert!(client.is_function_paused(&module, &paused_fn));
+    assert!(client.is_function_paused(&module, &other_fn));
+}
+
 #[test]
 fn test_max_paused_functions_limit() {
     let env = Env::default();


### PR DESCRIPTION
## closes #767
 I added Emergency Killswitch: add module-vs-function pause precedence tests for pause_module / is_function_paused