### PR TITLE
test(killswitch): prove transfer_admin auth and old-admin revocation

### DIFF
--- a/docs/killswitch-admin-transfer.md
+++ b/docs/killswitch-admin-transfer.md
@@ -1,0 +1,45 @@
+# Emergency Killswitch Admin Transfer
+
+## Overview
+
+`emergency_killswitch::transfer_admin(new_admin)` rotates the single address stored at
+`DataKey::Admin`. The stored admin controls global pause, scheduled unpause,
+module pause, and per-function pause operations, so admin transfer is treated as
+an emergency control-plane operation.
+
+## Authorization Flow
+
+1. `initialize(admin)` must have completed first. If `DataKey::Admin` is absent,
+   `transfer_admin` returns `Error::NotInitialized`.
+2. `transfer_admin` loads the current `DataKey::Admin`.
+3. The current admin must authorize the call through `admin.require_auth()`.
+4. After authorization succeeds, `DataKey::Admin` is overwritten with
+   `new_admin`.
+
+Soroban auth failures occur at the host layer. A caller that cannot satisfy the
+current admin's `require_auth()` does not receive a contract-level
+`Error::Unauthorized`; the call fails with an auth `HostError`. Contract-level
+`Error::Unauthorized` remains used by logic checks such as attempting to unpause
+before the scheduled timestamp.
+
+## Security Properties
+
+- Only the address currently stored at `DataKey::Admin` can authorize a
+  successful admin rotation.
+- The previous admin loses all pause, unpause, and module-pause authority as
+  soon as `DataKey::Admin` is updated.
+- Transferring to the same address is deterministic: the stored admin remains
+  unchanged, and the admin keeps pause authority.
+- Chained transfers are single-owner at every step. For `A -> B -> C`, `B` loses
+  authority once `C` is stored.
+
+## Verification
+
+The unit tests in `emergency_killswitch/src/lib.rs` assert:
+
+- transfer before initialization returns `Error::NotInitialized`;
+- non-admin auth cannot satisfy `transfer_admin`;
+- successful transfer updates `DataKey::Admin`;
+- the new admin can `pause`, `schedule_unpause`, `unpause`, and `pause_module`;
+- the old admin cannot `pause`, `unpause`, or `pause_module`;
+- self-transfer and double-transfer behavior are deterministic.

--- a/emergency_killswitch/RUNBOOK.md
+++ b/emergency_killswitch/RUNBOOK.md
@@ -1,0 +1,25 @@
+# Emergency Killswitch Runbook
+
+## Admin Transfer
+
+Use `transfer_admin(new_admin)` only when the replacement admin account is ready
+to operate the emergency controls. The current admin must authorize the
+transaction; no other address can rotate `DataKey::Admin`.
+
+Operational steps:
+
+1. Confirm the replacement address is controlled by the intended multisig or
+   hardware-backed account.
+2. Submit `transfer_admin(new_admin)` from the current admin.
+3. Verify `DataKey::Admin` now resolves to `new_admin`.
+4. Run a controlled pause-flow check in a test or staging environment:
+   `pause`, `schedule_unpause`, `unpause`, and `pause_module`.
+5. Treat the old admin as revoked immediately after the transaction succeeds.
+
+Expected failure behavior:
+
+- Before initialization, `transfer_admin` returns `Error::NotInitialized`.
+- If the current admin does not authorize the call, Soroban rejects the
+  transaction with an auth `HostError`.
+- After transfer, any pause or unpause operation authorized by the old admin
+  fails at the Soroban auth layer.

--- a/emergency_killswitch/src/lib.rs
+++ b/emergency_killswitch/src/lib.rs
@@ -254,3 +254,299 @@ impl EmergencyKillswitch {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod transfer_admin_tests {
+    extern crate std;
+
+    use super::*;
+    use soroban_sdk::{
+        symbol_short,
+        testutils::{
+            Address as _, AuthorizedFunction, AuthorizedInvocation, Ledger, MockAuth,
+            MockAuthInvoke,
+        },
+        IntoVal, Val,
+    };
+
+    fn setup(env: &Env) -> (Address, EmergencyKillswitchClient<'_>) {
+        let contract_id = env.register_contract(None, EmergencyKillswitch);
+        let client = EmergencyKillswitchClient::new(env, &contract_id);
+        (contract_id, client)
+    }
+
+    fn assert_auth(
+        env: &Env,
+        contract_id: &Address,
+        address: &Address,
+        fn_name: &str,
+        args: soroban_sdk::Vec<Val>,
+    ) {
+        assert_eq!(
+            env.auths(),
+            std::vec![(
+                address.clone(),
+                AuthorizedInvocation {
+                    function: AuthorizedFunction::Contract((
+                        contract_id.clone(),
+                        Symbol::new(env, fn_name),
+                        args
+                    )),
+                    sub_invocations: std::vec![],
+                }
+            )]
+        );
+    }
+
+    fn mock_no_arg_auth(
+        env: &Env,
+        client: &EmergencyKillswitchClient,
+        contract_id: &Address,
+        signer: &Address,
+        fn_name: &'static str,
+    ) {
+        client.mock_auths(&[MockAuth {
+            address: signer,
+            invoke: &MockAuthInvoke {
+                contract: contract_id,
+                fn_name,
+                args: ().into_val(env),
+                sub_invokes: &[],
+            },
+        }]);
+    }
+
+    fn stored_admin(env: &Env, contract_id: &Address) -> Address {
+        env.as_contract(contract_id, || {
+            env.storage()
+                .instance()
+                .get(&DataKey::Admin)
+                .expect("admin must be stored")
+        })
+    }
+
+    fn disable_mock_all_auths(env: &Env) {
+        env.set_auths(&[]);
+    }
+
+    /// Verifies transfer_admin fails closed before initialize stores DataKey::Admin.
+    #[test]
+    fn transfer_admin_before_initialize_returns_not_initialized() {
+        let env = Env::default();
+        let (_contract_id, client) = setup(&env);
+        let new_admin = Address::generate(&env);
+
+        assert_eq!(
+            client.try_transfer_admin(&new_admin),
+            Err(Ok(Error::NotInitialized))
+        );
+    }
+
+    /// Verifies only the current DataKey::Admin authorization can rotate the admin slot.
+    #[test]
+    #[should_panic(expected = "HostError: Error(Auth, InvalidAction)")]
+    fn transfer_admin_rejects_non_admin_auth() {
+        let env = Env::default();
+        let (contract_id, client) = setup(&env);
+        let admin = Address::generate(&env);
+        let attacker = Address::generate(&env);
+        let new_admin = Address::generate(&env);
+
+        client.initialize(&admin);
+        client.mock_auths(&[MockAuth {
+            address: &attacker,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "transfer_admin",
+                args: (&new_admin,).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+
+        client.transfer_admin(&new_admin);
+    }
+
+    /// Verifies DataKey::Admin is replaced and the new admin can use every pause surface.
+    #[test]
+    fn transfer_admin_grants_new_admin_pause_powers_and_updates_storage() {
+        let env = Env::default();
+        let (contract_id, client) = setup(&env);
+        let admin = Address::generate(&env);
+        let new_admin = Address::generate(&env);
+        let module = symbol_short!("bill");
+        let func = symbol_short!("pay");
+
+        client.initialize(&admin);
+        env.mock_all_auths();
+        client.transfer_admin(&new_admin);
+        assert_auth(
+            &env,
+            &contract_id,
+            &admin,
+            "transfer_admin",
+            (&new_admin,).into_val(&env),
+        );
+
+        let stored_admin = stored_admin(&env, &contract_id);
+        assert_eq!(stored_admin, new_admin);
+
+        client.pause();
+        assert_auth(&env, &contract_id, &new_admin, "pause", ().into_val(&env));
+        assert!(client.is_paused());
+
+        let unpause_at = env.ledger().timestamp() + 10;
+        client.schedule_unpause(&unpause_at);
+        assert_auth(
+            &env,
+            &contract_id,
+            &new_admin,
+            "schedule_unpause",
+            (unpause_at,).into_val(&env),
+        );
+
+        env.ledger().set_timestamp(unpause_at);
+        client.unpause();
+        assert_auth(&env, &contract_id, &new_admin, "unpause", ().into_val(&env));
+        assert!(!client.is_paused());
+
+        client.pause_module(&module);
+        assert_auth(
+            &env,
+            &contract_id,
+            &new_admin,
+            "pause_module",
+            (module.clone(),).into_val(&env),
+        );
+        assert!(client.is_function_paused(&module, &func));
+    }
+
+    /// Verifies the old admin cannot pause globally after admin authority is transferred.
+    #[test]
+    #[should_panic(expected = "HostError: Error(Auth, InvalidAction)")]
+    fn transfer_admin_revokes_old_admin_pause() {
+        let env = Env::default();
+        let (contract_id, client) = setup(&env);
+        let admin = Address::generate(&env);
+        let new_admin = Address::generate(&env);
+
+        client.initialize(&admin);
+        env.mock_all_auths();
+        client.transfer_admin(&new_admin);
+        disable_mock_all_auths(&env);
+
+        mock_no_arg_auth(&env, &client, &contract_id, &admin, "pause");
+        client.pause();
+    }
+
+    /// Verifies the old admin cannot unpause globally after admin authority is transferred.
+    #[test]
+    #[should_panic(expected = "HostError: Error(Auth, InvalidAction)")]
+    fn transfer_admin_revokes_old_admin_unpause() {
+        let env = Env::default();
+        let (contract_id, client) = setup(&env);
+        let admin = Address::generate(&env);
+        let new_admin = Address::generate(&env);
+
+        client.initialize(&admin);
+        env.mock_all_auths();
+        client.transfer_admin(&new_admin);
+
+        client.pause();
+        let unpause_at = env.ledger().timestamp();
+        client.schedule_unpause(&unpause_at);
+        disable_mock_all_auths(&env);
+
+        mock_no_arg_auth(&env, &client, &contract_id, &admin, "unpause");
+        client.unpause();
+    }
+
+    /// Verifies the old admin cannot pause modules after admin authority is transferred.
+    #[test]
+    #[should_panic(expected = "HostError: Error(Auth, InvalidAction)")]
+    fn transfer_admin_revokes_old_admin_pause_module() {
+        let env = Env::default();
+        let (contract_id, client) = setup(&env);
+        let admin = Address::generate(&env);
+        let new_admin = Address::generate(&env);
+        let module = symbol_short!("bill");
+
+        client.initialize(&admin);
+        env.mock_all_auths();
+        client.transfer_admin(&new_admin);
+        disable_mock_all_auths(&env);
+
+        client.mock_auths(&[MockAuth {
+            address: &admin,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "pause_module",
+                args: (module.clone(),).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        client.pause_module(&module);
+    }
+
+    /// Verifies transferring to the same admin is a no-op that still requires current admin auth.
+    #[test]
+    fn transfer_admin_to_self_is_deterministic() {
+        let env = Env::default();
+        let (contract_id, client) = setup(&env);
+        let admin = Address::generate(&env);
+
+        client.initialize(&admin);
+        env.mock_all_auths();
+        client.transfer_admin(&admin);
+        assert_auth(
+            &env,
+            &contract_id,
+            &admin,
+            "transfer_admin",
+            (&admin,).into_val(&env),
+        );
+
+        let stored_admin = stored_admin(&env, &contract_id);
+        assert_eq!(stored_admin, admin);
+
+        client.pause();
+        assert_auth(&env, &contract_id, &admin, "pause", ().into_val(&env));
+        assert!(client.is_paused());
+    }
+
+    /// Verifies double transfer A->B->C revokes B and leaves only C as DataKey::Admin.
+    #[test]
+    #[should_panic(expected = "HostError: Error(Auth, InvalidAction)")]
+    fn transfer_admin_double_transfer_revokes_intermediate_admin() {
+        let env = Env::default();
+        let (contract_id, client) = setup(&env);
+        let admin_a = Address::generate(&env);
+        let admin_b = Address::generate(&env);
+        let admin_c = Address::generate(&env);
+
+        client.initialize(&admin_a);
+        env.mock_all_auths();
+        client.transfer_admin(&admin_b);
+        assert_auth(
+            &env,
+            &contract_id,
+            &admin_a,
+            "transfer_admin",
+            (&admin_b,).into_val(&env),
+        );
+        client.transfer_admin(&admin_c);
+        assert_auth(
+            &env,
+            &contract_id,
+            &admin_b,
+            "transfer_admin",
+            (&admin_c,).into_val(&env),
+        );
+
+        let stored_admin = stored_admin(&env, &contract_id);
+        assert_eq!(stored_admin, admin_c);
+
+        disable_mock_all_auths(&env);
+        mock_no_arg_auth(&env, &client, &contract_id, &admin_b, "pause");
+        client.pause();
+    }
+}


### PR DESCRIPTION
Summary

  Adds adversarial coverage for `EmergencyKillswitch::transfer_admin` to prove
  the admin role can only be rotated by the current `DataKey::Admin`, and that
  the old admin loses emergency control powers immediately after transfer.

  Also documents the admin-transfer flow and operational expectations in the
  killswitch docs/runbook.

  ## What Changed

  - Added `transfer_admin` unit tests in `emergency_killswitch/src/lib.rs`
  covering:
    - transfer before initialization returns `Error::NotInitialized`;
    - non-admin auth cannot satisfy `transfer_admin`;
    - successful transfer updates `DataKey::Admin`;
    - new admin can `pause`, `schedule_unpause`, `unpause`, and `pause_module`;
    - old admin cannot `pause`, `unpause`, or `pause_module`;
    - self-transfer behavior is deterministic;
    - double transfer `A -> B -> C` revokes the intermediate admin.
  - Added exact Soroban auth assertions for successful admin-authorized calls.
  - Added `docs/killswitch-admin-transfer.md`.
  - Added `emergency_killswitch/RUNBOOK.md`.

  ## Security Note

  Soroban `require_auth()` failures surface as host-level auth failures
  (`HostError: Error(Auth, InvalidAction)`), not as contract-level
  `Error::Unauthorized`. The tests assert that behavior for unauthorized admin-
  transfer and old-admin revocation paths. `Error::Unauthorized` remains used
  for contract logic checks such as premature unpause.

  ## Verification

  ```bash
  cargo test -p emergency_killswitch transfer_admin -- --nocapture
  cargo test -p emergency_killswitch
  cargo clippy -p emergency_killswitch --all-targets -- -D warnings
  rustfmt --check emergency_killswitch/src/lib.rs

  All commands passed.
Closes #Summary

  Adds adversarial coverage for `EmergencyKillswitch::transfer_admin` to prove
  the admin role can only be rotated by the current `DataKey::Admin`, and that
  the old admin loses emergency control powers immediately after transfer.

  Also documents the admin-transfer flow and operational expectations in the
  killswitch docs/runbook.

  ## What Changed

  - Added `transfer_admin` unit tests in `emergency_killswitch/src/lib.rs`
  covering:
    - transfer before initialization returns `Error::NotInitialized`;
    - non-admin auth cannot satisfy `transfer_admin`;
    - successful transfer updates `DataKey::Admin`;
    - new admin can `pause`, `schedule_unpause`, `unpause`, and `pause_module`;
    - old admin cannot `pause`, `unpause`, or `pause_module`;
    - self-transfer behavior is deterministic;
    - double transfer `A -> B -> C` revokes the intermediate admin.
  - Added exact Soroban auth assertions for successful admin-authorized calls.
  - Added `docs/killswitch-admin-transfer.md`.
  - Added `emergency_killswitch/RUNBOOK.md`.

  ## Security Note

  Soroban `require_auth()` failures surface as host-level auth failures
  (`HostError: Error(Auth, InvalidAction)`), not as contract-level
  `Error::Unauthorized`. The tests assert that behavior for unauthorized admin-
  transfer and old-admin revocation paths. `Error::Unauthorized` remains used
  for contract logic checks such as premature unpause.

  ## Verification

  ```bash
  cargo test -p emergency_killswitch transfer_admin -- --nocapture
  cargo test -p emergency_killswitch
  cargo clippy -p emergency_killswitch --all-targets -- -D warnings
  rustfmt --check emergency_killswitch/src/lib.rs

  All commands passed.
Closes #768 