### PR TITLE
feat: document and clarify replay-protection limitations of untracked imports

### DIFF
--- a/data_migration/README.md
+++ b/data_migration/README.md
@@ -103,11 +103,12 @@ let b64 = data_migration::export_to_encrypted_payload(&ciphertext_bytes);
 All import functions validate version compatibility, SHA-256 checksum, **and payload-type semantic invariants** before returning. An `Err` is returned if any check fails — the caller must not use the snapshot data if validation fails.
 
 ```rust
-// JSON
-let snapshot = data_migration::import_from_json(&json_bytes)?;
+// JSON (tracked — provides cross-call duplicate/replay protection)
+let mut tracker = MigrationTracker::new();
+let snapshot = data_migration::import_from_json(&json_bytes, &mut tracker, timestamp_ms)?;
 
-// Binary
-let snapshot = data_migration::import_from_binary(&bin_bytes)?;
+// Binary (tracked — provides cross-call duplicate/replay protection)
+let snapshot = data_migration::import_from_binary(&bin_bytes, &mut tracker, timestamp_ms)?;
 
 // CSV (goals only; no header checksum)
 let goals = data_migration::import_goals_from_csv(&csv_bytes)?;
@@ -115,6 +116,17 @@ let goals = data_migration::import_goals_from_csv(&csv_bytes)?;
 // Encrypted passthrough (caller decrypts after)
 let plain_bytes = data_migration::import_from_encrypted_payload(&b64)?;
 ```
+
+> **⚠️ Untracked variants do NOT provide cross-call duplicate/replay protection.**
+>
+> [`import_from_json_untracked`] and [`import_from_binary_untracked`] construct a
+> throwaway [`MigrationTracker`] on each call. Importing the same payload twice via
+> these helpers **succeeds both times** — no error is raised on the second call.
+>
+> Use these functions only for true one-shot scenarios (e.g. migration scripts
+> guaranteed to run exactly once). Prefer the tracked variants in all other contexts.
+> See the [Tracked vs Untracked duplicate protection](#tracked-vs-untracked-duplicate-protection)
+> section below for the full behavioural matrix.
 
 ### Manual validation
 
@@ -138,6 +150,42 @@ snapshot.validate_for_import()?;
 | `Generic` | *(none beyond size/count bounds)* | — |
 
 **Why this matters:** migration is where contract invariants are most easily bypassed, because data arrives pre-formed rather than through guarded entry-points. A split config that sums to 73% or 140%, or a savings snapshot with a wound-back `next_id`, would produce corrupt on-chain state that the contract would subsequently refuse to touch — a silent data-integrity bug introduced at the import boundary.
+
+## Tracked vs Untracked duplicate protection
+
+[`MigrationTracker`] is how this crate prevents the same snapshot from being applied
+to on-chain state more than once. The tracker records every successfully imported
+snapshot by its `(checksum, version)` identity. Passing the **same long-lived tracker**
+to every `import_from_json` / `import_from_binary` call means a second attempt with
+the same payload is always rejected with `MigrationError::DuplicateImport`.
+
+The `_untracked` variants are **convenience wrappers that construct and immediately
+discard a throwaway tracker**. There is no persistent state between calls. Because
+of this:
+
+| Scenario | `import_from_json` / `import_from_binary` | `import_from_json_untracked` / `import_from_binary_untracked` |
+|---|:---:|:---:|
+| First import | ✅ `Ok` | ✅ `Ok` |
+| Second import, same payload, same call session | ❌ `Err(DuplicateImport)` | ✅ `Ok` (footgun!) |
+| Structural validation (size, version, checksum, semantics) | ✅ enforced | ✅ enforced |
+
+### When `_untracked` is safe
+
+- The import runs exactly once and there is no possibility of a retry or replay
+  (e.g. a CI migration script that runs as a one-shot job).
+- You manage duplicate detection outside this crate (e.g. idempotency keys at the
+  transport layer).
+
+### When `_untracked` is NOT safe
+
+Any scenario where the same snapshot bytes could arrive twice — network retries,
+operator restarts, replay attacks — requires a long-lived `MigrationTracker`. Use
+[`import_from_json`] / [`import_from_binary`] and persist the tracker.
+
+> **Deprecation note:** The `_untracked` variants are retained for legacy one-shot
+> call sites. New code should use the tracked variants and pass an explicit
+> `MigrationTracker`. A future breaking release may remove the untracked helpers
+> entirely.
 
 ## Data structures
 

--- a/data_migration/src/lib.rs
+++ b/data_migration/src/lib.rs
@@ -17,6 +17,36 @@
 //!
 //! Legacy snapshots without an explicit `hash_algorithm` field are still
 //! supported by accepting the older `Simple` checksum format on import.
+//!
+//! # Replay / duplicate-import protection
+//!
+//! [`MigrationTracker`] is the mechanism that prevents the same snapshot from
+//! being applied to on-chain state more than once. The tracked import functions
+//! ([`import_from_json`] and [`import_from_binary`]) accept a `&mut
+//! MigrationTracker` and record every successfully imported snapshot by its
+//! `(checksum, version)` identity. A second call with the same payload returns
+//! [`MigrationError::DuplicateImport`].
+//!
+//! ## ⚠️ Untracked variants provide NO cross-call duplicate protection
+//!
+//! [`import_from_json_untracked`] and [`import_from_binary_untracked`] are
+//! convenience wrappers that construct a **throwaway** [`MigrationTracker`]
+//! internally. Because the tracker is discarded after each call, **importing
+//! the same payload twice via the untracked path succeeds both times**. There
+//! is no error on the second call.
+//!
+//! **Prefer the tracked variants** ([`import_from_json`] /
+//! [`import_from_binary`]) in any context where a payload might be seen more
+//! than once. Use the untracked variants only for true one-shot scenarios (e.g.
+//! a migration script that is guaranteed to run exactly once) and document that
+//! choice explicitly at the call site.
+//!
+//! | Function | Duplicate protection | Suitable for |
+//! |---|:---:|---|
+//! | [`import_from_json`] | ✅ Cross-call via `MigrationTracker` | Production imports, replay protection |
+//! | [`import_from_binary`] | ✅ Cross-call via `MigrationTracker` | Production imports, replay protection |
+//! | [`import_from_json_untracked`] | ❌ Within-call only (throwaway tracker) | True one-shot scenarios only |
+//! | [`import_from_binary_untracked`] | ❌ Within-call only (throwaway tracker) | True one-shot scenarios only |
 
 #![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
 
@@ -926,51 +956,97 @@ pub fn import_from_binary(
     Ok(snapshot)
 }
 
-/// Legacy helper for callers that do not need replay tracking.
+/// Import a JSON snapshot **without** cross-call duplicate/replay protection.
 ///
-/// # Validation contract
+/// # ⚠️ No Replay / Duplicate-Import Protection
 ///
-/// Despite the "untracked" name, this function enforces the **full import safety
-/// contract** by delegating to [`import_from_json`]:
+/// This function constructs a **throwaway** [`MigrationTracker`] on every call.
+/// Because the tracker is discarded immediately after the call returns, calling
+/// this function twice with the **same payload will succeed both times** — the
+/// second import is not detected as a duplicate.
+///
+/// **This is a footgun.** Applying the same migration twice produces
+/// double-applied on-chain state that is difficult to detect and hard to
+/// reverse. Use this function only when you can guarantee single-call usage
+/// through an external mechanism (e.g. the call site is inside a one-shot
+/// migration script that runs exactly once, or the test is exercising a
+/// one-shot round-trip and does not need duplicate protection).
+///
+/// **In all other cases, use [`import_from_json`] and pass a long-lived
+/// [`MigrationTracker`]** that persists across calls. Prefer the tracked variant
+/// by default; reach for this function consciously and document why duplicate
+/// protection is not needed at the call site.
+///
+/// > **Deprecation note:** This function is retained for existing call sites that
+/// > perform true one-shot imports. New code should use [`import_from_json`]
+/// > with an explicit tracker. A future breaking release may remove this helper
+/// > entirely in favour of requiring callers to be explicit about tracker scope.
+///
+/// # Validation contract (what IS enforced on every call)
+///
+/// Despite the absence of cross-call duplicate detection, this function still
+/// enforces the **full structural and semantic import safety contract**:
 ///
 /// 1. **Size guard** – rejects snapshots larger than [`MAX_MIGRATION_SNAPSHOT_BYTES`]
 ///    before deserialisation to prevent DoS.
-/// 2. **Version check** – calls [`ExportSnapshot::is_version_compatible`], which
-///    requires `MIN_SUPPORTED_VERSION <= header.version <= SCHEMA_VERSION`.
-///    Snapshots with a future version or a below-minimum version are rejected with
-///    [`MigrationError::IncompatibleVersion`].
-/// 3. **Payload bounds** – validates record count and payload byte size.
-/// 4. **Checksum verification** – calls [`ExportSnapshot::verify_checksum`]; any
-///    tampered or corrupted snapshot is rejected with [`MigrationError::ChecksumMismatch`].
+/// 2. **Version check** – requires `MIN_SUPPORTED_VERSION <= header.version <= SCHEMA_VERSION`;
+///    out-of-range versions are rejected with [`MigrationError::IncompatibleVersion`].
+/// 3. **Payload bounds** – validates record count and canonical payload byte size.
+/// 4. **Checksum verification** – any tampered or corrupted snapshot is rejected with
+///    [`MigrationError::ChecksumMismatch`].
+/// 5. **Semantic invariants** – enforces the same business rules as the live contracts
+///    (e.g. `RemittanceSplit` percentages must sum to 100).
 ///
-/// The only difference from [`import_from_json`] is that a throwaway
-/// [`MigrationTracker`] is used, so duplicate-import detection is not persisted
-/// across calls. Prefer [`import_from_json`] when replay protection is required.
+/// See also: [`data_migration` module docs](self) for the cross-call replay-protection
+/// distinction between tracked and untracked import paths.
 pub fn import_from_json_untracked(bytes: &[u8]) -> Result<ExportSnapshot, MigrationError> {
     let mut tracker = MigrationTracker::new();
     import_from_json(bytes, &mut tracker, 0)
 }
 
-/// Legacy helper for callers that do not need replay tracking.
+/// Import a binary snapshot **without** cross-call duplicate/replay protection.
 ///
-/// # Validation contract
+/// # ⚠️ No Replay / Duplicate-Import Protection
 ///
-/// Despite the "untracked" name, this function enforces the **full import safety
-/// contract** by delegating to [`import_from_binary`]:
+/// This function constructs a **throwaway** [`MigrationTracker`] on every call.
+/// Because the tracker is discarded immediately after the call returns, calling
+/// this function twice with the **same payload will succeed both times** — the
+/// second import is not detected as a duplicate.
+///
+/// **This is a footgun.** Applying the same migration twice produces
+/// double-applied on-chain state that is difficult to detect and hard to
+/// reverse. Use this function only when you can guarantee single-call usage
+/// through an external mechanism (e.g. the call site is inside a one-shot
+/// migration script that runs exactly once, or the test is exercising a
+/// one-shot round-trip and does not need duplicate protection).
+///
+/// **In all other cases, use [`import_from_binary`] and pass a long-lived
+/// [`MigrationTracker`]** that persists across calls. Prefer the tracked variant
+/// by default; reach for this function consciously and document why duplicate
+/// protection is not needed at the call site.
+///
+/// > **Deprecation note:** This function is retained for existing call sites that
+/// > perform true one-shot imports. New code should use [`import_from_binary`]
+/// > with an explicit tracker. A future breaking release may remove this helper
+/// > entirely in favour of requiring callers to be explicit about tracker scope.
+///
+/// # Validation contract (what IS enforced on every call)
+///
+/// Despite the absence of cross-call duplicate detection, this function still
+/// enforces the **full structural and semantic import safety contract**:
 ///
 /// 1. **Size guard** – rejects snapshots larger than [`MAX_MIGRATION_SNAPSHOT_BYTES`]
 ///    before deserialisation to prevent DoS.
-/// 2. **Version check** – calls [`ExportSnapshot::is_version_compatible`], which
-///    requires `MIN_SUPPORTED_VERSION <= header.version <= SCHEMA_VERSION`.
-///    Snapshots with a future version or a below-minimum version are rejected with
-///    [`MigrationError::IncompatibleVersion`].
-/// 3. **Payload bounds** – validates record count and payload byte size.
-/// 4. **Checksum verification** – calls [`ExportSnapshot::verify_checksum`]; any
-///    tampered or corrupted snapshot is rejected with [`MigrationError::ChecksumMismatch`].
+/// 2. **Version check** – requires `MIN_SUPPORTED_VERSION <= header.version <= SCHEMA_VERSION`;
+///    out-of-range versions are rejected with [`MigrationError::IncompatibleVersion`].
+/// 3. **Payload bounds** – validates record count and canonical payload byte size.
+/// 4. **Checksum verification** – any tampered or corrupted snapshot is rejected with
+///    [`MigrationError::ChecksumMismatch`].
+/// 5. **Semantic invariants** – enforces the same business rules as the live contracts
+///    (e.g. `RemittanceSplit` percentages must sum to 100).
 ///
-/// The only difference from [`import_from_binary`] is that a throwaway
-/// [`MigrationTracker`] is used, so duplicate-import detection is not persisted
-/// across calls. Prefer [`import_from_binary`] when replay protection is required.
+/// See also: [`data_migration` module docs](self) for the cross-call replay-protection
+/// distinction between tracked and untracked import paths.
 pub fn import_from_binary_untracked(bytes: &[u8]) -> Result<ExportSnapshot, MigrationError> {
     let mut tracker = MigrationTracker::new();
     import_from_binary(bytes, &mut tracker, 0)
@@ -3715,5 +3791,309 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("1"), "error must mention next_id");
         assert!(msg.contains("5"), "error must mention max goal id");
+    }
+
+    // ==================== TRACKED VS UNTRACKED DUPLICATE-PROTECTION BEHAVIOURAL TESTS ====================
+    //
+    // These tests are the authoritative proof of the behavioural difference described in the
+    // `import_from_json_untracked` / `import_from_binary_untracked` doc-comments and in the
+    // crate-level "Replay / duplicate-import protection" section.
+    //
+    // Contract:
+    //   - Tracked double-import  → second call returns `Err(MigrationError::DuplicateImport)`.
+    //   - Untracked double-import → both calls succeed (each constructs a fresh throwaway tracker).
+    //   - Mixed (tracked first, then untracked same payload) → untracked succeeds because it has
+    //     no access to the long-lived tracker.
+    //   - Mixed (untracked first, then tracked same payload) → tracked succeeds on the first
+    //     call (the untracked call left no marker behind); duplicate would only fire on a second
+    //     tracked call.
+
+    // --- JSON: tracked double-import is rejected ---
+
+    #[test]
+    fn test_tracked_json_double_import_second_returns_duplicate_import() {
+        let snapshot = ExportSnapshot::new(sample_remittance_payload(), ExportFormat::Json);
+        let bytes = export_to_json(&snapshot).unwrap();
+        let mut tracker = MigrationTracker::new();
+
+        // First import succeeds.
+        import_from_json(&bytes, &mut tracker, 1_000).unwrap();
+
+        // Second import of the SAME payload via the SAME tracker must fail.
+        let result = import_from_json(&bytes, &mut tracker, 2_000);
+        assert_eq!(
+            result.unwrap_err(),
+            MigrationError::DuplicateImport,
+            "tracked JSON: second import of the same payload must return DuplicateImport"
+        );
+    }
+
+    #[test]
+    fn test_tracked_json_double_import_savings_goals_second_returns_duplicate_import() {
+        let snapshot = ExportSnapshot::new(sample_savings_payload(), ExportFormat::Json);
+        let bytes = export_to_json(&snapshot).unwrap();
+        let mut tracker = MigrationTracker::new();
+
+        import_from_json(&bytes, &mut tracker, 1_000).unwrap();
+
+        let result = import_from_json(&bytes, &mut tracker, 2_000);
+        assert_eq!(
+            result.unwrap_err(),
+            MigrationError::DuplicateImport,
+            "tracked JSON: SavingsGoals double-import must return DuplicateImport"
+        );
+    }
+
+    #[test]
+    fn test_tracked_json_double_import_generic_second_returns_duplicate_import() {
+        let snapshot = ExportSnapshot::new(sample_generic_payload(), ExportFormat::Json);
+        let bytes = export_to_json(&snapshot).unwrap();
+        let mut tracker = MigrationTracker::new();
+
+        import_from_json(&bytes, &mut tracker, 1_000).unwrap();
+
+        let result = import_from_json(&bytes, &mut tracker, 2_000);
+        assert_eq!(
+            result.unwrap_err(),
+            MigrationError::DuplicateImport,
+            "tracked JSON: Generic double-import must return DuplicateImport"
+        );
+    }
+
+    // --- Binary: tracked double-import is rejected ---
+
+    #[test]
+    fn test_tracked_binary_double_import_second_returns_duplicate_import() {
+        let snapshot = ExportSnapshot::new(sample_remittance_payload(), ExportFormat::Binary);
+        let bytes = export_to_binary(&snapshot).unwrap();
+        let mut tracker = MigrationTracker::new();
+
+        import_from_binary(&bytes, &mut tracker, 1_000).unwrap();
+
+        let result = import_from_binary(&bytes, &mut tracker, 2_000);
+        assert_eq!(
+            result.unwrap_err(),
+            MigrationError::DuplicateImport,
+            "tracked binary: second import of the same payload must return DuplicateImport"
+        );
+    }
+
+    #[test]
+    fn test_tracked_binary_double_import_savings_goals_second_returns_duplicate_import() {
+        let snapshot = ExportSnapshot::new(sample_savings_payload(), ExportFormat::Binary);
+        let bytes = export_to_binary(&snapshot).unwrap();
+        let mut tracker = MigrationTracker::new();
+
+        import_from_binary(&bytes, &mut tracker, 1_000).unwrap();
+
+        let result = import_from_binary(&bytes, &mut tracker, 2_000);
+        assert_eq!(
+            result.unwrap_err(),
+            MigrationError::DuplicateImport,
+            "tracked binary: SavingsGoals double-import must return DuplicateImport"
+        );
+    }
+
+    // --- JSON: untracked double-import BOTH succeed ---
+
+    #[test]
+    fn test_untracked_json_double_import_both_succeed() {
+        // DOCUMENTED BEHAVIOUR: importing the same payload twice via the untracked path
+        // succeeds both times. This test asserts — and therefore documents — that absence
+        // of cross-call duplicate detection is intentional for the untracked helpers.
+        let snapshot = ExportSnapshot::new(sample_remittance_payload(), ExportFormat::Json);
+        let bytes = export_to_json(&snapshot).unwrap();
+
+        let first = import_from_json_untracked(&bytes);
+        assert!(
+            first.is_ok(),
+            "untracked JSON: first import must succeed, got {:?}",
+            first
+        );
+
+        // No error — throwaway tracker was discarded; no memory of the first import.
+        let second = import_from_json_untracked(&bytes);
+        assert!(
+            second.is_ok(),
+            "untracked JSON: second import of the same payload also succeeds \
+             (no cross-call duplicate protection — documented footgun)"
+        );
+    }
+
+    #[test]
+    fn test_untracked_json_double_import_savings_goals_both_succeed() {
+        let snapshot = ExportSnapshot::new(sample_savings_payload(), ExportFormat::Json);
+        let bytes = export_to_json(&snapshot).unwrap();
+
+        import_from_json_untracked(&bytes).unwrap();
+        // Second call must not return DuplicateImport.
+        let second = import_from_json_untracked(&bytes);
+        assert!(
+            second.is_ok(),
+            "untracked JSON: SavingsGoals double-import both succeed (no cross-call protection)"
+        );
+    }
+
+    #[test]
+    fn test_untracked_json_double_import_generic_both_succeed() {
+        let snapshot = ExportSnapshot::new(sample_generic_payload(), ExportFormat::Json);
+        let bytes = export_to_json(&snapshot).unwrap();
+
+        import_from_json_untracked(&bytes).unwrap();
+        let second = import_from_json_untracked(&bytes);
+        assert!(
+            second.is_ok(),
+            "untracked JSON: Generic double-import both succeed (no cross-call protection)"
+        );
+    }
+
+    // --- Binary: untracked double-import BOTH succeed ---
+
+    #[test]
+    fn test_untracked_binary_double_import_both_succeed() {
+        let snapshot = ExportSnapshot::new(sample_remittance_payload(), ExportFormat::Binary);
+        let bytes = export_to_binary(&snapshot).unwrap();
+
+        import_from_binary_untracked(&bytes).unwrap();
+
+        let second = import_from_binary_untracked(&bytes);
+        assert!(
+            second.is_ok(),
+            "untracked binary: second import of the same payload also succeeds \
+             (no cross-call duplicate protection — documented footgun)"
+        );
+    }
+
+    #[test]
+    fn test_untracked_binary_double_import_savings_goals_both_succeed() {
+        let snapshot = ExportSnapshot::new(sample_savings_payload(), ExportFormat::Binary);
+        let bytes = export_to_binary(&snapshot).unwrap();
+
+        import_from_binary_untracked(&bytes).unwrap();
+        let second = import_from_binary_untracked(&bytes);
+        assert!(
+            second.is_ok(),
+            "untracked binary: SavingsGoals double-import both succeed (no cross-call protection)"
+        );
+    }
+
+    // --- Mixing tracked and untracked: untracked does NOT see the long-lived tracker ---
+
+    #[test]
+    fn test_tracked_first_then_untracked_same_payload_untracked_succeeds() {
+        // Tracked import records the payload. The untracked call that follows has no
+        // access to that tracker and therefore succeeds — it is not duplicate-protected
+        // by the tracked call's state.
+        let snapshot = ExportSnapshot::new(sample_remittance_payload(), ExportFormat::Json);
+        let bytes = export_to_json(&snapshot).unwrap();
+        let mut tracker = MigrationTracker::new();
+
+        import_from_json(&bytes, &mut tracker, 1_000).unwrap();
+        assert!(tracker.is_imported(&snapshot), "tracker must reflect first import");
+
+        // Untracked call: throwaway tracker has no record of the above import.
+        let result = import_from_json_untracked(&bytes);
+        assert!(
+            result.is_ok(),
+            "untracked call after tracked import of the same payload still succeeds \
+             because untracked has no access to the long-lived tracker"
+        );
+
+        // The long-lived tracker is unchanged by the untracked call.
+        assert!(
+            tracker.is_imported(&snapshot),
+            "long-lived tracker must still show the original import as recorded"
+        );
+    }
+
+    #[test]
+    fn test_tracked_first_then_untracked_binary_same_payload_untracked_succeeds() {
+        let snapshot = ExportSnapshot::new(sample_savings_payload(), ExportFormat::Binary);
+        let bytes = export_to_binary(&snapshot).unwrap();
+        let mut tracker = MigrationTracker::new();
+
+        import_from_binary(&bytes, &mut tracker, 1_000).unwrap();
+
+        let result = import_from_binary_untracked(&bytes);
+        assert!(
+            result.is_ok(),
+            "untracked binary call after tracked import still succeeds"
+        );
+    }
+
+    #[test]
+    fn test_untracked_first_then_tracked_same_payload_tracked_first_call_succeeds() {
+        // Untracked call leaves NO trace in any persistent tracker; the subsequent
+        // tracked call with the same payload succeeds on its first use of the tracker.
+        let snapshot = ExportSnapshot::new(sample_generic_payload(), ExportFormat::Json);
+        let bytes = export_to_json(&snapshot).unwrap();
+
+        // Untracked call: throwaway tracker, discarded.
+        import_from_json_untracked(&bytes).unwrap();
+
+        // First tracked call with the same payload and a fresh long-lived tracker: succeeds.
+        let mut tracker = MigrationTracker::new();
+        let first_tracked = import_from_json(&bytes, &mut tracker, 2_000);
+        assert!(
+            first_tracked.is_ok(),
+            "first tracked import after untracked must succeed \
+             (untracked left no marker in any persistent tracker)"
+        );
+
+        // Only the second tracked call against the SAME tracker produces DuplicateImport.
+        let second_tracked = import_from_json(&bytes, &mut tracker, 3_000);
+        assert_eq!(
+            second_tracked.unwrap_err(),
+            MigrationError::DuplicateImport,
+            "second tracked import must still be rejected by the long-lived tracker"
+        );
+    }
+
+    #[test]
+    fn test_untracked_first_then_tracked_binary_same_payload_tracked_succeeds() {
+        let snapshot = ExportSnapshot::new(sample_remittance_payload(), ExportFormat::Binary);
+        let bytes = export_to_binary(&snapshot).unwrap();
+
+        import_from_binary_untracked(&bytes).unwrap();
+
+        let mut tracker = MigrationTracker::new();
+        let tracked = import_from_binary(&bytes, &mut tracker, 1_000);
+        assert!(
+            tracked.is_ok(),
+            "tracked binary import after untracked must succeed"
+        );
+    }
+
+    // --- Payload returned by untracked double-import is valid and identical ---
+
+    #[test]
+    fn test_untracked_json_double_import_payloads_are_identical() {
+        // Both successful calls must return the same snapshot data.
+        let snapshot = ExportSnapshot::new(sample_remittance_payload(), ExportFormat::Json);
+        let bytes = export_to_json(&snapshot).unwrap();
+
+        let first = import_from_json_untracked(&bytes).unwrap();
+        let second = import_from_json_untracked(&bytes).unwrap();
+
+        assert_eq!(
+            first.payload, second.payload,
+            "both untracked imports must yield identical payloads"
+        );
+        assert_eq!(
+            first.header.checksum, second.header.checksum,
+            "both untracked imports must yield identical checksums"
+        );
+    }
+
+    #[test]
+    fn test_untracked_binary_double_import_payloads_are_identical() {
+        let snapshot = ExportSnapshot::new(sample_savings_payload(), ExportFormat::Binary);
+        let bytes = export_to_binary(&snapshot).unwrap();
+
+        let first = import_from_binary_untracked(&bytes).unwrap();
+        let second = import_from_binary_untracked(&bytes).unwrap();
+
+        assert_eq!(first.payload, second.payload);
+        assert_eq!(first.header.checksum, second.header.checksum);
     }
 }


### PR DESCRIPTION
Closes #847 
<html>
<body>
<!--StartFragment--><div><div class="flex h-svh w-screen flex-col"><div class="relative z-0 flex min-h-0 w-full flex-1"><div class="relative flex min-h-0 w-full min-w-0 flex-1"><div class="relative flex min-h-0 min-w-0 flex-1" data-side-pane-shell-host="true"><div class="@container/main relative flex min-w-0 flex-1 flex-col -translate-y-[calc(env(safe-area-inset-bottom,0px)/2)] pt-[calc(env(safe-area-inset-bottom,0px)/2)]"><div data-scroll-root="" class="@w-sm/main:[scrollbar-gutter:var(--stage-scroll-gutter)] touch:[scrollbar-width:none] group/scroll-root relative flex min-h-0 min-w-0 flex-1 flex-col [scrollbar-gutter:stable] not-print:overflow-x-clip not-print:overflow-y-auto group-data-stream-active/scroll-root:[overflow-anchor:none] not-print:data-expanded-composer:overflow-y-hidden! scroll-pt-(--header-height) [--sticky-padding-top:var(--header-height)] [--sticky-padding-bottom:0px] [--scroll-root-safe-area-inset-top:calc(var(--sticky-padding-top)+env(safe-area-inset-top,0px))] [--scroll-root-safe-area-inset-bottom:calc(var(--sticky-padding-bottom)+var(--screen-keyboard-height,0px)+env(safe-area-inset-bottom,0px))] [--scroll-root-safe-area-height:calc(100lvh-var(--scroll-root-safe-area-inset-top)-var(--scroll-root-safe-area-inset-bottom))] has-data-[fixed-header=less-than-md]:md:scroll-pt-0 has-data-[fixed-header=less-than-md]:md:[--sticky-padding-top:0px] has-data-[fixed-header=less-than-xl]:@w-xl/main:scroll-pt-0 has-data-[fixed-header=less-than-xl]:@w-xl/main:[--sticky-padding-top:0px] has-data-[fixed-header=less-than-xxl]:@w-2xl/main:scroll-pt-0 has-data-[fixed-header=less-than-xxl]:@w-2xl/main:[--sticky-padding-top:0px]" data-scroll-from-top="" data-scroll-from-end=""><div class="contents"><main class="not-keyboard-focused:outline-none min-h-0 flex-1" id="main" tabindex="-1" z-index="-1"><div id="thread" class="group/thread flex flex-col min-h-full"><div role="presentation" class="composer-parent flex flex-1 flex-col focus-visible:outline-0"><div data-voice-floating-orb-focus-background="" class="relative basis-auto flex-col -mb-(--composer-overlap-px) pb-(--composer-overlap-px) [--composer-overlap-px:28px] grow flex"><div class="flex flex-col text-sm"><div class="qMYqUG_convSearchResultHighlightRoot"><div class="" data-turn-id-container="request-WEB:ea8667a9-ad6a-426f-8151-d3d6a70c4a89-2" data-is-intersecting="true"><section class="text-token-text-primary w-full focus:outline-none has-data-writing-block:pointer-events-none [&amp;:has([data-writing-block])&gt;*]:pointer-events-auto R6Vx5W_threadScrollVars scroll-mb-[calc(var(--scroll-root-safe-area-inset-bottom,0px)+var(--thread-response-height))] scroll-mt-[calc(var(--header-height)+min(200px,max(70px,20svh)))]" dir="auto" data-turn-id="request-WEB:ea8667a9-ad6a-426f-8151-d3d6a70c4a89-2" data-turn-id-container="request-WEB:ea8667a9-ad6a-426f-8151-d3d6a70c4a89-2" data-testid="conversation-turn-6" data-turn="assistant"><div class="text-base my-auto mx-auto pb-10 [--thread-content-margin:var(--thread-content-margin-xs,calc(var(--spacing)*4))] @w-sm/main:[--thread-content-margin:var(--thread-content-margin-sm,calc(var(--spacing)*6))] @w-lg/main:[--thread-content-margin:var(--thread-content-margin-lg,calc(var(--spacing)*16))] px-(--thread-content-margin)"><div data-conversation-screenshot-content="" class="[--thread-content-max-width:40rem] @w-lg/main:[--thread-content-max-width:48rem] mx-auto max-w-(--thread-content-max-width) flex-1 group/turn-messages focus-visible:outline-hidden relative flex w-full min-w-0 flex-col agent-turn"><div class="flex max-w-full flex-col gap-4 grow"><div data-message-author-role="assistant" data-message-id="eeef918a-9cb8-4bb7-bc73-14ac448bbb7c" dir="auto" data-message-model-slug="gpt-5-5" class="min-h-8 text-message relative flex w-full flex-col items-end gap-2 text-start break-words whitespace-normal outline-none keyboard-focused:focus-ring [.text-message+&amp;]:mt-1" data-turn-start-message="true" tabindex="0"><div class="flex w-full flex-col gap-1 empty:hidden"><div class="markdown prose dark:prose-invert wrap-break-word w-full dark markdown-new-styling"><h3 data-section-id="iifc0y" data-start="112" data-end="130" class="PDq2pG_selectionAnchorContainer">PR Description<span aria-hidden="true" class="PDq2pG_selectionAnchor"></span></h3>
<h2 data-section-id="1k5q749" data-start="132" data-end="142">Summary</h2>
<p data-start="144" data-end="392">This PR improves the safety and discoverability of the untracked import APIs by explicitly documenting their replay-protection limitations and adding regression tests that demonstrate the behavioral difference between tracked and untracked imports.</p>
<p data-start="394" data-end="758">The <code data-start="398" data-end="428">import_from_json_untracked()</code> and <code data-start="433" data-end="465">import_from_binary_untracked()</code> helpers create a temporary <code data-start="493" data-end="511">MigrationTracker</code> internally, which means duplicate-import detection does <strong data-start="568" data-end="575">not</strong> persist across calls. As a result, importing the same payload multiple times through these APIs succeeds repeatedly, unlike the tracked APIs which correctly return <code data-start="740" data-end="757">DuplicateImport</code>.</p>
<p data-start="760" data-end="932">This behavior is intentional but previously undocumented, creating a potential footgun for consumers expecting replay protection to apply uniformly across all import paths.</p>
<h2 data-section-id="bzco8g" data-start="934" data-end="944">Changes</h2>
<h3 data-section-id="8q6zro" data-start="946" data-end="963">Documentation</h3>
<p data-start="965" data-end="1002"><strong data-start="965" data-end="974">File:</strong> <code data-start="975" data-end="1002">data_migration/src/lib.rs</code></p>
<ul data-start="1004" data-end="1435">
<li data-section-id="de693v" data-start="1004" data-end="1126">
Added prominent <code data-start="1022" data-end="1027">///</code> documentation comments to:
<ul data-start="1057" data-end="1126">
<li data-section-id="i1lx0w" data-start="1057" data-end="1089">
<code data-start="1059" data-end="1089">import_from_json_untracked()</code>
</li>
<li data-section-id="1ulzizr" data-start="1092" data-end="1126">
<code data-start="1094" data-end="1126">import_from_binary_untracked()</code>
</li>
</ul>
</li>
<li data-section-id="n3qtyr" data-start="1127" data-end="1353">
Explicitly state that these functions:
<ul data-start="1170" data-end="1353">
<li data-section-id="ume3ls" data-start="1170" data-end="1233">
Do <strong data-start="1175" data-end="1182">not</strong> provide cross-call duplicate or replay protection.
</li>
<li data-section-id="cjgc7d" data-start="1236" data-end="1292">
Create a fresh <code data-start="1253" data-end="1271">MigrationTracker</code> for each invocation.
</li>
<li data-section-id="18vte5g" data-start="1295" data-end="1353">
Should only be used for true one-shot import operations.
</li>
</ul>
</li>
<li data-section-id="1554zkp" data-start="1354" data-end="1435">
Added examples and usage guidance to help consumers choose the appropriate API.
</li>
</ul>
<h3 data-section-id="cztyp5" data-start="1437" data-end="1472">Replay-Protection Documentation</h3>
<ul data-start="1474" data-end="1760">
<li data-section-id="6o9tzz" data-start="1474" data-end="1543">
Updated data-migration replay-protection/fail-closed documentation.
</li>
<li data-section-id="wxlu0m" data-start="1544" data-end="1672">
Added cross-references between:
<ul data-start="1580" data-end="1672">
<li data-section-id="1p7n4pc" data-start="1580" data-end="1601">
Tracked import APIs
</li>
<li data-section-id="1ww2u6j" data-start="1604" data-end="1627">
Untracked import APIs
</li>
<li data-section-id="1kepet8" data-start="1630" data-end="1650">
<code data-start="1632" data-end="1650">MigrationTracker</code>
</li>
<li data-section-id="1l9bbvm" data-start="1653" data-end="1672">
<code data-start="1655" data-end="1672">DuplicateImport</code>
</li>
</ul>
</li>
<li data-section-id="197jj0y" data-start="1673" data-end="1760">
Clarified when replay protection is guaranteed and when it is intentionally bypassed.
</li>
</ul>
<h3 data-section-id="1ri4zyc" data-start="1762" data-end="1784">Deprecation Review</h3>
<ul data-start="1786" data-end="1996">
<li data-section-id="19gk3ph" data-start="1786" data-end="1836">
Evaluated deprecating untracked import variants.
</li>
<li data-section-id="gp6vzy" data-start="1837" data-end="1874">
Documented rationale and tradeoffs.
</li>
<li data-section-id="1lrmk1o" data-start="1875" data-end="1996">
Retained existing APIs for backward compatibility while making the loss of replay protection explicit in documentation.
</li>
</ul>
<h3 data-section-id="79tlsz" data-start="1998" data-end="2007">Tests</h3>
<p data-start="2009" data-end="2041">Added behavioral tests covering:</p>
<h4 data-start="2043" data-end="2063">Tracked Imports</h4>
<pre class="overflow-visible! px-0!" data-start="2065" data-end="2122"><div class="relative w-full mt-4 mb-1"><div class=""><div class="contents"><div class="border border-token-border-light border-radius-3xl corner-superellipse/1.1 rounded-3xl"><div class="relative h-full w-full border-radius-3xl bg-token-bg-elevated-secondary corner-superellipse/1.1 overflow-clip rounded-3xl lxnfua_clipPathFallback"><div class="pointer-events-none absolute inset-x-4 top-12 bottom-4"><div class="pointer-events-none sticky z-40 shrink-0 z-1!"><div class="sticky bg-token-border-light"></div></div></div><div class="relative"><div class="h-full min-h-0 min-w-0"><div class="h-full min-h-0 min-w-0"><div class=""><div class="relative"><div class=""><div class="relative z-0 flex max-w-full"><div id="code-block-viewer" dir="ltr" class="q9tKkq_viewer cm-editor z-10 light:cm-light dark:cm-light flex h-full w-full flex-col items-stretch ͼs ͼ16"><div class="cm-scroller"><pre class="cm-content q9tKkq_readonly m-0"><code><span class="ͼ11">import_from_json</span><span>(...)</span><br><span>import_from_binary(...)</span></code></pre></div></div></div></div></div></div></div></div><div class=""><div class=""></div></div></div></div></div></div></div></div></pre>
<ul data-start="2124" data-end="2211">
<li data-section-id="1m5rxkg" data-start="2124" data-end="2148">
First import succeeds.
</li>
<li data-section-id="t8xzng" data-start="2149" data-end="2211">
Second import of the same payload returns <code data-start="2193" data-end="2210">DuplicateImport</code>.
</li>
</ul>
<h4 data-start="2213" data-end="2235">Untracked Imports</h4>
<pre class="overflow-visible! px-0!" data-start="2237" data-end="2314"><div class="relative w-full mt-4 mb-1"><div class=""><div class="contents"><div class="border border-token-border-light border-radius-3xl corner-superellipse/1.1 rounded-3xl"><div class="relative h-full w-full border-radius-3xl bg-token-bg-elevated-secondary corner-superellipse/1.1 overflow-clip rounded-3xl lxnfua_clipPathFallback"><div class="pointer-events-none absolute inset-x-4 top-12 bottom-4"><div class="pointer-events-none sticky z-40 shrink-0 z-1!"><div class="sticky bg-token-border-light"></div></div></div><div class="relative"><div class="h-full min-h-0 min-w-0"><div class="h-full min-h-0 min-w-0"><div class=""><div class="relative"><div class=""><div class="relative z-0 flex max-w-full"><div id="code-block-viewer" dir="ltr" class="q9tKkq_viewer cm-editor z-10 light:cm-light dark:cm-light flex h-full w-full flex-col items-stretch ͼs ͼ16"><div class="cm-scroller"><pre class="cm-content q9tKkq_readonly m-0"><code><span class="ͼ11">import_from_json_untracked</span><span>(...)</span><br><span>import_from_binary_untracked(...)</span></code></pre></div></div></div></div></div></div></div></div><div class=""><div class=""></div></div></div></div></div></div></div></div></pre>
<ul data-start="2316" data-end="2441">
<li data-section-id="1m5rxkg" data-start="2316" data-end="2340">
First import succeeds.
</li>
<li data-section-id="nukze7" data-start="2341" data-end="2391">
Second import of the same payload also succeeds.
</li>
<li data-section-id="sdi7jk" data-start="2392" data-end="2441">
Behavior is explicitly verified and documented.
</li>
</ul>
<h4 data-start="2443" data-end="2459">Mixed Usage</h4>
<ul data-start="2461" data-end="2653">
<li data-section-id="b5wo1f" data-start="2461" data-end="2486">
Import via tracked API.
</li>
<li data-section-id="1ahxbfg" data-start="2487" data-end="2527">
Import same payload via untracked API.
</li>
<li data-section-id="4ofywf" data-start="2528" data-end="2575">
Verify behavior matches documented semantics.
</li>
<li data-section-id="c5rsqu" data-start="2576" data-end="2653">
Ensure no hidden replay-protection assumptions exist across API boundaries.
</li>
</ul>
<h2 data-section-id="o74n9f" data-start="2655" data-end="2673">Why This Change</h2>
<p data-start="2675" data-end="2682">Before:</p>
<div class="TyagGW_tableContainer"><div tabindex="-1" class="group TyagGW_tableWrapper flex flex-col-reverse w-fit">
API | Duplicate Detection
-- | --
import_from_json | ✅ Yes
import_from_binary | ✅ Yes
import_from_json_untracked | ❌ No (undocumented)
import_from_binary_untracked | ❌ No (undocumented)

</div></div>
<p data-start="3180" data-end="3311">This makes replay-protection guarantees explicit and helps prevent accidental double-applied migrations in production environments.</p>
<h2 data-section-id="23idtf" data-start="3313" data-end="3323">Testing</h2>
<pre class="overflow-visible! px-0!" data-start="3325" data-end="3425"><div class="relative w-full mt-4 mb-1"><div class=""><div class="contents"><div class="border border-token-border-light border-radius-3xl corner-superellipse/1.1 rounded-3xl"><div class="relative h-full w-full border-radius-3xl bg-token-bg-elevated-secondary corner-superellipse/1.1 overflow-clip rounded-3xl lxnfua_clipPathFallback"><div class="pointer-events-none absolute inset-x-4 top-12 bottom-4"><div class="pointer-events-none sticky z-40 shrink-0 z-1!"><div class="sticky bg-token-border-light"></div></div></div><div class="relative"><div class="h-full min-h-0 min-w-0"><div class="h-full min-h-0 min-w-0"><div class=""><div class="relative"><div class=""><div class="relative z-0 flex max-w-full"><div id="code-block-viewer" dir="ltr" class="q9tKkq_viewer cm-editor z-10 light:cm-light dark:cm-light flex h-full w-full flex-col items-stretch ͼs ͼ16"><div class="cm-scroller"><pre class="cm-content q9tKkq_readonly m-0"><code><span>cargo test </span><span class="ͼ12">-p</span><span> data_migration</span><br><span>cargo clippy </span><span class="ͼ12">-p</span><span> data_migration </span><span class="ͼ12">--all-targets</span><span> </span><span class="ͼ12">--all-features</span></code></pre></div></div></div></div></div></div></div></div><div class=""><div class=""></div></div></div></div></div></div></div></div></pre>
<h3 data-section-id="6z9eyl" data-start="3427" data-end="3449">Verified Scenarios</h3>
<ul data-start="3451" data-end="3692">
<li data-section-id="1iee7w4" data-start="3451" data-end="3489">
✅ Tracked duplicate imports rejected
</li>
<li data-section-id="14ax50g" data-start="3490" data-end="3530">
✅ Untracked duplicate imports accepted
</li>
<li data-section-id="t3m70a" data-start="3531" data-end="3560">
✅ JSON import paths covered
</li>
<li data-section-id="jxwp71" data-start="3561" data-end="3592">
✅ Binary import paths covered
</li>
<li data-section-id="pz8ann" data-start="3593" data-end="3648">
✅ Mixed tracked/untracked usage documented and tested
</li>
<li data-section-id="ajhjnb" data-start="3649" data-end="3692">
✅ Replay-protection documentation updated
</li>
</ul>
<h2 data-section-id="1540xrk" data-start="3694" data-end="3711">Security Notes</h2>
<ul data-start="3713" data-end="3979">
<li data-section-id="15atzsk" data-start="3713" data-end="3760">
No replay-protection guarantees were changed.
</li>
<li data-section-id="a892sb" data-start="3761" data-end="3812">
This PR improves visibility of existing behavior.
</li>
<li data-section-id="11jhq1w" data-start="3813" data-end="3897">
Consumers are now clearly informed when duplicate-import protection is not active.
</li>
<li data-section-id="1c527g2" data-start="3898" data-end="3979">
Reduces risk of accidental migration replays caused by incorrect API selection.
</li>
</ul>
<h3 data-section-id="16elh21" data-start="3981" data-end="4009">Suggested Commit Message</h3>
<pre class="overflow-visible! px-0!" data-start="4011" data-end="4460" data-is-last-node=""><div class="relative w-full mt-4 mb-1"><div class=""><div class="contents"><div class="relative"><div class="h-full min-h-0 min-w-0"><div class="h-full min-h-0 min-w-0"><div class="border border-token-border-light border-radius-3xl corner-superellipse/1.1 rounded-3xl"><div class="h-full w-full border-radius-3xl bg-token-bg-elevated-secondary corner-superellipse/1.1 overflow-clip rounded-3xl lxnfua_clipPathFallback"><div class="pointer-events-none absolute end-1.5 top-1 z-2 md:end-2 md:top-1"></div><div class="relative"><div class="pe-11 pt-3"><div class="relative z-0 flex max-w-full"><div id="code-block-viewer" dir="ltr" class="q9tKkq_viewer cm-editor z-10 light:cm-light dark:cm-light flex h-full w-full flex-col items-stretch ͼs ͼ16"><div class="cm-scroller"><pre class="cm-content q9tKkq_readonly m-0"><code><span>feat(data_migration): document and test replay-protection limits of untracked imports</span><br><br><span>Add prominent warnings for import_from_json_untracked and</span><br><span>import_from_binary_untracked, clarifying that they create a fresh</span><br><span>MigrationTracker and provide no cross-call duplicate detection.</span><br><br><span>Adds regression tests covering tracked vs untracked import behavior and</span><br><span>updates replay-protection documentation to prevent accidental double-</span><br><span>applied migrations.</span></code></pre></div></div></div></div></div></div></div></div></div><div class=""><div class=""></div></div></div></div></div></div></pre></div></div></div></div><div class="z-0 flex min-h-[46px] justify-start"></div><div class="mt-3 w-full empty:hidden"><div class="text-center"></div></div></div></div></section></div></div><div aria-hidden="true" class="pointer-events-none -mt-px h-px translate-y-[calc(var(--scroll-root-safe-area-inset-bottom)-14*var(--spacing))]"></div><div class="pointer-events-none translate-y-(--scroll-root-safe-area-inset-bottom) R6Vx5W_threadScrollVars min-h-(--gutter-remaining-height,0px) group-data-stream-active/scroll-root:h-[calc(var(--thread-response-height)-16*var(--spacing))]"></div></div></div><div id="thread-bottom-container" class="sticky bottom-0 z-10 group/thread-bottom-container relative isolate w-full basis-auto has-data-has-thread-error:pt-2 has-data-has-thread-error:[box-shadow:var(--sharp-edge-bottom-shadow)] md:border-transparent md:pt-0 dark:border-white/20 md:dark:border-transparent print:hidden content-fade single-line flex flex-col"><div class="relative mx-auto h-0"><div class="flex h-0 items-end justify-center motion-safe:transition-all motion-safe:delay-300 motion-safe:duration-300 group-[:not([data-scroll-from-end])]/scroll-root:scale-50 group-[:not([data-scroll-from-end])]/scroll-root:translate-y-2 group-[:not([data-scroll-from-end])]/scroll-root:opacity-0 group-[:not([data-scroll-from-end])]/scroll-root:pointer-events-none group-[:not([data-scroll-from-end])]/scroll-root:duration-100 group-[:not([data-scroll-from-end])]/scroll-root:delay-0 absolute start-1/2 z-10 -translate-x-1/2 bottom-[calc(100%+3*var(--spacing)+var(--thread-scroll-to-bottom-banner-offset,0px))]"></div></div><div id="thread-bottom"><div><div class="text-base mx-auto [--thread-content-margin:var(--thread-content-margin-xs,calc(var(--spacing)*4))] @w-sm/main:[--thread-content-margin:var(--thread-content-margin-sm,calc(var(--spacing)*6))] @w-lg/main:[--thread-content-margin:var(--thread-content-margin-lg,calc(var(--spacing)*16))] px-(--thread-content-margin)"><div><div class="[--thread-content-max-width:40rem] @w-lg/main:[--thread-content-max-width:48rem] mx-auto max-w-(--thread-content-max-width) flex-1 mb-[var(--thread-component-gap,1rem)]"><div class="w-full"><div class="flex justify-center empty:hidden"></div><div class="pointer-events-auto relative z-1 flex h-(--composer-container-height,100%) max-w-full flex-(--composer-container-flex,1) flex-col"><div data-prompt-textarea-header="" class="absolute start-0 end-0 bottom-full z-20"></div><form autocomplete="off" class="group/composer w-full" data-type="unified-composer"><div class="hidden"><input multiple="" type="file" tabindex="-1" id="upload-files"></div><div class="relative"><div class="bg-(--composer-surface-primary) cursor-text overflow-clip bg-clip-padding px-2 py-[9px] contain-inline-size motion-safe:transition-colors motion-safe:duration-200 motion-safe:ease-in-out group-not-data-expanded/composer:min-h-[52px] group-not-data-expanded/composer:py-[5px] grid grid-cols-[auto_1fr_auto] [grid-template-areas:'header_header_header'_'leading_primary_trailing'_'._footer_.'] group-data-expanded/composer:[grid-template-areas:'header_header_header'_'primary_primary_primary'_'leading_footer_trailing'] max-sm:[grid-template-areas:'header_header_header'_'primary_primary_primary'_'leading_footer_trailing'] shadow-short-composer" data-composer-surface="true"><div class="self-center [grid-area:leading]"><div id="_R_2akb2nekpaha4relnakoac97l35_" popover="hint" hidden="" role="tooltip" class="fixed inset-s-[anchor(center)] inset-e-auto top-[calc(anchor(bottom)+var(--spacing))] bottom-auto h-fit -translate-x-1/2 [position-try-fallbacks:flip-block] flex flex-col overflow-visible bg-transparent z-50"><!--$--><!--/$--></div><span class="flex"><button type="button" class="composer-btn" data-testid="composer-plus-btn" aria-label="Add files and more" aria-describedby="_R_2akb2nekpaha4relnakoac97l35_" interestfor="_R_2akb2nekpaha4relnakoac97l35_" id="composer-plus-btn"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" aria-hidden="true" class="icon"><use href="/cdn/assets/sprites-core-c74d0474.svg#decc1a" fill="currentColor"></use></svg></button></span></div><div class="-my-2.5 flex overflow-x-hidden ps-1.75 pe-1.5 [grid-area:primary] group-data-expanded/composer:mb-0 group-data-expanded/composer:ps-2.5 group-data-expanded/composer:pe-2.5 min-h-14 items-center"><div class="wcDTda_prosemirror-parent text-token-text-primary max-h-[max(30svh,5rem)] max-h-52 min-h-[var(--deep-research-composer-extra-height,unset)] flex-1 overflow-auto [scrollbar-width:thin] default-browser vertical-scroll-fade-mask group-data-[expanded-composer-mode-button]/composer:pe-9"><textarea class="wcDTda_fallbackTextarea" name="prompt-textarea" autocomplete="off" inputmode="text" autocorrect="on" autocapitalize="sentences" spellcheck="true" autofocus="" placeholder="Ask anything" aria-label="Chat with ChatGPT" data-virtualkeyboard="true"></textarea><div contenteditable="true" autocomplete="off" inputmode="text" autocorrect="on" autocapitalize="sentences" spellcheck="true" translate="no" class="ProseMirror" id="prompt-textarea" data-virtualkeyboard="true" role="textbox" aria-multiline="true" aria-label="Chat with ChatGPT"><p data-empty-paragraph="true" data-placeholder="Ask anything" class="placeholder"><br class="ProseMirror-trailingBreak"></p></div></div></div><div class="flex items-center gap-1 [grid-area:trailing]"><div class="ms-auto flex items-center gap-2"><div id="_r_0_" popover="hint" hidden="" role="tooltip" class="fixed inset-s-[anchor(center)] inset-e-auto top-[calc(anchor(bottom)+var(--spacing))] bottom-auto h-fit -translate-x-1/2 [position-try-fallbacks:flip-block] flex flex-col overflow-visible bg-transparent z-50"></div><button aria-label="Start dictation" type="button" class="composer-btn h-9 min-h-9 w-9 min-w-9" aria-describedby="_r_0_" interestfor="_r_0_"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" aria-label="" class="icon" font-size="inherit"><use href="/cdn/assets/sprites-core-c74d0474.svg#33d595" fill="currentColor"></use></svg></button><div><div class="inline-flex"><div><div id="_r_9b_" popover="hint" hidden="" role="tooltip" class="fixed inset-s-[anchor(center)] inset-e-auto top-[calc(anchor(bottom)+var(--spacing))] bottom-auto h-fit -translate-x-1/2 [position-try-fallbacks:flip-block] flex flex-col overflow-visible bg-transparent z-50"></div><button aria-describedby="_r_9b_" interestfor="_r_9b_" type="button" aria-label="Start Voice" class="composer-submit-button-color text-submit-btn-text keyboard-focused:focus-ring relative flex h-9 w-9 items-center justify-center rounded-full transition-colors hover:opacity-70 disabled:text-[#f4f4f4] disabled:opacity-30"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" aria-hidden="true" class="h-6 w-6"><use href="/cdn/assets/sprites-core-c74d0474.svg#28eb3d" fill="currentColor"></use></svg></button></div></div></div></div></div></div></div></form></div></div></div></div></div></div></div><div class="-mt-4 text-token-text-tertiary relative w-full overflow-hidden text-center text-xs [view-transition-name:var(--vt-disclaimer)] md:px-[60px]"><div class="text-base mx-auto [--thread-content-margin:var(--thread-content-margin-xs,calc(var(--spacing)*4))] @w-sm/main:[--thread-content-margin:var(--thread-content-margin-sm,calc(var(--spacing)*6))] @w-lg/main:[--thread-content-margin:var(--thread-content-margin-lg,calc(var(--spacing)*16))] px-(--thread-content-margin)"><div class="[--thread-content-max-width:40rem] @w-lg/main:[--thread-content-max-width:48rem] mx-auto max-w-(--thread-content-max-width) flex-1"></div></div></div></div></div></div></main></div></div></div><div class="relative min-h-0 shrink-0 overflow-hidden ease-out motion-reduce:transition-none transition-[width] duration-300" data-side-pane-shell-rail="true"><div aria-hidden="true" class="h-full w-full" data-side-pane-shell-surface="true"><div class="h-full w-full"></div></div></div></div></div></div><div></div></div></div><dialog class="group/dialog @container inset-0 min-h-full min-w-full whitespace-normal items-center justify-center overflow-auto overscroll-y-contain bg-[rgba(0,0,0,0.5)] backdrop-blur-[1px]"></dialog><audio class="fixed start-0 bottom-0 hidden h-0 w-0" autoplay="" crossorigin="anonymous"></audio><!--EndFragment-->
</body>
</html>