### PR TITLE
feat(family-wallet): emit multisig configuration event

### DIFF
--- a/EVENTS.md
+++ b/EVENTS.md
@@ -730,6 +730,25 @@ pub struct SpendingLimitUpdatedEvent {
 }
 ```
 
+### Event: Multisig Configured
+
+**Topic:** `("Remitwise", EventCategory::Access, EventPriority::High, "ms_cfg")`
+
+**Data Structure:**
+```rust
+pub struct MultisigConfiguredEvent {
+    pub tx_type: TransactionType,    // Multisig transaction class being configured
+    pub threshold: u32,              // Required signatures after the change
+    pub signer_count: u32,           // Number of configured signers
+    pub spending_limit: i128,        // Spending limit for the transaction class
+    pub timestamp: u64,              // Event timestamp
+}
+```
+
+The payload intentionally records `signer_count` instead of raw signer
+addresses. Off-chain monitors can alert on quorum and signer-set-size changes
+without duplicating the full signer set in the event stream.
+
 ### Event: Transaction Proposed
 
 **Topic:** `("family", "tx_proposed")`

--- a/INDEXER_FEATURE.md
+++ b/INDEXER_FEATURE.md
@@ -49,6 +49,7 @@ Smart contracts emit events but don't provide efficient querying capabilities. T
 | Bill Payments | bill_created, bill_paid, tags_add, tags_rem | Bill |
 | Insurance | policy_created, tags_add, tags_rem | InsurancePolicy |
 | Remittance Split | split_created, split_executed | RemittanceSplit |
+| Family Wallet | member, limit, ms_cfg, tx_proposed, tx_executed, em_mode | FamilyMember, MultisigConfig |
 
 ## Architecture
 

--- a/docs/EVENT_TAXONOMY.md
+++ b/docs/EVENT_TAXONOMY.md
@@ -93,6 +93,7 @@ Below is a representative mapping of events emitted by each contract to the taxo
 |-------|----------|----------|
 | `MemberAdded` | `Access` | `Low` |
 | `SpendingLimitUpdated` | `Access` | `Low` |
+| `MultisigConfigured` | `Access` | `High` |
 | `TransactionProposed` | `Transaction` | `Medium` |
 | `TransactionExecuted` | `Transaction` | `High` |
 | `EmergencyModeOn/Off` | `System` | `High` |

--- a/family_wallet/src/events_schema_test.rs
+++ b/family_wallet/src/events_schema_test.rs
@@ -48,12 +48,13 @@ fn remitwise_action_symbols_are_stable() {
         symbol_short!("add_mem"),
         symbol_short!("rem_mem"),
         symbol_short!("role_exp"),
+        symbol_short!("ms_cfg"),
         symbol_short!("archived"),
         symbol_short!("exp_cln"),
         symbol_short!("upgraded"),
         symbol_short!("adm_xfr"),
     ];
-    assert_eq!(actions.len(), 13);
+    assert_eq!(actions.len(), 14);
 }
 
 // ---------------------------------------------------------------------------
@@ -101,6 +102,28 @@ fn spending_limit_updated_event_payload_schema() {
     assert_eq!(decoded.old_limit, 500_000);
     assert_eq!(decoded.new_limit, 750_000);
     assert_eq!(decoded.timestamp, 1_234_567_900);
+}
+
+#[test]
+fn multisig_configured_event_payload_schema() {
+    let env = Env::default();
+
+    let evt = MultisigConfiguredEvent {
+        tx_type: TransactionType::RoleChange,
+        threshold: 2,
+        signer_count: 3,
+        spending_limit: 1_000_000,
+        timestamp: 1_234_568_000,
+    };
+
+    let v: Val = evt.clone().into_val(&env);
+    let decoded = MultisigConfiguredEvent::try_from_val(&env, &v).expect("round-trip failed");
+
+    assert_eq!(decoded.tx_type, TransactionType::RoleChange);
+    assert_eq!(decoded.threshold, 2);
+    assert_eq!(decoded.signer_count, 3);
+    assert_eq!(decoded.spending_limit, 1_000_000);
+    assert_eq!(decoded.timestamp, 1_234_568_000);
 }
 
 #[test]

--- a/family_wallet/src/lib.rs
+++ b/family_wallet/src/lib.rs
@@ -211,6 +211,21 @@ pub struct SpendingLimitUpdatedEvent {
     pub timestamp: u64,
 }
 
+/// Emitted after a successful multisig configuration update.
+///
+/// The event intentionally records only `signer_count`, not raw signer
+/// addresses, so indexers can audit quorum changes without duplicating the
+/// signer set in the event stream.
+#[contracttype]
+#[derive(Clone)]
+pub struct MultisigConfiguredEvent {
+    pub tx_type: TransactionType,
+    pub threshold: u32,
+    pub signer_count: u32,
+    pub spending_limit: i128,
+    pub timestamp: u64,
+}
+
 #[contracttype]
 #[derive(Clone)]
 pub struct ProposalInvalidatedEvent {
@@ -690,6 +705,20 @@ impl FamilyWallet {
         env.storage()
             .instance()
             .set(&Self::get_config_key(tx_type), &config);
+
+        RemitwiseEvents::emit(
+            &env,
+            EventCategory::Access,
+            EventPriority::High,
+            symbol_short!("ms_cfg"),
+            MultisigConfiguredEvent {
+                tx_type,
+                threshold,
+                signer_count,
+                spending_limit,
+                timestamp: env.ledger().timestamp(),
+            },
+        );
 
         Ok(true)
     }

--- a/family_wallet/src/test.rs
+++ b/family_wallet/src/test.rs
@@ -1,9 +1,9 @@
 use super::*;
-use soroban_sdk::testutils::storage::Instance as _;
 use soroban_sdk::{
-    testutils::{Address as _, Ledger, LedgerInfo},
+    symbol_short,
+    testutils::{storage::Instance as _, Address as _, Events, Ledger, LedgerInfo},
     token::{StellarAssetClient, TokenClient},
-    vec, Env, InvokeError,
+    vec, Env, InvokeError, Symbol, TryFromVal,
 };
 use testutils::set_ledger_time;
 
@@ -84,6 +84,82 @@ fn test_configure_multisig() {
     assert_eq!(config.threshold, 2);
     assert_eq!(config.signers.len(), 3);
     assert_eq!(config.spending_limit, 1000_0000000);
+}
+
+#[test]
+fn test_configure_multisig_emits_auditable_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_700_000);
+    let contract_id = env.register_contract(None, FamilyWallet);
+    let client = FamilyWalletClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let member1 = Address::generate(&env);
+    let member2 = Address::generate(&env);
+    let member3 = Address::generate(&env);
+    client.init(
+        &owner,
+        &vec![&env, member1.clone(), member2.clone(), member3.clone()],
+    );
+
+    let before = env.events().all().len();
+    let signers = vec![&env, member1.clone(), member2.clone(), member3.clone()];
+    let result = client.configure_multisig(
+        &owner,
+        &TransactionType::RoleChange,
+        &2,
+        &signers,
+        &500_0000000,
+    );
+    assert!(result);
+
+    let events = env.events().all();
+    assert_eq!(events.len(), before + 1);
+    let event = events.last().unwrap();
+
+    let topics = &event.1;
+    assert_eq!(topics.len(), 4);
+    let namespace: Symbol = Symbol::try_from_val(&env, &topics.get(0).unwrap()).unwrap();
+    let category: u32 = u32::try_from_val(&env, &topics.get(1).unwrap()).unwrap();
+    let priority: u32 = u32::try_from_val(&env, &topics.get(2).unwrap()).unwrap();
+    let action: Symbol = Symbol::try_from_val(&env, &topics.get(3).unwrap()).unwrap();
+    assert_eq!(namespace, symbol_short!("Remitwise"));
+    assert_eq!(category, EventCategory::Access.to_u32());
+    assert_eq!(priority, EventPriority::High.to_u32());
+    assert_eq!(action, symbol_short!("ms_cfg"));
+
+    let payload = MultisigConfiguredEvent::try_from_val(&env, &event.2).unwrap();
+    assert_eq!(payload.tx_type, TransactionType::RoleChange);
+    assert_eq!(payload.threshold, 2);
+    assert_eq!(payload.signer_count, 3);
+    assert_eq!(payload.spending_limit, 500_0000000);
+    assert_eq!(payload.timestamp, 1_700_000);
+}
+
+#[test]
+fn test_configure_multisig_failed_validation_emits_no_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, FamilyWallet);
+    let client = FamilyWalletClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let member1 = Address::generate(&env);
+    let member2 = Address::generate(&env);
+    client.init(&owner, &vec![&env, member1.clone(), member2.clone()]);
+
+    let before = env.events().all().len();
+    let duplicate_signers = vec![&env, member1.clone(), member1.clone()];
+    let result = client.try_configure_multisig(
+        &owner,
+        &TransactionType::LargeWithdrawal,
+        &2,
+        &duplicate_signers,
+        &1000_0000000,
+    );
+    assert_eq!(result, Err(Ok(Error::DuplicateSigner)));
+    assert_eq!(env.events().all().len(), before);
 }
 
 #[test]


### PR DESCRIPTION
Closes #831.

## Summary
- Adds a `MultisigConfiguredEvent` payload for successful family-wallet multisig reconfiguration.
- Emits the event through `RemitwiseEvents::emit` with the stable `ms_cfg` action after validation and storage update succeed.
- Documents the event in the event catalogue/indexer notes and keeps raw signer addresses out of the emitted payload.

## Validation
- `cargo test -p family_wallet configure_multisig -- --nocapture`
- `cargo test -p family_wallet events_schema_test -- --nocapture`
- `git diff --check -- family_wallet/src/lib.rs family_wallet/src/events_schema_test.rs family_wallet/src/test.rs EVENTS.md INDEXER_FEATURE.md docs/EVENT_TAXONOMY.md`

## Pre-submit checks
- Issue #831 was open and unassigned at refresh time.
- No open PR matched `#831`, `MultisigConfigured`, `ms_cfg`, or `configure_multisig` at refresh time.
- Broader `rustfmt --check` still reports pre-existing formatting drift in unrelated `family_wallet` test sections; touched diff is whitespace-clean.