### PR TITLE
refactor(bill_payments): emit declared BillEvent variants

### DIFF
--- a/CHANGELOG_CONTRACTS.md
+++ b/CHANGELOG_CONTRACTS.md
@@ -22,6 +22,16 @@ This document tracks changes, versions, and migration notes for each of the smar
 
 ## Bill Payments (`bill_payments`)
 
+### Unreleased
+
+- **Summary**: Aligns Bill Payments event emissions with the declared `BillEvent` taxonomy.
+- **Indexer Notes**:
+  - `cancel_bill` now emits `BillEvent::Cancelled` with `(bill_id, owner, cancelled_at)`.
+  - `restore_bill` now emits `BillEvent::Restored` with `(bill_id, owner, restored_at)`.
+  - `set_external_ref` now emits `BillEvent::ExternalRefUpdated` with `(bill_id, owner, external_ref, updated_at)`.
+  - `batch_pay_bills` emits per-bill `BillEvent::Paid` events for successful items, matching `pay_bill`.
+- **Migration Notes**: Indexers should subscribe to the direct `("bill", BillEvent::...)` topics for canonical bill lifecycle events; generic `Remitwise` audit topics remain available for compatibility.
+
 ### v0.1.0
 
 - **Summary**: Initial release of the Bill Payments contract.

--- a/EVENTS.md
+++ b/EVENTS.md
@@ -100,17 +100,18 @@ pub struct Bill {
 
 ### Event: Bill Paid
 
-**Topic:** `"Remitwise"` (category: Transaction, priority: High)  
-**Action Symbol:** `"pay_bill"`
+**BillEvent Topic:** `("bill", BillEvent::Paid)`
+**Remitwise Topic:** `"Remitwise"` (category: Transaction, priority: High)
+**Remitwise Action Symbol:** `"paid"`
+**Emitted by:** `pay_bill`; each successful item in `batch_pay_bills`
 
 **Data Structure:**
 ```rust
-pub struct BillPaidEvent {
-    pub bill_id: u32,               // ID of paid bill
-    pub owner: Address,             // Bill owner
-    pub amount: i128,               // Amount paid
-    pub paid_at: u64,               // Payment timestamp
-}
+// BillEvent payload
+(bill_id: u32, owner: Address, external_ref: Option<String>)
+
+// Remitwise action payload
+(bill_id: u32, owner: Address, amount: i128)
 ```
 
 **Example Event:**
@@ -118,23 +119,44 @@ pub struct BillPaidEvent {
 {
   "bill_id": 1,
   "owner": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-  "amount": 1000,
-  "paid_at": 1234567850
+  "external_ref": null
+}
+```
+
+### Event: Bill External Reference Updated
+
+**BillEvent Topic:** `("bill", BillEvent::ExternalRefUpdated)`
+**Remitwise Topic:** `"Remitwise"` (category: State, priority: Medium)
+**Remitwise Action Symbol:** `"ext_ref"`
+
+**Data Structure:**
+```rust
+// BillEvent payload
+(bill_id: u32, owner: Address, external_ref: Option<String>, updated_at: u64)
+
+// Remitwise action payload
+(bill_id: u32, owner: Address, external_ref: Option<String>)
+```
+
+**Example Event:**
+```json
+{
+  "bill_id": 1,
+  "owner": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+  "external_ref": "INV-2026-001",
+  "updated_at": 1234567900
 }
 ```
 
 ### Event: Bill Cancelled
 
-**Topic:** `"Remitwise"` (category: State, priority: Medium)  
-**Action Symbol:** `"can_bill"`
+**BillEvent Topic:** `("bill", BillEvent::Cancelled)`
+**Remitwise Topic:** `"Remitwise"` (category: State, priority: Medium)
+**Remitwise Action Symbol:** `"can_bill"`
 
 **Data Structure:**
 ```rust
-pub struct BillCancelledEvent {
-    pub bill_id: u32,               // ID of cancelled bill
-    pub owner: Address,             // Bill owner
-    pub cancelled_at: u64,          // Cancellation timestamp
-}
+(bill_id: u32, owner: Address, cancelled_at: u64)
 ```
 
 ### Event: Bills Archived
@@ -152,16 +174,13 @@ pub struct BillsArchivedEvent {
 
 ### Event: Bill Restored
 
-**Topic:** `"Remitwise"` (category: State, priority: Medium)  
-**Action Symbol:** `"restore"`
+**BillEvent Topic:** `("bill", BillEvent::Restored)`
+**Remitwise Topic:** `"Remitwise"` (category: State, priority: Medium)
+**Remitwise Action Symbol:** `"restore"`
 
 **Data Structure:**
 ```rust
-pub struct BillRestoredEvent {
-    pub bill_id: u32,               // ID of restored bill
-    pub owner: Address,             // Bill owner
-    pub restored_at: u64,           // Restoration timestamp
-}
+(bill_id: u32, owner: Address, restored_at: u64)
 ```
 
 ### Event: Contract Paused/Unpaused

--- a/INDEXER_FEATURE.md
+++ b/INDEXER_FEATURE.md
@@ -46,7 +46,7 @@ Smart contracts emit events but don't provide efficient querying capabilities. T
 | Contract | Events Tracked | Entities |
 |----------|----------------|----------|
 | Savings Goals | goal_created, goal_deposit, goal_withdraw, tags_add, tags_rem | SavingsGoal |
-| Bill Payments | bill_created, bill_paid, tags_add, tags_rem | Bill |
+| Bill Payments | bill_created, bill_paid, bill_external_ref_updated, bill_cancelled, bill_restored, tags_add, tags_rem | Bill |
 | Insurance | policy_created, tags_add, tags_rem | InsurancePolicy |
 | Remittance Split | split_created, split_executed | RemittanceSplit |
 

--- a/bill_payments/README.md
+++ b/bill_payments/README.md
@@ -333,6 +333,11 @@ let overdue_page = bill_payments::get_overdue_bills(env, 0, 10);
 The contract emits events for audit trails:
 - `BillEvent::Created`: When a bill is created
 - `BillEvent::Paid`: When a bill is paid
+- `BillEvent::ExternalRefUpdated`: When a bill external reference is set or cleared
+- `BillEvent::Cancelled`: When an active bill is cancelled
+- `BillEvent::Restored`: When an archived bill is restored
+
+`batch_pay_bills` emits one `BillEvent::Paid` event for each successfully paid bill, matching the single-bill `pay_bill` event shape.
 
 ## Integration Patterns
 

--- a/bill_payments/src/events_schema_test.rs
+++ b/bill_payments/src/events_schema_test.rs
@@ -13,7 +13,11 @@
 
 use super::*;
 use crate::pause_functions::{ARCHIVE, CANCEL_BILL, CREATE_BILL, PAY_BILL, RESTORE};
-use soroban_sdk::{symbol_short, Env, IntoVal, Symbol, TryFromVal, Val};
+use soroban_sdk::{
+    symbol_short,
+    testutils::{Address as _, Events, Ledger},
+    Address, Env, IntoVal, String as SorobanString, Symbol, TryFromVal, Val, Vec as SorobanVec,
+};
 
 // ---------------------------------------------------------------------------
 // Pause-function symbols
@@ -48,9 +52,9 @@ fn remitwise_action_symbols_are_stable() {
     let actions = [
         symbol_short!("created"),
         symbol_short!("paid"),
-        symbol_short!("canceled"),
+        symbol_short!("can_bill"),
         symbol_short!("archived"),
-        symbol_short!("restored"),
+        symbol_short!("restore"),
         symbol_short!("cleaned"),
         symbol_short!("ext_ref"),
         symbol_short!("paused"),
@@ -63,6 +67,94 @@ fn remitwise_action_symbols_are_stable() {
         symbol_short!("f_pay_pd"),
     ];
     assert_eq!(actions.len(), 15);
+}
+
+fn bill_event_matches(env: &Env, val: &Val, expected: &BillEvent) -> bool {
+    let Ok(decoded) = BillEvent::try_from_val(env, val) else {
+        return false;
+    };
+    matches!(
+        (&decoded, expected),
+        (BillEvent::Created, BillEvent::Created)
+            | (BillEvent::Paid, BillEvent::Paid)
+            | (BillEvent::ExternalRefUpdated, BillEvent::ExternalRefUpdated)
+            | (BillEvent::Cancelled, BillEvent::Cancelled)
+            | (BillEvent::Archived, BillEvent::Archived)
+            | (BillEvent::Restored, BillEvent::Restored)
+            | (BillEvent::ScheduleCreated, BillEvent::ScheduleCreated)
+            | (BillEvent::ScheduleExecuted, BillEvent::ScheduleExecuted)
+            | (BillEvent::ScheduleMissed, BillEvent::ScheduleMissed)
+            | (BillEvent::ScheduleModified, BillEvent::ScheduleModified)
+            | (BillEvent::ScheduleCancelled, BillEvent::ScheduleCancelled)
+            | (
+                BillEvent::RecurringBillCreated,
+                BillEvent::RecurringBillCreated,
+            )
+    )
+}
+
+fn is_direct_bill_event(env: &Env, topics: &SorobanVec<Val>, expected: &BillEvent) -> bool {
+    if topics.len() != 2 {
+        return false;
+    }
+    let Ok(namespace) = Symbol::try_from_val(env, &topics.get(0).unwrap()) else {
+        return false;
+    };
+    namespace == symbol_short!("bill") && bill_event_matches(env, &topics.get(1).unwrap(), expected)
+}
+
+fn has_remitwise_action(env: &Env, action: Symbol) -> bool {
+    for (_, topics, _) in env.events().all() {
+        if topics.len() != 4 {
+            continue;
+        }
+        let Ok(namespace) = Symbol::try_from_val(env, &topics.get(0).unwrap()) else {
+            continue;
+        };
+        let Ok(actual_action) = Symbol::try_from_val(env, &topics.get(3).unwrap()) else {
+            continue;
+        };
+        if namespace == symbol_short!("Remitwise") && actual_action == action {
+            return true;
+        }
+    }
+    false
+}
+
+fn count_direct_bill_events(env: &Env, contract_id: &Address, expected: BillEvent) -> u32 {
+    let mut count = 0;
+    for (cid, topics, _) in env.events().all() {
+        if cid == *contract_id && is_direct_bill_event(env, &topics, &expected) {
+            count += 1;
+        }
+    }
+    count
+}
+
+fn create_test_bill(env: &Env, client: &BillPaymentsClient, owner: &Address) -> u32 {
+    client.create_bill(
+        owner,
+        &SorobanString::from_str(env, "Utility"),
+        &100,
+        &1_000_000,
+        &false,
+        &0,
+        &None,
+        &SorobanString::from_str(env, "XLM"),
+        &None,
+    )
+}
+
+fn direct_bill_payload<T>(env: &Env, contract_id: &Address, expected: BillEvent) -> Option<T>
+where
+    T: TryFromVal<Env, Val>,
+{
+    for (cid, topics, data) in env.events().all() {
+        if cid == *contract_id && is_direct_bill_event(env, &topics, &expected) {
+            return T::try_from_val(env, &data).ok();
+        }
+    }
+    None
 }
 
 // ---------------------------------------------------------------------------
@@ -96,6 +188,92 @@ fn bill_event_variant_set_is_stable() {
         // `(bill, BillEvent::Foo)` keeps publishing.
         let _: Val = v.into_val(&env);
     }
+}
+
+#[test]
+fn external_ref_update_emits_declared_bill_event_variant() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(42);
+    let contract_id = env.register_contract(None, BillPayments);
+    let client = BillPaymentsClient::new(&env, &contract_id);
+    let owner = Address::generate(&env);
+    let bill_id = create_test_bill(&env, &client, &owner);
+    let external_ref = Some(SorobanString::from_str(&env, "INV-2026-001"));
+
+    client.set_external_ref(&owner, &bill_id, &external_ref);
+
+    let payload: (u32, Address, Option<SorobanString>, u64) =
+        direct_bill_payload(&env, &contract_id, BillEvent::ExternalRefUpdated)
+            .expect("ExternalRefUpdated event missing");
+    assert_eq!(payload, (bill_id, owner.clone(), external_ref, 42));
+    assert!(has_remitwise_action(&env, symbol_short!("ext_ref")));
+}
+
+#[test]
+fn cancel_bill_emits_declared_bill_event_variant() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(84);
+    let contract_id = env.register_contract(None, BillPayments);
+    let client = BillPaymentsClient::new(&env, &contract_id);
+    let owner = Address::generate(&env);
+    let bill_id = create_test_bill(&env, &client, &owner);
+
+    client.cancel_bill(&owner, &bill_id);
+
+    let payload: (u32, Address, u64) =
+        direct_bill_payload(&env, &contract_id, BillEvent::Cancelled)
+            .expect("Cancelled event missing");
+    assert_eq!(payload, (bill_id, owner.clone(), 84));
+    assert!(has_remitwise_action(&env, CANCEL_BILL));
+}
+
+#[test]
+fn restore_bill_emits_declared_bill_event_variant() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(100);
+    let contract_id = env.register_contract(None, BillPayments);
+    let client = BillPaymentsClient::new(&env, &contract_id);
+    let owner = Address::generate(&env);
+    let bill_id = create_test_bill(&env, &client, &owner);
+    client.pay_bill(&owner, &bill_id);
+    env.ledger().set_timestamp(200);
+    assert_eq!(client.archive_paid_bills(&owner, &150), 1);
+
+    env.ledger().set_timestamp(300);
+    client.restore_bill(&owner, &bill_id);
+
+    let payload: (u32, Address, u64) = direct_bill_payload(&env, &contract_id, BillEvent::Restored)
+        .expect("Restored event missing");
+    assert_eq!(payload, (bill_id, owner.clone(), 300));
+    assert!(has_remitwise_action(&env, RESTORE));
+}
+
+#[test]
+fn batch_pay_bills_emits_paid_variant_per_successful_bill() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, BillPayments);
+    let client = BillPaymentsClient::new(&env, &contract_id);
+    let owner = Address::generate(&env);
+    let first_id = create_test_bill(&env, &client, &owner);
+    let second_id = create_test_bill(&env, &client, &owner);
+    let already_paid_id = create_test_bill(&env, &client, &owner);
+    client.pay_bill(&owner, &already_paid_id);
+    let paid_events_before = count_direct_bill_events(&env, &contract_id, BillEvent::Paid);
+    let mut ids = SorobanVec::new(&env);
+    ids.push_back(first_id);
+    ids.push_back(999);
+    ids.push_back(second_id);
+    ids.push_back(already_paid_id);
+
+    assert_eq!(client.batch_pay_bills(&owner, &ids), 2);
+
+    let paid_events_after = count_direct_bill_events(&env, &contract_id, BillEvent::Paid);
+    assert_eq!(paid_events_after - paid_events_before, 2);
+    assert!(has_remitwise_action(&env, symbol_short!("paid")));
 }
 
 // ---------------------------------------------------------------------------

--- a/bill_payments/src/lib.rs
+++ b/bill_payments/src/lib.rs
@@ -388,7 +388,7 @@ impl BillPayments {
         let mut idx = Self::get_currency_index(env);
         let key = (owner.clone(), currency.clone());
         let ids = idx.get(key.clone()).unwrap_or_else(|| Vec::new(env));
-        
+
         // Insert in ascending order
         let mut new_ids: Vec<u32> = Vec::new(env);
         let mut inserted = false;
@@ -1535,7 +1535,9 @@ impl BillPayments {
         }
     }
 
-    /// Set or clear an external reference ID for a bill
+    /// Set or clear an external reference ID for a bill.
+    ///
+    /// Emits `BillEvent::ExternalRefUpdated` after a successful update.
     ///
     /// # Arguments
     /// * `caller` - Address of the caller (must be the bill owner)
@@ -1589,6 +1591,15 @@ impl BillPayments {
             .instance()
             .set(&symbol_short!("BILLS"), &bills);
 
+        env.events().publish(
+            (symbol_short!("bill"), BillEvent::ExternalRefUpdated),
+            (
+                bill_id,
+                caller.clone(),
+                validated_ext_ref.clone(),
+                env.ledger().timestamp(),
+            ),
+        );
         RemitwiseEvents::emit(
             &env,
             EventCategory::State,
@@ -1781,6 +1792,9 @@ impl BillPayments {
     // Remaining operations
     // -----------------------------------------------------------------------
 
+    /// Cancel an active bill.
+    ///
+    /// Emits `BillEvent::Cancelled` after a successful cancellation.
     pub fn cancel_bill(env: Env, caller: Address, bill_id: u32) -> Result<(), BillPaymentsError> {
         caller.require_auth();
         Self::require_not_paused(&env, pause_functions::CANCEL_BILL)?;
@@ -1812,12 +1826,16 @@ impl BillPayments {
         Self::index_remove_active(&env, &caller, bill_id);
         // Remove from currency index
         Self::index_remove_currency(&env, &caller, &bill_currency, bill_id);
+        env.events().publish(
+            (symbol_short!("bill"), BillEvent::Cancelled),
+            (bill_id, caller.clone(), env.ledger().timestamp()),
+        );
         RemitwiseEvents::emit(
             &env,
             EventCategory::State,
             EventPriority::Medium,
-            symbol_short!("canceled"),
-            bill_id,
+            pause_functions::CANCEL_BILL,
+            (bill_id, caller, env.ledger().timestamp()),
         );
         Ok(())
     }
@@ -1932,6 +1950,9 @@ impl BillPayments {
         Ok(archived_count)
     }
 
+    /// Restore an archived bill into active bill storage.
+    ///
+    /// Emits `BillEvent::Restored` after a successful restore.
     pub fn restore_bill(env: Env, caller: Address, bill_id: u32) -> Result<(), BillPaymentsError> {
         caller.require_auth();
         Self::require_not_paused(&env, pause_functions::RESTORE)?;
@@ -1994,12 +2015,16 @@ impl BillPayments {
 
         Self::update_storage_stats(&env);
 
+        env.events().publish(
+            (symbol_short!("bill"), BillEvent::Restored),
+            (bill_id, caller.clone(), env.ledger().timestamp()),
+        );
         RemitwiseEvents::emit(
             &env,
             EventCategory::State,
             EventPriority::Medium,
-            symbol_short!("restored"),
-            bill_id,
+            pause_functions::RESTORE,
+            (bill_id, caller, env.ledger().timestamp()),
         );
         Ok(())
     }
@@ -2147,9 +2172,14 @@ impl BillPayments {
                 unpaid_delta = unpaid_delta.saturating_sub(amount);
             }
 
+            let bill_ext_ref = bill.external_ref.clone();
             bills.set(bill_id, bill);
             success_count += 1;
 
+            env.events().publish(
+                (symbol_short!("bill"), BillEvent::Paid),
+                (bill_id, caller.clone(), bill_ext_ref),
+            );
             RemitwiseEvents::emit(
                 &env,
                 EventCategory::Transaction,
@@ -2479,5 +2509,7 @@ impl BillPayments {
     }
 }
 
+#[cfg(test)]
+mod events_schema_test;
 #[cfg(test)]
 mod test;


### PR DESCRIPTION
Closes #835.

## Summary
- emit the declared direct BillEvent::ExternalRefUpdated, BillEvent::Cancelled, and BillEvent::Restored topics from the matching bill lifecycle operations
- emit per-success direct BillEvent::Paid events from atch_pay_bills, matching the single-bill pay_bill event shape
- retain generic Remitwise audit events for compatibility and update event/indexer documentation
- add runtime schema coverage for the new event emissions and batch paid-event behavior

## Validation
- cargo test -p bill_payments events_schema_test -- --nocapture -> 9 passed, 0 failed
- git diff --check -> passed
- ustfmt --edition 2021 --check bill_payments/src/events_schema_test.rs -> passed

Note: full package formatting was not used as the final gate because existing unrelated files in the package already report formatting diffs.