### PR TITLE
refactor(common): add canonicalize_tags_checked returning Result

### DIFF
--- a/TAGGING_FEATURE.md
+++ b/TAGGING_FEATURE.md
@@ -101,6 +101,14 @@ Tags are normalized before storage using the following rules:
 3. **Length validation**: Tags must be 1-32 characters after normalization
 4. **Rejection**: Tags with invalid characters (e.g., @, !, #, spaces) are rejected with an error
 
+#### Shared helpers (`remitwise-common`)
+Tag validation is centralized in `remitwise-common`:
+
+- **`canonicalize_tags_checked(env, tags) -> Result<Vec<String>, TagError>`** — preferred for untrusted or indexer-supplied input. Returns typed errors (`Empty`, `TooLong`, `InvalidChar { position }`) and short-circuits on the first violation.
+- **`canonicalize_tags(env, tags, on_invalid_char)`** — legacy panic-based wrapper retained for backward compatibility. New contract code should prefer the checked variant and map `TagError` to each crate's contract errors (e.g. `SavingsGoalError::InvalidTagContent`).
+
+`TAG_MAX_LEN` (32) in `remitwise-common` is the single source of truth for maximum tag length.
+
 #### Examples
 - `"URGENT-1_Tag"` → `"urgent-1_tag"` (normalized)
 - `"Monthly-Bill"` → `"monthly-bill"` (normalized)

--- a/remitwise-common/src/lib.rs
+++ b/remitwise-common/src/lib.rs
@@ -132,15 +132,98 @@ pub fn clamp_limit(limit: u32) -> u32 {
 /// Maximum allowed byte length for a single tag.
 pub const TAG_MAX_LEN: u32 = 32;
 
-/// Validates and canonicalizes a batch of tags.
+/// Validation failure returned by [`canonicalize_tags_checked`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TagError {
+    /// The tag batch is empty, or an individual tag is zero bytes long.
+    Empty,
+    /// A tag exceeds [`TAG_MAX_LEN`] bytes.
+    TooLong,
+    /// A byte at `position` is not in the allowed charset after upper-case folding.
+    InvalidChar { position: u32 },
+}
+
+/// Validates and canonicalizes a batch of tags without panicking.
+///
+/// # Rules
+/// - The batch must contain at least one tag ([`TagError::Empty`]).
+/// - Each tag must be between 1 and [`TAG_MAX_LEN`] bytes inclusive
+///   ([`TagError::Empty`] for zero length, [`TagError::TooLong`] otherwise).
+/// - Allowed charset: `[a-z0-9\-_]`. ASCII uppercase letters are silently
+///   folded to lowercase; any other byte yields [`TagError::InvalidChar`].
+///
+/// Validation short-circuits on the first violation (empty batch, length, or
+/// invalid byte) for gas efficiency.
+///
+/// # Returns
+/// On success, a new `Vec<String>` containing the normalized (lowercased) tags
+/// in the same order as the input. The function does **not** deduplicate.
+///
+/// # Usage
+/// ```ignore
+/// use remitwise_common::{canonicalize_tags_checked, TagError};
+/// match canonicalize_tags_checked(&env, &tags) {
+///     Ok(normalized) => { /* store normalized */ }
+///     Err(TagError::InvalidChar { .. }) => {
+///         soroban_sdk::panic_with_error!(&env, MyError::InvalidTagContent)
+///     }
+///     Err(TagError::Empty) | Err(TagError::TooLong) => { /* map to caller error */ }
+/// }
+/// ```
+pub fn canonicalize_tags_checked(
+    env: &soroban_sdk::Env,
+    tags: &soroban_sdk::Vec<soroban_sdk::String>,
+) -> Result<soroban_sdk::Vec<soroban_sdk::String>, TagError> {
+    if tags.is_empty() {
+        return Err(TagError::Empty);
+    }
+    let mut out = soroban_sdk::Vec::new(env);
+    for tag in tags.iter() {
+        let len = tag.len();
+        if len == 0 {
+            return Err(TagError::Empty);
+        }
+        if len > TAG_MAX_LEN {
+            return Err(TagError::TooLong);
+        }
+        let mut buf = [0u8; 32];
+        tag.copy_into_slice(&mut buf[..len as usize]);
+        for (position, byte) in buf.iter_mut().take(len as usize).enumerate() {
+            if byte.is_ascii_uppercase() {
+                *byte += b'a' - b'A';
+            }
+            let b = *byte;
+            if !(b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-' || b == b'_') {
+                return Err(TagError::InvalidChar {
+                    position: position as u32,
+                });
+            }
+        }
+        let s = match core::str::from_utf8(&buf[..len as usize]) {
+            Ok(v) => v,
+            Err(_) => {
+                return Err(TagError::InvalidChar { position: 0 });
+            }
+        };
+        out.push_back(soroban_sdk::String::from_str(env, s));
+    }
+    Ok(out)
+}
+
+/// Validates and canonicalizes a batch of tags, panicking on failure.
+///
+/// This is a thin wrapper around [`canonicalize_tags_checked`] that preserves
+/// the legacy panic-based contract for existing callers. Prefer
+/// [`canonicalize_tags_checked`] when handling untrusted or indexer-supplied
+/// tag strings so errors can be mapped to typed contract errors.
 ///
 /// # Rules
 /// - The batch must contain at least one tag (`panic!("Tags cannot be empty")`).
-/// - Each tag must be between 1 and `TAG_MAX_LEN` bytes inclusive
+/// - Each tag must be between 1 and [`TAG_MAX_LEN`] bytes inclusive
 ///   (`panic!("Tag must be between 1 and 32 characters")`).
-/// - Allowed charset: `[a-z0-9\-_]`.  ASCII uppercase letters are silently
+/// - Allowed charset: `[a-z0-9\-_]`. ASCII uppercase letters are silently
 ///   folded to lowercase; any other byte causes the supplied `on_invalid_char`
-///   closure to be called (typically `panic_with_error!` or `panic!`).
+///   closure to be called once (typically `panic_with_error!` or `panic!`).
 ///
 /// # Returns
 /// A new `Vec<String>` containing the normalized (lowercased) tags in the
@@ -161,37 +244,21 @@ pub fn canonicalize_tags<F>(
 where
     F: Fn(),
 {
-    if tags.is_empty() {
-        panic!("Tags cannot be empty");
-    }
-    let mut out = soroban_sdk::Vec::new(env);
-    for tag in tags.iter() {
-        let len = tag.len();
-        if len == 0 || len > TAG_MAX_LEN {
+    match canonicalize_tags_checked(env, tags) {
+        Ok(out) => out,
+        Err(TagError::Empty) => {
+            if tags.is_empty() {
+                panic!("Tags cannot be empty");
+            }
             panic!("Tag must be between 1 and 32 characters");
         }
-        let mut buf = [0u8; 32];
-        tag.copy_into_slice(&mut buf[..len as usize]);
-        for byte in buf.iter_mut().take(len as usize) {
-            if byte.is_ascii_uppercase() {
-                *byte += b'a' - b'A';
-            }
-            let b = *byte;
-            if !(b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-' || b == b'_') {
-                on_invalid_char();
-            }
+        Err(TagError::TooLong) => panic!("Tag must be between 1 and 32 characters"),
+        Err(TagError::InvalidChar { .. }) => {
+            on_invalid_char();
+            // on_invalid_char must diverge (panic); this is unreachable.
+            soroban_sdk::Vec::new(env)
         }
-        let s = match core::str::from_utf8(&buf[..len as usize]) {
-            Ok(v) => v,
-            Err(_) => {
-                on_invalid_char();
-                // on_invalid_char must diverge (panic); this is unreachable.
-                ""
-            }
-        };
-        out.push_back(soroban_sdk::String::from_str(env, s));
     }
-    out
 }
 
 /// Event emission helper

--- a/remitwise-common/src/tests.rs
+++ b/remitwise-common/src/tests.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 
-/// Tests for [`canonicalize_tags`] and [`clamp_limit`].
+/// Tests for [`canonicalize_tags`], [`canonicalize_tags_checked`], and [`clamp_limit`].
 ///
 /// # Canonicalization contract (pinned here)
 /// - ASCII uppercase letters are silently folded to lowercase.
@@ -255,6 +255,118 @@ fn test_canonicalize_invalid_tag_in_batch_fires_callback() {
     // First tag is valid; second has a space.
     let input = tags(&env, &["valid", "bad tag"]);
     canonicalize_tags(&env, &input, || panic!("invalid char"));
+}
+
+// ─── canonicalize_tags_checked: success paths ──────────────────────────────
+
+#[test]
+fn test_checked_normalizes_valid_tags() {
+    let env = Env::default();
+    let input = tags(&env, &["Travel", "FIRE", "long-term"]);
+    let out = canonicalize_tags_checked(&env, &input).unwrap();
+    assert_eq!(out.len(), 3);
+    assert_eq!(get(&env, &out, 0), "travel");
+    assert_eq!(get(&env, &out, 1), "fire");
+    assert_eq!(get(&env, &out, 2), "long-term");
+}
+
+#[test]
+fn test_checked_tag_exactly_32_chars_passes() {
+    let env = Env::default();
+    let tag = "abcdefghijklmnopqrstuvwxyzabcdef";
+    assert_eq!(tag.len(), 32);
+    let out = canonicalize_tags_checked(&env, &single(&env, tag)).unwrap();
+    assert_eq!(get(&env, &out, 0), tag);
+}
+
+#[test]
+fn test_checked_does_not_deduplicate() {
+    let env = Env::default();
+    let input = tags(&env, &["Travel", "travel"]);
+    let out = canonicalize_tags_checked(&env, &input).unwrap();
+    assert_eq!(out.len(), 2);
+    assert_eq!(get(&env, &out, 0), "travel");
+    assert_eq!(get(&env, &out, 1), "travel");
+}
+
+// ─── canonicalize_tags_checked: error paths ──────────────────────────────────
+
+#[test]
+fn test_checked_empty_batch_returns_empty() {
+    let env = Env::default();
+    let empty: Vec<String> = Vec::new(&env);
+    assert_eq!(
+        canonicalize_tags_checked(&env, &empty),
+        Err(TagError::Empty)
+    );
+}
+
+#[test]
+fn test_checked_empty_string_tag_returns_empty() {
+    let env = Env::default();
+    assert_eq!(
+        canonicalize_tags_checked(&env, &single(&env, "")),
+        Err(TagError::Empty)
+    );
+}
+
+#[test]
+fn test_checked_tag_33_chars_returns_too_long() {
+    let env = Env::default();
+    let tag = "abcdefghijklmnopqrstuvwxyzabcdefg";
+    assert_eq!(tag.len(), 33);
+    assert_eq!(
+        canonicalize_tags_checked(&env, &single(&env, tag)),
+        Err(TagError::TooLong)
+    );
+}
+
+#[test]
+fn test_checked_invalid_char_at_position_zero() {
+    let env = Env::default();
+    assert_eq!(
+        canonicalize_tags_checked(&env, &single(&env, "#savings")),
+        Err(TagError::InvalidChar { position: 0 })
+    );
+}
+
+#[test]
+fn test_checked_invalid_char_at_last_position() {
+    let env = Env::default();
+    let tag = "valid!";
+    let last = (tag.len() - 1) as u32;
+    assert_eq!(
+        canonicalize_tags_checked(&env, &single(&env, tag)),
+        Err(TagError::InvalidChar { position: last })
+    );
+}
+
+#[test]
+fn test_checked_short_circuits_on_first_invalid_char() {
+    let env = Env::default();
+    // '!' is at position 3; a later space at position 4 must not be reported.
+    assert_eq!(
+        canonicalize_tags_checked(&env, &single(&env, "bad! tag")),
+        Err(TagError::InvalidChar { position: 3 })
+    );
+}
+
+#[test]
+fn test_checked_invalid_tag_in_batch_short_circuits() {
+    let env = Env::default();
+    let input = tags(&env, &["valid", "bad tag"]);
+    assert_eq!(
+        canonicalize_tags_checked(&env, &input),
+        Err(TagError::InvalidChar { position: 3 })
+    );
+}
+
+#[test]
+fn test_checked_empty_batch_before_length_check() {
+    let env = Env::default();
+    let empty: Vec<String> = Vec::new(&env);
+    let err = canonicalize_tags_checked(&env, &empty).unwrap_err();
+    assert_eq!(err, TagError::Empty);
 }
 
 // ─── clamp_limit ─────────────────────────────────────────────────────────────

--- a/savings_goals/src/lib.rs
+++ b/savings_goals/src/lib.rs
@@ -605,12 +605,24 @@ impl SavingsGoalContract {
 
     /// Validates and canonicalizes a tag batch for metadata operations.
     ///
-    /// Delegates to the shared [`remitwise_common::canonicalize_tags`] helper.
+    /// Delegates to the shared [`remitwise_common::canonicalize_tags_checked`] helper.
     /// Invalid characters are reported as [`SavingsGoalError::InvalidTagContent`].
     fn validate_and_normalize_tags(env: &Env, tags: &Vec<String>) -> Vec<String> {
-        remitwise_common::canonicalize_tags(env, tags, || {
-            soroban_sdk::panic_with_error!(env, SavingsGoalError::InvalidTagContent)
-        })
+        match remitwise_common::canonicalize_tags_checked(env, tags) {
+            Ok(normalized) => normalized,
+            Err(remitwise_common::TagError::Empty) => {
+                if tags.is_empty() {
+                    panic!("Tags cannot be empty");
+                }
+                panic!("Tag must be between 1 and 32 characters");
+            }
+            Err(remitwise_common::TagError::TooLong) => {
+                panic!("Tag must be between 1 and 32 characters");
+            }
+            Err(remitwise_common::TagError::InvalidChar { .. }) => {
+                soroban_sdk::panic_with_error!(env, SavingsGoalError::InvalidTagContent)
+            }
+        }
     }
 
     /// Adds a goal ID to the tag index for an (owner, tag) pair.


### PR DESCRIPTION
## Overview
This PR adds a non-panicking `canonicalize_tags_checked` helper to `remitwise-common` so contracts can validate and normalize untrusted/indexer-supplied tag strings without panicking. It introduces `TagError` (`Empty`, `TooLong`, `InvalidChar { position }`), reimplements the legacy `canonicalize_tags` panic wrapper on top of the checked variant, and migrates `savings_goals::validate_and_normalize_tags` (used by `add_tags_to_goal`) as a reference consumer mapping `TagError::InvalidChar` → `SavingsGoalError::InvalidTagContent`.

## Related Issue
Closes #830

## Changes

### ⚙️ Shared Tag Validation (`remitwise-common`)
- **[ADD]** `TagError` enum with `Empty`, `TooLong`, and `InvalidChar { position }`
- **[ADD]** `canonicalize_tags_checked(env, tags) -> Result<Vec<String>, TagError>`
  - Validates non-empty batch, per-tag length (`TAG_MAX_LEN` = 32), and charset `[a-z0-9\-_]`
  - Folds ASCII uppercase to lowercase
  - Short-circuits on the first violation for gas efficiency
- **[MODIFY]** `canonicalize_tags` — thin panic-based wrapper over `canonicalize_tags_checked` for backward compatibility

### 🏦 Savings Goals Consumer Migration
- **[MODIFY]** `savings_goals/src/lib.rs` — `validate_and_normalize_tags`
  - Uses `canonicalize_tags_checked` instead of panicking closure
  - Maps `TagError::InvalidChar` → `SavingsGoalError::InvalidTagContent`
  - Preserves existing panic messages for `Empty` / `TooLong`

### 🧪 Tests
- **[ADD]** 11 unit tests in `remitwise-common/src/tests.rs` for `canonicalize_tags_checked`
  - Empty batch / empty tag / too-long tag
  - Invalid char at position 0 and last position
  - Short-circuit on first invalid byte
  - Normalization, dedup policy, and 32-char boundary

### 📄 Documentation
- **[MODIFY]** `TAGGING_FEATURE.md` — documents `canonicalize_tags_checked` vs `canonicalize_tags` and `TAG_MAX_LEN` as single source of truth

## Verification Results

```
cargo test -p remitwise-common ✅ passed (44/44)
cargo test -p savings_goals (add_tags) ✅ passed
cargo clippy -p remitwise-common -- -D warnings ✅ clean
```

| Acceptance Criteria | Status |
|---|---|
| `canonicalize_tags_checked` with distinct error cases (`Empty`, `TooLong`, `InvalidChar`) | ✅ |
| Short-circuit on first violation | ✅ |
| Legacy `canonicalize_tags` reimplemented on checked variant | ✅ |
| One consumer migrated (`savings_goals::add_tags_to_goal` via `validate_and_normalize_tags`) | ✅ |
| `TAGGING_FEATURE.md` updated | ✅ |
| `cargo test -p remitwise-common` passes | ✅ |
| `cargo test -p savings_goals` tag tests pass | ✅ |
| `cargo clippy -p remitwise-common` clean | ✅ |