### PR TITLE
fix: prune precision state on family member removal

### DIFF
--- a/family_wallet/src/lib.rs
+++ b/family_wallet/src/lib.rs
@@ -1242,6 +1242,7 @@ impl FamilyWallet {
         env.storage()
             .instance()
             .set(&symbol_short!("MEMBERS"), &members);
+        Self::prune_precision_state_for_member(&env, &member);
 
         // Re-validate in-flight proposals: strip signatures from the removed
         // member and invalidate any proposal that can no longer reach quorum.
@@ -1947,6 +1948,34 @@ impl FamilyWallet {
         env.storage().instance().get(&symbol_short!("UPG_ADM"))
     }
 
+    fn prune_precision_state_for_member(env: &Env, member: &Address) {
+        if let Some(mut limits) = env
+            .storage()
+            .instance()
+            .get::<_, Map<Address, PrecisionSpendingLimit>>(&symbol_short!("PREC_LIM"))
+        {
+            if limits.get(member.clone()).is_some() {
+                limits.remove(member.clone());
+                env.storage()
+                    .instance()
+                    .set(&symbol_short!("PREC_LIM"), &limits);
+            }
+        }
+
+        if let Some(mut trackers) = env
+            .storage()
+            .instance()
+            .get::<_, Map<Address, SpendingTracker>>(&symbol_short!("SPND_TRK"))
+        {
+            if trackers.get(member.clone()).is_some() {
+                trackers.remove(member.clone());
+                env.storage()
+                    .instance()
+                    .set(&symbol_short!("SPND_TRK"), &trackers);
+            }
+        }
+    }
+
     fn current_spending_tracker(env: &Env, proposer: &Address) -> SpendingTracker {
         let current_time = env.ledger().timestamp();
         let period_duration = 86_400u64;
@@ -2303,6 +2332,7 @@ impl FamilyWallet {
         let mut count = 0u32;
         for addr in addresses.iter() {
             members_map.remove(addr.clone());
+            Self::prune_precision_state_for_member(&env, &addr);
             Self::append_access_audit(
                 &env,
                 symbol_short!("rem_mem"),

--- a/family_wallet/src/test.rs
+++ b/family_wallet/src/test.rs
@@ -3408,6 +3408,49 @@ fn test_spending_tracker_persistence() {
 }
 
 #[test]
+fn test_remove_family_member_prunes_precision_state_before_readd() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = FamilyWalletClient::new(&env, &env.register_contract(None, FamilyWallet));
+
+    let owner = Address::generate(&env);
+    let member = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token_contract = env.register_stellar_asset_contract_v2(token_admin.clone());
+    let recipient = Address::generate(&env);
+    StellarAssetClient::new(&env, &token_contract.address()).mint(&member, &1000_0000000);
+
+    client.init(&owner, &vec![&env]);
+    client.add_member(&owner, &member, &FamilyRole::Member, &1000_0000000);
+
+    let precision_limit = PrecisionSpendingLimit {
+        limit: 500_0000000,
+        min_precision: 1_0000000,
+        max_single_tx: 300_0000000,
+        enable_rollover: true,
+    };
+    assert!(client.set_precision_spending_limit(&owner, &member, &precision_limit));
+
+    let tx = client.withdraw(&member, &token_contract.address(), &recipient, &200_0000000);
+    assert_eq!(tx, 0);
+    assert_eq!(
+        client.get_spending_tracker(&member).unwrap().current_spent,
+        200_0000000
+    );
+
+    assert!(client.remove_family_member(&owner, &member));
+    assert!(client.get_family_member(&member).is_none());
+    assert!(client.get_spending_tracker(&member).is_none());
+
+    client.add_member(&owner, &member, &FamilyRole::Member, &1000_0000000);
+
+    // The old precision limit would reject this amount by max_single_tx and cumulative cap.
+    let tx = client.withdraw(&member, &token_contract.address(), &recipient, &400_0000000);
+    assert_eq!(tx, 0);
+    assert!(client.get_spending_tracker(&member).is_none());
+}
+
+#[test]
 fn test_owner_admin_bypass_precision_limits() {
     let env = Env::default();
     env.mock_all_auths();
@@ -3986,6 +4029,96 @@ fn test_batch_remove_family_members_rejects_missing_and_duplicate_without_partia
     assert!(invalid_result.is_err());
     assert!(client.get_family_member(&member_a).is_some());
     assert!(client.get_family_member(&member_b).is_some());
+}
+
+#[test]
+fn test_batch_remove_family_members_prunes_precision_state_for_removed_members() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, FamilyWallet);
+    let client = FamilyWalletClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let member_a = Address::generate(&env);
+    let member_b = Address::generate(&env);
+    let member_c = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token_contract = env.register_stellar_asset_contract_v2(token_admin.clone());
+    let recipient = Address::generate(&env);
+    StellarAssetClient::new(&env, &token_contract.address()).mint(&member_a, &1000_0000000);
+    StellarAssetClient::new(&env, &token_contract.address()).mint(&member_b, &1000_0000000);
+    StellarAssetClient::new(&env, &token_contract.address()).mint(&member_c, &1000_0000000);
+
+    client.init(
+        &owner,
+        &vec![&env, member_a.clone(), member_b.clone(), member_c.clone()],
+    );
+
+    let precision_limit = PrecisionSpendingLimit {
+        limit: 500_0000000,
+        min_precision: 1_0000000,
+        max_single_tx: 300_0000000,
+        enable_rollover: true,
+    };
+    assert!(client.set_precision_spending_limit(&owner, &member_a, &precision_limit));
+    assert!(client.set_precision_spending_limit(&owner, &member_b, &precision_limit));
+    assert!(client.set_precision_spending_limit(&owner, &member_c, &precision_limit));
+
+    assert_eq!(
+        client.withdraw(
+            &member_a,
+            &token_contract.address(),
+            &recipient,
+            &100_0000000
+        ),
+        0
+    );
+    assert_eq!(
+        client.withdraw(
+            &member_b,
+            &token_contract.address(),
+            &recipient,
+            &200_0000000
+        ),
+        0
+    );
+    assert_eq!(
+        client.withdraw(
+            &member_c,
+            &token_contract.address(),
+            &recipient,
+            &300_0000000
+        ),
+        0
+    );
+    assert!(client.get_spending_tracker(&member_a).is_some());
+    assert!(client.get_spending_tracker(&member_b).is_some());
+    assert!(client.get_spending_tracker(&member_c).is_some());
+
+    let to_remove = vec![&env, member_a.clone(), member_b.clone()];
+    assert_eq!(client.batch_remove_family_members(&owner, &to_remove), 2);
+    assert!(client.get_spending_tracker(&member_a).is_none());
+    assert!(client.get_spending_tracker(&member_b).is_none());
+    assert_eq!(
+        client
+            .get_spending_tracker(&member_c)
+            .unwrap()
+            .current_spent,
+        300_0000000
+    );
+
+    client.add_member(&owner, &member_a, &FamilyRole::Member, &1000_0000000);
+
+    // If the old PREC_LIM entry survived batch removal this amount would be rejected.
+    assert_eq!(
+        client.withdraw(
+            &member_a,
+            &token_contract.address(),
+            &recipient,
+            &400_0000000
+        ),
+        0
+    );
 }
 
 #[test]


### PR DESCRIPTION
Fixes #827.

## Summary
- prune `PREC_LIM` entries when a family member is removed
- prune `SPND_TRK` entries for the removed member in both single and batch removal paths
- add regression coverage for remove/re-add behavior so stale precision limits or trackers cannot be inherited

## Tests
- `cargo test -p family_wallet prunes_precision_state -- --nocapture`
- `cargo test -p family_wallet remove_family_member -- --nocapture`
- `git diff --check -- family_wallet/src/lib.rs family_wallet/src/test.rs`

Note: the full `cargo fmt -p family_wallet -- --check` reports pre-existing formatting drift in unrelated sections of `family_wallet`; this change keeps the touched diff whitespace-clean.