### PR TITLE
Pagination Consolidation for Savings Goals

### DIFF
--- a/docs/rate-limiting-design.md
+++ b/docs/rate-limiting-design.md
@@ -101,7 +101,7 @@ The following **should NOT** be rate-limited as they are read-only and do not co
 
 - `get_split()`, `calculate_split()` – Remittance Split
 - `get_unpaid_bills()`, `get_bill()`, `get_overdue_bills()` – Bill Payments
-- `get_goal()`, `get_goals_by_owner()` – Savings Goals
+- `get_goal()`, `get_goals()` – Savings Goals
 - `get_policy()`, `get_policies_by_owner()` – Insurance
 - `get_report()`, `get_health_score()` – Reporting
 

--- a/savings_goals/README.md
+++ b/savings_goals/README.md
@@ -35,28 +35,24 @@ The Savings Goals contract allows users to create savings goals, add/withdraw fu
 
 ## Pagination Stability
 
-`get_goals(owner, cursor, limit)` now uses the owner goal-ID index as the canonical ordering source.
+The contract uses a single, canonical **cursor-based pagination** pattern via `get_goals(owner, cursor, limit)`.
 
-- Ordering is deterministic: ascending goal creation ID for that owner.
-- Cursor is exclusive: page N+1 starts strictly after the cursor ID.
-- Cursor is owner-bound: a non-zero cursor must exist in that owner's index.
-- Invalid/stale non-zero cursors are rejected to prevent silent duplicate/skip behavior.
+- **Deterministic ordering**: Ascending goal creation ID for that owner
+- **Exclusive cursor semantics**: Page N+1 starts strictly after the cursor goal ID
+- **Owner-bound validation**: A non-zero cursor must exist in that owner's index; invalid cursors are rejected
+- **Consistency guarantees**: Index-to-storage mismatches fail fast instead of returning ambiguous data
+- **Stable pagination**: If new goals are added between reads, they appear in later pages without duplicating already-read items
 
-### Cursor Semantics
+### Cursor Contract
 
-- `cursor = 0` starts from the first goal.
-- `next_cursor = 0` means there are no more pages.
-- If writes happen between reads, new goals are appended and will appear in later pages without duplicating already-read items.
-
-### Offset Pagination
-
-The contract also provides `get_goals_by_owner(owner, offset, limit)` for simple offset-based pagination. This is efficient as it uses the owner's goal index vector directly.
+- `cursor = 0`: Start from the first goal
+- `next_cursor = 0`: No more pages; this is the last page
+- Invalid non-zero cursors are rejected to prevent silent duplicate/skip behavior
 
 ### Security Notes
 
-- Pagination validates index-to-storage consistency and owner binding.
-- Any detected index/storage mismatch fails fast instead of returning ambiguous data.
-- This reduces the risk of inconsistent client state caused by malformed or stale cursors.
+- Pagination validates index-to-storage consistency and owner binding
+- This reduces the risk of inconsistent client state caused by stale or malformed cursors
 
 ## Archived Goals
 

--- a/savings_goals/src/lib.rs
+++ b/savings_goals/src/lib.rs
@@ -369,50 +369,6 @@ impl SavingsGoalContract {
         }
     }
 
-    /// Returns a list of goals for an owner using offset-based pagination.
-    ///
-    /// # Arguments
-    /// * `owner` - The address of the goal owner.
-    /// * `offset` - The number of items to skip.
-    /// * `limit` - The maximum number of items to return.
-    ///
-    /// # Returns
-    /// A `Vec<SavingsGoal>` containing the requested goals.
-    pub fn get_goals_by_owner(
-        env: Env,
-        owner: Address,
-        offset: u32,
-        limit: u32,
-    ) -> Vec<SavingsGoal> {
-        let limit = Self::clamp_limit(limit);
-
-        let ids: Vec<u32> = env
-            .storage()
-            .persistent()
-            .get(&DataKey::OwnerGoals(owner.clone()))
-            .unwrap_or_else(|| Vec::new(&env));
-
-        let total_count = ids.len();
-        if offset >= total_count {
-            return Vec::new(&env);
-        }
-
-        let end = (offset + limit).min(total_count);
-        let mut result = Vec::new(&env);
-        for i in offset..end {
-            let goal_id = ids.get(i).unwrap_or_else(|| panic!("Index out of sync"));
-            if let Some(goal) = env
-                .storage()
-                .persistent()
-                .get::<_, SavingsGoal>(&DataKey::Goal(goal_id))
-            {
-                result.push_back(goal);
-            }
-        }
-
-        result
-    }
-
     // -----------------------------------------------------------------------
     // Pause / upgrade
     // -----------------------------------------------------------------------
@@ -1440,20 +1396,40 @@ impl SavingsGoalContract {
     // PAGINATED LIST QUERIES
     // -----------------------------------------------------------------------
 
-    /// @notice Returns a deterministic page of goals for one owner.
-    /// @dev Paging order is anchored to the owner-goal ID index (append-only,
-    ///      ascending by creation ID), not map iteration order.
-    /// @dev `cursor` is exclusive and must match an existing goal ID in the
-    ///      owner's index when non-zero; invalid cursors are rejected.
+    /// Returns a deterministic page of goals for one owner using cursor-based pagination.
+    ///
+    /// # Pagination Contract (Cursor-Based)
+    /// - **Deterministic order**: Goals are ordered by ID ascending (creation order)
+    /// - **Cursor semantics**: `cursor` is the ID of the last goal from the previous page.
+    ///   Pass `0` to start from the first page. The cursor is *exclusive* — results begin
+    ///   after the goal with the given ID.
+    /// - **Cursor validation**: If `cursor != 0`, it must match an existing goal ID in the
+    ///   owner's goal index; invalid cursors panic.
+    /// - **Next page**: Use `next_cursor` as the cursor for the next call. When `next_cursor == 0`,
+    ///   there are no more pages.
     ///
     /// # Arguments
-    /// * `owner`  - whose goals to return
-    /// * `cursor` - start after this goal ID (pass 0 for the first page)
-    /// * `limit`  - max items per page (0 -> DEFAULT_PAGE_LIMIT, capped at MAX_PAGE_LIMIT)
+    /// * `owner`  - Address whose goals to return
+    /// * `cursor` - Goal ID to start after (pass 0 for the first page)
+    /// * `limit`  - Max items per page (clamped: 0 → DEFAULT_PAGE_LIMIT, > MAX_PAGE_LIMIT → MAX_PAGE_LIMIT)
     ///
     /// # Returns
-    /// `GoalPage { items, next_cursor, count }`.
-    /// `next_cursor == 0` means no more pages.
+    /// `GoalPage { items: Vec<SavingsGoal>, next_cursor: u32, count: u32 }`
+    /// - `items`: The goals on this page
+    /// - `next_cursor`: Pass this to the next call for pagination; 0 = no more pages
+    /// - `count`: Number of items returned
+    ///
+    /// # Panics
+    /// - If `cursor != 0` and does not match an existing goal ID in the owner's index
+    ///
+    /// # Example
+    /// ```ignore
+    /// let page1 = get_goals(env, owner, 0, 20);
+    /// for goal in page1.items.iter() { /* process goal */ }
+    /// if page1.next_cursor != 0 {
+    ///   let page2 = get_goals(env, owner, page1.next_cursor, 20);
+    /// }
+    /// ```
     pub fn get_goals(env: Env, owner: Address, cursor: u32, limit: u32) -> GoalPage {
         let limit = Self::clamp_limit(limit);
 

--- a/savings_goals/src/test.rs
+++ b/savings_goals/src/test.rs
@@ -5166,33 +5166,37 @@ fn test_pagination_by_owner() {
 
     client.init();
 
-    // Create 15 goals
+    // Create 15 goals (IDs 1-15)
     for i in 1..=15 {
         let name = String::from_str(&env, &std::format!("Goal {}", i));
         client.create_goal(&owner, &name, &1000, &2000000000);
     }
 
-    // Page 1: offset 0, limit 5
-    let page1 = client.get_goals_by_owner(&owner, &0, &5);
-    assert_eq!(page1.len(), 5);
-    assert_eq!(page1.get(0).unwrap().id, 1);
-    assert_eq!(page1.get(4).unwrap().id, 5);
+    // Page 1: cursor=0 (start from beginning), limit=5
+    let page1 = client.get_goals(&owner, &0, &5);
+    assert_eq!(page1.count, 5);
+    assert_eq!(page1.items.get(0).unwrap().id, 1);
+    assert_eq!(page1.items.get(4).unwrap().id, 5);
+    assert_eq!(page1.next_cursor, 5);
 
-    // Page 2: offset 5, limit 5
-    let page2 = client.get_goals_by_owner(&owner, &5, &5);
-    assert_eq!(page2.len(), 5);
-    assert_eq!(page2.get(0).unwrap().id, 6);
-    assert_eq!(page2.get(4).unwrap().id, 10);
+    // Page 2: cursor=5 (start after goal 5), limit=5
+    let page2 = client.get_goals(&owner, &page1.next_cursor, &5);
+    assert_eq!(page2.count, 5);
+    assert_eq!(page2.items.get(0).unwrap().id, 6);
+    assert_eq!(page2.items.get(4).unwrap().id, 10);
+    assert_eq!(page2.next_cursor, 10);
 
-    // Page 3: offset 10, limit 10 (only 5 left)
-    let page3 = client.get_goals_by_owner(&owner, &10, &10);
-    assert_eq!(page3.len(), 5);
-    assert_eq!(page3.get(0).unwrap().id, 11);
-    assert_eq!(page3.get(4).unwrap().id, 15);
+    // Page 3: cursor=10 (start after goal 10), limit=10
+    let page3 = client.get_goals(&owner, &page2.next_cursor, &10);
+    assert_eq!(page3.count, 5);
+    assert_eq!(page3.items.get(0).unwrap().id, 11);
+    assert_eq!(page3.items.get(4).unwrap().id, 15);
+    assert_eq!(page3.next_cursor, 0); // No more pages
 
-    // Page 4: offset 15, limit 5 (empty)
-    let page4 = client.get_goals_by_owner(&owner, &15, &5);
-    assert_eq!(page4.len(), 0);
+    // Page 4: cursor=15 (start after goal 15), should be empty
+    let page4 = client.get_goals(&owner, &15, &5);
+    assert_eq!(page4.count, 0);
+    assert_eq!(page4.next_cursor, 0);
 }
 
 #[test]


### PR DESCRIPTION

Summary: 
I've successfully consolidated the two pagination methods into a single, documented cursor-based pagination contract. Here's what was done:

Changes Made:

1. Removed get_goals_by_owner(offset-based) function (44 lines deleted)
  - This offset-based method had two different pagination idioms covering the same data
  - Created maintenance hazard with inconsistent error handling
2. Enhanced get_goals() documentation with clear pagination contract:
  - Documented deterministic ordering by goal ID
  - Explained exclusive cursor semantics: cursor is the ID of the last goal from previous page
  - Clarified cursor validation: invalid cursors panic (consistent with workspace pattern)
  - Added usage example showing pagination flow
  - Documented return value structure clearly
3. Updated tests to use cursor-based pagination:
  - Converted test_pagination_by_owner() to use get_goals() with cursor semantics
  - Verified pagination behavior with explicit next_cursor assertions
  - Test now validates that next_cursor == 0 indicates last page
4. Updated documentation:
  - README.md: Simplified "Pagination Stability" section to focus on single canonical cursor-based method
  - rate-limiting-design.md: Updated function reference from get_goals_by_owner() to get_goals()
  
  closes #834 