### PR TITLE
Bill Payments: replace O(max_id) scan in get_overdue_bills with an owner-indexed walk

### DIFF
--- a/bill_payments/src/lib.rs
+++ b/bill_payments/src/lib.rs
@@ -1432,9 +1432,22 @@ impl BillPayments {
     /// `BillPage { items, next_cursor, count }`.
     /// When `next_cursor == 0` there are no more pages.
     ///
+    /// # Overdue Semantics
+    /// A bill is overdue when `!bill.paid && bill.due_date < current_ledger_time`. The
+    /// comparison is strict less-than, so a bill whose `due_date == now` is **not** overdue.
+    ///
     /// # Canonical Ordering
     /// Results are always ordered by bill ID ascending. Pagination uses the same
-    /// ordering, so `cursor` is stable across repeated calls.
+    /// ordering, so `cursor` is stable across repeated calls (including across sparse
+    /// IDs left by cancelled/archived bills, which are absent from the index).
+    ///
+    /// # Gas Complexity
+    /// `O(A)` where `A` is the number of **active** (non-archived, non-cancelled) bills
+    /// across all owners, *not* the global `NEXT_ID` high-water mark. This walks the
+    /// per-owner active index (`OWN_IDX`) instead of scanning `1..=NEXT_ID`, so the cost
+    /// no longer grows with historically created-then-removed bills. For a query scoped
+    /// to a single owner whose cost tracks only that owner's bills, use
+    /// [`Self::get_overdue_bills_for_owner`].
     pub fn get_overdue_bills(env: Env, cursor: u32, limit: u32) -> BillPage {
         let limit = clamp_limit(limit);
         let current_time = env.ledger().timestamp();
@@ -1443,10 +1456,87 @@ impl BillPayments {
             .instance()
             .get(&symbol_short!("BILLS"))
             .unwrap_or_else(|| Map::new(&env));
-        let max_id = Self::get_next_bill_id(&env);
+
+        // Walk the per-owner active index (OWN_IDX) rather than the global
+        // `1..=NEXT_ID` range. Each owner's ID list is ascending, so we merge the
+        // matching candidates into one globally ID-ascending page using a bounded
+        // staging buffer that only ever retains the smallest `limit + 1` IDs.
+        let idx: Map<Address, Vec<u32>> = env
+            .storage()
+            .instance()
+            .get(&STORAGE_OWNER_INDEX)
+            .unwrap_or_else(|| Map::new(&env));
+
+        let cap = limit + 1;
+        let mut staging: Vec<(u32, Bill)> = Vec::new(&env);
+
+        for owner in idx.keys().iter() {
+            let owner_ids = idx.get(owner).unwrap_or_else(|| Vec::new(&env));
+            for id in owner_ids.iter() {
+                if id <= cursor {
+                    continue;
+                }
+                let Some(bill) = bills.get(id) else {
+                    continue;
+                };
+                if bill.paid || bill.due_date >= current_time {
+                    continue;
+                }
+                Self::staging_insert_bounded(&mut staging, id, bill, cap);
+            }
+        }
+
+        Self::build_page(&env, staging, limit)
+    }
+
+    /// @notice Get a paginated list of overdue bills (unpaid + past due_date) for a single owner.
+    /// @dev Owner-scoped counterpart to [`Self::get_overdue_bills`]. The global variant is
+    /// intentionally cross-owner; this variant restricts results to `owner` and is the cheaper
+    /// query when callers only care about one account.
+    ///
+    /// # Arguments
+    /// * `owner`  - Whose overdue bills to return (must authorize the call)
+    /// * `cursor` - Start after this bill ID (pass 0 for the first page)
+    /// * `limit`  - Max items per page (0 -> DEFAULT_PAGE_LIMIT, capped at MAX_PAGE_LIMIT)
+    ///
+    /// # Returns
+    /// `BillPage { items, next_cursor, count }`.
+    /// When `next_cursor == 0` there are no more pages.
+    ///
+    /// # Overdue Semantics
+    /// Identical to [`Self::get_overdue_bills`]: `!bill.paid && bill.due_date < current_ledger_time`
+    /// (strict less-than; `due_date == now` is not overdue).
+    ///
+    /// # Canonical Ordering
+    /// Results are always ordered by bill ID ascending. Pagination uses the same
+    /// ordering, so `cursor` is stable across repeated calls.
+    ///
+    /// # Gas Complexity
+    /// `O(owner_bills)` — walks only this owner's `OWN_IDX` entry and is bounded by
+    /// `MAX_BILLS_PER_OWNER`, independent of the global `NEXT_ID` high-water mark.
+    pub fn get_overdue_bills_for_owner(
+        env: Env,
+        owner: Address,
+        cursor: u32,
+        limit: u32,
+    ) -> BillPage {
+        owner.require_auth();
+        let limit = clamp_limit(limit);
+        let current_time = env.ledger().timestamp();
+        let bills: Map<u32, Bill> = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("BILLS"))
+            .unwrap_or_else(|| Map::new(&env));
+
+        // Use the owner index for O(owner_bills) traversal instead of O(NEXT_ID).
+        let owner_ids = Self::get_owner_bills(&env, &owner);
 
         let mut staging: Vec<(u32, Bill)> = Vec::new(&env);
-        for id in (cursor.saturating_add(1))..=max_id {
+        for id in owner_ids.iter() {
+            if id <= cursor {
+                continue;
+            }
             let Some(bill) = bills.get(id) else {
                 continue;
             };
@@ -1460,6 +1550,40 @@ impl BillPayments {
         }
 
         Self::build_page(&env, staging, limit)
+    }
+
+    /// Insert `(id, bill)` into `staging` keeping it sorted ascending by bill ID and
+    /// capped at `cap` entries (i.e. retaining only the smallest `cap` IDs seen).
+    ///
+    /// Used by [`Self::get_overdue_bills`] to merge the per-owner indices into one
+    /// globally ID-ascending page without materialising every candidate: the buffer
+    /// never holds more than `cap` (= `limit + 1`) entries regardless of how many
+    /// overdue bills exist across all owners.
+    fn staging_insert_bounded(staging: &mut Vec<(u32, Bill)>, id: u32, bill: Bill, cap: u32) {
+        let len = staging.len();
+        // Buffer is full and already holds `cap` smaller IDs — this one can't make the page.
+        if len >= cap {
+            if let Some((last_id, _)) = staging.get(len - 1) {
+                if id >= last_id {
+                    return;
+                }
+            }
+        }
+        // Locate the ascending insertion position.
+        let mut pos = len;
+        for i in 0..len {
+            if let Some((sid, _)) = staging.get(i) {
+                if id < sid {
+                    pos = i;
+                    break;
+                }
+            }
+        }
+        staging.insert(pos, (id, bill));
+        // Drop the largest entry if we exceeded the cap.
+        if staging.len() > cap {
+            staging.remove(staging.len() - 1);
+        }
     }
 
     /// Admin-only: get ALL bills (any owner), paginated.

--- a/bill_payments/tests/gas_bench.rs
+++ b/bill_payments/tests/gas_bench.rs
@@ -603,6 +603,65 @@ fn bench_get_overdue_bills_page_first_1000_total() {
     );
 }
 
+/// Scale guard: `get_overdue_bills` cost must track the active result set, not the
+/// global `NEXT_ID` high-water mark.
+///
+/// We hold the overdue result set fixed (10 bills) and inflate `NEXT_ID` by
+/// creating-then-cancelling 80 filler bills. Cancelled bills leave `OWN_IDX`, so the
+/// owner-index walk does identical work in both scenarios. With the previous
+/// `1..=NEXT_ID` scan, scenario B (`NEXT_ID == 90`) would have cost ~9x scenario A
+/// (`NEXT_ID == 10`); the index walk keeps the cost flat.
+#[test]
+fn scale_get_overdue_bills_independent_of_next_id() {
+    // Scenario A: 10 overdue bills, NEXT_ID == 10.
+    let env_a = bench_env();
+    let id_a = env_a.register_contract(None, BillPayments);
+    let client_a = BillPaymentsClient::new(&env_a, &id_a);
+    let owner_a = <Address as AddressTrait>::generate(&env_a);
+    create_many_overdue(&client_a, &env_a, &owner_a, "OverdueA", 10);
+    let (cpu_a, mem_a, page_a) = measure(&env_a, || client_a.get_overdue_bills(&0u32, &50u32));
+    assert_eq!(page_a.count, 10);
+
+    // Scenario B: same 10 overdue bills, but NEXT_ID inflated to 90 via create+cancel.
+    let env_b = bench_env();
+    let id_b = env_b.register_contract(None, BillPayments);
+    let client_b = BillPaymentsClient::new(&env_b, &id_b);
+    let owner_b = <Address as AddressTrait>::generate(&env_b);
+    create_many_overdue(&client_b, &env_b, &owner_b, "OverdueB", 10);
+    let filler = create_many_unpaid(&client_b, &env_b, &owner_b, "Filler", 80);
+    for fid in filler.iter() {
+        client_b.cancel_bill(&owner_b, &fid);
+    }
+    let (cpu_b, mem_b, page_b) = measure(&env_b, || client_b.get_overdue_bills(&0u32, &50u32));
+    assert_eq!(
+        page_b.count, 10,
+        "filler bills cancelled: only the 10 overdue bills remain"
+    );
+
+    // Allow a small tolerance for incidental differences; the key invariant is that
+    // a 9x larger NEXT_ID does NOT translate into a 9x larger query cost.
+    assert!(
+        cpu_b <= cpu_a + cpu_a / 5,
+        "overdue cpu must not scale with NEXT_ID: A(next_id=10)={}, B(next_id=90)={}",
+        cpu_a,
+        cpu_b
+    );
+    assert!(
+        mem_b <= mem_a + mem_a / 5,
+        "overdue mem must not scale with NEXT_ID: A(next_id=10)={}, B(next_id=90)={}",
+        mem_a,
+        mem_b
+    );
+
+    emit_bench_result(
+        "get_overdue_bills",
+        "next_id_10_vs_90_fixed_10_result",
+        cpu_b,
+        mem_b,
+        OVERDUE_BILLS_PAGE_50,
+    );
+}
+
 /// Benchmark owner bill listing pagination at varying dataset sizes.
 #[test]
 fn bench_get_all_bills_for_owner_page_first_50_total() {

--- a/bill_payments/tests/tests_overdue.rs
+++ b/bill_payments/tests/tests_overdue.rs
@@ -435,6 +435,173 @@ fn test_overdue_owner_isolation_payment_does_not_affect_other_owner() {
     );
 }
 
+/// Global overdue list merges multiple owners' bills into one strictly ascending,
+/// duplicate-free page — verifying the owner-index merge preserves canonical ordering.
+#[test]
+fn test_overdue_global_merges_owners_in_ascending_order() {
+    let due_date = BASE_TIME - 1;
+
+    let env = make_env(due_date);
+    let client = setup_contract(&env);
+    let owner_a = Address::generate(&env);
+    let owner_b = Address::generate(&env);
+
+    // Interleave creation so per-owner index lists do not line up with global order:
+    // IDs 1,3,5 -> A ; IDs 2,4,6 -> B.
+    create_bill(&env, &client, &owner_a, due_date); // 1
+    create_bill(&env, &client, &owner_b, due_date); // 2
+    create_bill(&env, &client, &owner_a, due_date); // 3
+    create_bill(&env, &client, &owner_b, due_date); // 4
+    create_bill(&env, &client, &owner_a, due_date); // 5
+    create_bill(&env, &client, &owner_b, due_date); // 6
+
+    set_time(&env, BASE_TIME);
+
+    // Page through with a small limit to exercise the bounded merge + cursor.
+    let mut collected: std::vec::Vec<u32> = std::vec::Vec::new();
+    let mut cursor = 0u32;
+    loop {
+        let page = client.get_overdue_bills(&cursor, &2);
+        for bill in page.items.iter() {
+            collected.push(bill.id);
+        }
+        if page.next_cursor == 0 {
+            break;
+        }
+        cursor = page.next_cursor;
+    }
+
+    assert_eq!(
+        collected,
+        std::vec![1u32, 2, 3, 4, 5, 6],
+        "global overdue page must merge both owners in strictly ascending ID order"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Owner-scoped variant: get_overdue_bills_for_owner
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Owner-scoped query returns only the requested owner's overdue bills.
+#[test]
+fn test_overdue_for_owner_scopes_to_single_owner() {
+    let due_date = BASE_TIME - 1;
+
+    let env = make_env(due_date);
+    let client = setup_contract(&env);
+    let owner_a = Address::generate(&env);
+    let owner_b = Address::generate(&env);
+
+    create_bill(&env, &client, &owner_a, due_date); // 1 (A)
+    create_bill(&env, &client, &owner_b, due_date); // 2 (B)
+    create_bill(&env, &client, &owner_a, due_date); // 3 (A)
+
+    set_time(&env, BASE_TIME);
+
+    let page = client.get_overdue_bills_for_owner(&owner_a, &0, &100);
+    assert_eq!(page.count, 2, "owner A has exactly 2 overdue bills");
+    let mut ids: std::vec::Vec<u32> = std::vec::Vec::new();
+    for bill in page.items.iter() {
+        assert_eq!(bill.owner, owner_a, "only owner A's bills may appear");
+        ids.push(bill.id);
+    }
+    assert_eq!(ids, std::vec![1u32, 3u32], "ascending owner-scoped IDs");
+}
+
+/// Owner-scoped boundary matches the global semantics: now-1 overdue; now / now+1 not.
+#[test]
+fn test_overdue_for_owner_boundary_strict_less_than() {
+    let env = make_env(BASE_TIME - 1);
+    let client = setup_contract(&env);
+    let owner = Address::generate(&env);
+
+    create_bill(&env, &client, &owner, BASE_TIME - 1); // overdue once clock advances
+
+    set_time(&env, BASE_TIME);
+    create_bill(&env, &client, &owner, BASE_TIME); // due_date == now -> NOT overdue
+    create_bill(&env, &client, &owner, BASE_TIME + 1); // future -> NOT overdue
+
+    let page = client.get_overdue_bills_for_owner(&owner, &0, &100);
+    assert_eq!(page.count, 1, "only the bill with due_date < now is overdue");
+    assert!(page.items.get(0).unwrap().due_date < BASE_TIME);
+}
+
+/// Owner-scoped query excludes paid bills and survives sparse IDs from cancellation.
+#[test]
+fn test_overdue_for_owner_excludes_paid_and_handles_gaps() {
+    let due_date = BASE_TIME - 1;
+
+    let env = make_env(due_date);
+    let client = setup_contract(&env);
+    let owner = Address::generate(&env);
+
+    for _ in 0..5 {
+        create_bill(&env, &client, &owner, due_date); // IDs 1..=5
+    }
+    // Cancel 2 and 4 (sparse IDs), pay 5 (excluded as paid).
+    client.cancel_bill(&owner, &2u32);
+    client.cancel_bill(&owner, &4u32);
+
+    set_time(&env, BASE_TIME);
+    client.pay_bill(&owner, &5u32);
+
+    let page = client.get_overdue_bills_for_owner(&owner, &0, &100);
+    let mut ids: std::vec::Vec<u32> = std::vec::Vec::new();
+    for bill in page.items.iter() {
+        ids.push(bill.id);
+    }
+    assert_eq!(
+        ids,
+        std::vec![1u32, 3u32],
+        "cancelled (2,4) and paid (5) bills excluded; ascending order preserved"
+    );
+}
+
+/// Owner-scoped pagination is cursor-stable across pages.
+#[test]
+fn test_overdue_for_owner_pagination_stable_cursor() {
+    let due_date = BASE_TIME - 1;
+
+    let env = make_env(due_date);
+    let client = setup_contract(&env);
+    let owner = Address::generate(&env);
+
+    for _ in 0..5 {
+        create_bill(&env, &client, &owner, due_date);
+    }
+
+    set_time(&env, BASE_TIME);
+
+    let mut collected: std::vec::Vec<u32> = std::vec::Vec::new();
+    let mut cursor = 0u32;
+    loop {
+        let page = client.get_overdue_bills_for_owner(&owner, &cursor, &2);
+        for bill in page.items.iter() {
+            collected.push(bill.id);
+        }
+        if page.next_cursor == 0 {
+            break;
+        }
+        cursor = page.next_cursor;
+    }
+
+    assert_eq!(collected, std::vec![1u32, 2, 3, 4, 5]);
+}
+
+/// Owner-scoped query returns an empty page for an owner with no overdue bills.
+#[test]
+fn test_overdue_for_owner_empty_when_none_overdue() {
+    let env = make_env(BASE_TIME);
+    let client = setup_contract(&env);
+    let owner = Address::generate(&env);
+
+    create_bill(&env, &client, &owner, BASE_TIME + 1_000); // future, never overdue here
+
+    let page = client.get_overdue_bills_for_owner(&owner, &0, &100);
+    assert_eq!(page.count, 0);
+    assert_eq!(page.next_cursor, 0);
+}
+
 /// Bill due far in the past still appears overdue (no age limit on overdue).
 #[test]
 fn test_overdue_bill_due_far_in_past_is_overdue() {


### PR DESCRIPTION
## perf(bill_payments): index-walk `get_overdue_bills` instead of O(max_id) scan

Close #840

### Problem
`get_overdue_bills` iterated `for id in (cursor+1)..=NEXT_ID`, loading every bill
ID from the cursor up to the global `NEXT_ID` high-water mark and filtering for
overdue + unpaid. This is **O(max_id)** regardless of how few bills are actually
overdue — cost grew with the total count of bills ever created (including
cancelled/archived gaps), even though the owner index (`OWN_IDX`) already lets the
other list queries (`get_unpaid_bills`, `get_bills_by_currency`, …) walk only the
relevant IDs. A list endpoint whose cost scales with total historical bills rather
than the result set is a gas time-bomb in production.

### Change
- **`get_overdue_bills` (global, cross-owner) — rewritten.** Now walks `OWN_IDX`
  (`Map<Address, Vec<u32>>`) across all owners instead of the `1..=NEXT_ID` range.
  Each owner's list is ID-ascending, so candidates are merged into one globally
  ID-ascending page via a bounded `staging_insert_bounded` helper that only ever
  retains the smallest `limit + 1` IDs. Cost is now **O(active bills)**, independent
  of the `NEXT_ID` high-water mark.
- **`get_overdue_bills_for_owner` (new, owner-scoped).** The issue noted the global
  query is intentional, so this adds the owner-scoped variant it asked for. Walks
  only that owner's `OWN_IDX` entry → **O(owner_bills)**, bounded by
  `MAX_BILLS_PER_OWNER`. Requires `owner.require_auth()`, matching `get_unpaid_bills`.
- Doc-comments on both functions document the distinction and the complexity bounds.

### Semantics preserved
- Overdue = `!paid && due_date < now` (strict less-than; `due_date == now` is **not**
  overdue — existing boundary test stays green).
- Same `BillPage` shape, ascending ID ordering, and cursor stability across pages,
  including sparse IDs / archived gaps (those IDs are simply absent from the index).

### Tests
- Existing 14 `tests_overdue` tests stay green (boundary, paid/cancelled/archived
  exclusion, sparse-ID pagination, owner isolation).
- **+6 new correctness tests**: global multi-owner ascending merge; owner-scoped
  scoping, boundary, paid + gap exclusion, pagination cursor stability, empty page.
- **+ gas/scale assertion** `scale_get_overdue_bills_independent_of_next_id` in
  `gas_bench.rs`: holds the result set at 10 overdue bills, inflates `NEXT_ID` to 90
  via create-then-cancel, and asserts CPU/mem stay flat (≤20% delta) — where the old
  O(max_id) scan would have cost ~9×.

### Verification
- `cargo test -p bill_payments` → all green (lib 71, gas_bench 9, tests_overdue 20,
  stress_tests 23, + all other binaries).
- `cargo clippy -p bill_payments --tests` → clean.


