### PR TITLE
refactor(reporting): unify period range validation in remitwise-common

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ A common crate containing shared types, enums, and constants used across multipl
 
 **Shared Utilities:**
 - `clamp_limit()`: Helper for pagination limit validation
+- `validate_period()`: Helper for checking logical ordering of start/end ranges
 - `RemitwiseEvents`: Standardized event emission with `emit()` and `emit_batch()` methods
 
 ## Shared Enums & Constants Stability Coverage

--- a/docs/validate-period.md
+++ b/docs/validate-period.md
@@ -1,0 +1,11 @@
+# Period Validation Helper
+
+`remitwise-common::validate_period` is the canonical validation utility for checking the logical ordering of start and end timestamps/dates in range reads across Remitwise contracts.
+
+The contract is:
+- Returns `Ok(())` if `start <= end`.
+- Returns `Err(TimeError::InvalidPeriod)` if `start > end`.
+- Executed as an $O(1)$ stateless check.
+- Prevents redundant range validation implementation across different contracts.
+
+Callers should import and use this helper to standardize range validation and ensure consistent error handling when reading time-indexed data.

--- a/remitwise-common/Cargo.toml
+++ b/remitwise-common/Cargo.toml
@@ -11,5 +11,8 @@ soroban-sdk = "=21.7.7"
 proptest = "1"
 soroban-sdk = { version = "=21.7.7", features = ["testutils"] }
 
+[features]
+testutils = []
+
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/remitwise-common/src/emit_tests.rs
+++ b/remitwise-common/src/emit_tests.rs
@@ -1,12 +1,18 @@
-use soroban_sdk::{Env, Val, IntoVal, symbol_short, Vec};
-use crate::{RemitwiseEvents, EventCategory, EventPriority};
+use crate::{EventCategory, EventPriority, RemitwiseEvents};
+use soroban_sdk::{symbol_short, Env, Vec};
 
 #[test]
 fn test_compact_event_passes() {
     let env = Env::default();
     // A small payload
     let data = 42u32;
-    RemitwiseEvents::emit(&env, EventCategory::Transaction, EventPriority::High, symbol_short!("test"), data);
+    RemitwiseEvents::emit(
+        &env,
+        EventCategory::Transaction,
+        EventPriority::High,
+        symbol_short!("test"),
+        data,
+    );
 }
 
 #[test]
@@ -18,5 +24,11 @@ fn test_oversized_event_flagged() {
     for i in 0..100 {
         large_data.push_back(i);
     }
-    RemitwiseEvents::emit(&env, EventCategory::Transaction, EventPriority::High, symbol_short!("test"), large_data);
+    RemitwiseEvents::emit(
+        &env,
+        EventCategory::Transaction,
+        EventPriority::High,
+        symbol_short!("test"),
+        large_data,
+    );
 }

--- a/remitwise-common/src/lib.rs
+++ b/remitwise-common/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
 
-use soroban_sdk::{contracttype, symbol_short, Symbol};
+use soroban_sdk::{contracterror, contracttype, symbol_short, Symbol};
 
 /// Financial categories for remittance allocation
 #[contracttype]
@@ -122,6 +122,26 @@ pub fn clamp_limit(limit: u32) -> u32 {
         MAX_PAGE_LIMIT
     } else {
         limit
+    }
+}
+
+/// Error related to time and periods.
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum TimeError {
+    InvalidPeriod = 7,
+}
+
+/// Validates that a requested period is logically ordered.
+///
+/// # Errors
+/// Returns `TimeError::InvalidPeriod` if `start > end`.
+pub fn validate_period(start: u64, end: u64) -> Result<(), TimeError> {
+    if start > end {
+        Err(TimeError::InvalidPeriod)
+    } else {
+        Ok(())
     }
 }
 
@@ -279,7 +299,7 @@ impl RemitwiseEvents {
     /// * `data` – The event payload implementing `IntoVal`.
     ///
     /// The emitted event follows the topic schema defined in `docs/EVENT_TAXONOMY.md`.
-    /// 
+    ///
     /// **Size Budget**: Event data must be compact (topics + small payload, not bulk records).
     /// The recommended maximum serialized size for the `data` payload is 256 bytes.
     /// Oversized payloads will trigger a debug/test assertion.
@@ -298,22 +318,25 @@ impl RemitwiseEvents {
             priority.to_u32(),
             action,
         );
-        
+
         #[cfg(any(test, feature = "testutils"))]
         {
+            use soroban_sdk::xdr::ToXdr;
+            use soroban_sdk::TryFromVal;
             let val = data.into_val(env);
             if let Ok(sc_val) = soroban_sdk::xdr::ScVal::try_from_val(env, &val) {
-                if let Ok(xdr_bytes) = soroban_sdk::xdr::ToXdr::to_xdr(&sc_val) {
-                    let size = xdr_bytes.len();
-                    if size > 256 {
-                        panic!("Event data size {} exceeds 256-byte budget. Emits must be compact.", size);
-                    }
+                let xdr_bytes = sc_val.to_xdr(env);
+                let size = xdr_bytes.len();
+                if size > 256 {
+                    panic!(
+                        "Event data size {} exceeds the 256-byte budget. Emits must be compact.",
+                        size
+                    );
                 }
             }
             env.events().publish(topics, val);
-            return;
         }
-
+        #[cfg(not(any(test, feature = "testutils")))]
         env.events().publish(topics, data);
     }
 

--- a/remitwise-common/src/tests.rs
+++ b/remitwise-common/src/tests.rs
@@ -36,7 +36,7 @@ fn tags(env: &Env, items: &[&str]) -> Vec<String> {
 }
 
 // helper: extract the nth tag as a std::String for assertions
-fn get(env: &Env, v: &Vec<String>, i: u32) -> std::string::String {
+fn get(_env: &Env, v: &Vec<String>, i: u32) -> std::string::String {
     let s = v.get(i).unwrap();
     let mut buf = std::vec![0u8; s.len() as usize];
     s.copy_into_slice(&mut buf);

--- a/reporting/src/lib.rs
+++ b/reporting/src/lib.rs
@@ -623,14 +623,6 @@ impl ReportingContract {
         Ok(())
     }
 
-    /// Validates that a requested report period is logically ordered.
-    fn validate_period(period_start: u64, period_end: u64) -> Result<(), ReportingError> {
-        if period_start > period_end {
-            return Err(ReportingError::InvalidPeriod);
-        }
-        Ok(())
-    }
-
     /// Verify a [`ContractAddresses`] bundle using the same rules as [`ReportingContract::configure_addresses`].
     ///
     /// Does **not** write storage and does **not** require authorization. Intended for admin UIs and
@@ -958,7 +950,8 @@ impl ReportingContract {
         period_start: u64,
         period_end: u64,
     ) -> Result<RemittanceSummary, ReportingError> {
-        Self::validate_period(period_start, period_end)?;
+        remitwise_common::validate_period(period_start, period_end)
+            .map_err(|_| ReportingError::InvalidPeriod)?;
         user.require_auth();
         Self::get_remittance_summary_internal(&env, total_amount, period_start, period_end)
     }
@@ -1057,7 +1050,8 @@ impl ReportingContract {
         period_start: u64,
         period_end: u64,
     ) -> Result<SavingsReport, ReportingError> {
-        Self::validate_period(period_start, period_end)?;
+        remitwise_common::validate_period(period_start, period_end)
+            .map_err(|_| ReportingError::InvalidPeriod)?;
         user.require_auth();
         Self::get_savings_report_internal(&env, user, period_start, period_end)
     }
@@ -1113,7 +1107,8 @@ impl ReportingContract {
         period_start: u64,
         period_end: u64,
     ) -> Result<BillComplianceReport, ReportingError> {
-        Self::validate_period(period_start, period_end)?;
+        remitwise_common::validate_period(period_start, period_end)
+            .map_err(|_| ReportingError::InvalidPeriod)?;
         user.require_auth();
         Self::get_bill_compliance_report_internal(&env, user, period_start, period_end)
     }
@@ -1195,7 +1190,8 @@ impl ReportingContract {
         period_start: u64,
         period_end: u64,
     ) -> Result<InsuranceReport, ReportingError> {
-        Self::validate_period(period_start, period_end)?;
+        remitwise_common::validate_period(period_start, period_end)
+            .map_err(|_| ReportingError::InvalidPeriod)?;
         user.require_auth();
         Self::get_insurance_report_internal(&env, user, period_start, period_end)
     }
@@ -1263,7 +1259,8 @@ impl ReportingContract {
         period_start: u64,
         period_end: u64,
     ) -> Result<FamilySpendingReport, ReportingError> {
-        Self::validate_period(period_start, period_end)?;
+        remitwise_common::validate_period(period_start, period_end)
+            .map_err(|_| ReportingError::InvalidPeriod)?;
         user.require_auth();
         Self::get_family_spending_report_internal(&env, period_start, period_end)
     }
@@ -1572,7 +1569,8 @@ impl ReportingContract {
         period_start: u64,
         period_end: u64,
     ) -> Result<FinancialHealthReport, ReportingError> {
-        Self::validate_period(period_start, period_end)?;
+        remitwise_common::validate_period(period_start, period_end)
+            .map_err(|_| ReportingError::InvalidPeriod)?;
         user.require_auth();
         let health_score =
             Self::calculate_health_score(env.clone(), user.clone(), total_remittance)?;
@@ -1623,7 +1621,8 @@ impl ReportingContract {
         period_start: u64,
         period_end: u64,
     ) -> Result<TopNBillsReport, ReportingError> {
-        Self::validate_period(period_start, period_end)?;
+        remitwise_common::validate_period(period_start, period_end)
+            .map_err(|_| ReportingError::InvalidPeriod)?;
         user.require_auth();
         Ok(Self::get_top_bills_report_internal(
             &env,
@@ -1717,7 +1716,8 @@ impl ReportingContract {
         period_start: u64,
         period_end: u64,
     ) -> Result<TopNSavingsReport, ReportingError> {
-        Self::validate_period(period_start, period_end)?;
+        remitwise_common::validate_period(period_start, period_end)
+            .map_err(|_| ReportingError::InvalidPeriod)?;
         user.require_auth();
         Ok(Self::get_top_savings_report_internal(
             &env,

--- a/reporting/src/tests_archived_pagination_bound.rs
+++ b/reporting/src/tests_archived_pagination_bound.rs
@@ -86,7 +86,7 @@ mod savings_goals_mock {
             let mut goals = Vec::new(&env);
             goals.push_back(SavingsGoal {
                 id: 1,
-                owner: AddressTestutils::generate(&env),
+                owner: <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env),
                 name: SorobanString::from_str(&env, "Education"),
                 target_amount: 1000,
                 current_amount: 500,
@@ -185,7 +185,7 @@ mod family_wallet_mock {
     #[contractimpl]
     impl FamilyWalletTrait for FamilyWallet {
         fn get_owner(env: &Env) -> Address {
-            AddressTestutils::generate(env)
+            <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(env)
         }
         fn get_member_addresses_page(env: Env, _cursor: u32, _limit: u32) -> MemberAddressPage {
             MemberAddressPage {
@@ -264,7 +264,7 @@ fn make_zero_report(env: &Env, _user: &Address, generated_at: u64) -> FinancialH
 fn setup(env: &Env) -> (ReportingContractClient<'_>, Address) {
     let contract_id = env.register_contract(None, ReportingContract);
     let client = ReportingContractClient::new(env, &contract_id);
-    let admin = AddressTestutils::generate(env);
+    let admin = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(env);
     client.init(&admin);
 
     let remittance = env.register_contract(None, remittance_split_mock::RemittanceSplit);
@@ -334,7 +334,7 @@ fn deprecated_get_archived_reports_is_bounded_to_default_page_limit() {
     let env = Env::default();
     env.mock_all_auths();
     let (client, admin) = setup(&env);
-    let user = AddressTestutils::generate(&env);
+    let user = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
 
     // Seed `2 * DEFAULT_PAGE_LIMIT + 5` archives to prove the reader does
     // **not** scan the entire index even when there are many more entries.
@@ -357,7 +357,7 @@ fn deprecated_get_archived_reports_matches_first_page_of_paged_reader() {
     let env = Env::default();
     env.mock_all_auths();
     let (client, admin) = setup(&env);
-    let user = AddressTestutils::generate(&env);
+    let user = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
 
     let total = DEFAULT_PAGE_LIMIT + 7;
     seed_n_archives(&env, &client, &admin, &user, total);
@@ -404,7 +404,7 @@ fn paged_reader_walks_entire_archive_and_terminates() {
     let env = Env::default();
     env.mock_all_auths();
     let (client, admin) = setup(&env);
-    let user = AddressTestutils::generate(&env);
+    let user = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
 
     let page_size = 10u32;
     // 34 entries spans exactly 4 pages of 10 (10 + 10 + 10 + 4).
@@ -456,7 +456,7 @@ fn paged_reader_out_of_range_cursor_returns_empty_page_with_terminator() {
     let env = Env::default();
     env.mock_all_auths();
     let (client, admin) = setup(&env);
-    let user = AddressTestutils::generate(&env);
+    let user = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
 
     seed_n_archives(&env, &client, &admin, &user, 5);
 
@@ -488,7 +488,7 @@ fn paged_reader_empty_archive_returns_terminator() {
     let env = Env::default();
     env.mock_all_auths();
     let (client, _admin) = setup(&env);
-    let user = AddressTestutils::generate(&env);
+    let user = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
 
     let page = client.get_archived_reports_page(&user, &0u32, &DEFAULT_PAGE_LIMIT);
     assert_eq!(page.items.len(), 0, "empty archive returns no items");
@@ -504,7 +504,7 @@ fn paged_reader_normalizes_zero_limit_to_default_page_limit() {
     let env = Env::default();
     env.mock_all_auths();
     let (client, admin) = setup(&env);
-    let user = AddressTestutils::generate(&env);
+    let user = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
 
     seed_n_archives(&env, &client, &admin, &user, DEFAULT_PAGE_LIMIT + 5);
 
@@ -522,7 +522,7 @@ fn paged_reader_clamps_oversized_limit_to_max_page_limit() {
     let env = Env::default();
     env.mock_all_auths();
     let (client, admin) = setup(&env);
-    let user = AddressTestutils::generate(&env);
+    let user = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
 
     // Seed enough reports to know the clamp didn't shrink the page.
     seed_n_archives(&env, &client, &admin, &user, MAX_PAGE_LIMIT + 5);
@@ -545,8 +545,8 @@ fn paged_reader_user_isolation_holds_under_bound() {
     let env = Env::default();
     env.mock_all_auths();
     let (client, admin) = setup(&env);
-    let user_a = AddressTestutils::generate(&env);
-    let user_b = AddressTestutils::generate(&env);
+    let user_a = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
+    let user_b = <soroban_sdk::Address as soroban_sdk::testutils::Address>::generate(&env);
 
     seed_n_archives(&env, &client, &admin, &user_a, DEFAULT_PAGE_LIMIT + 10);
     seed_n_archives(&env, &client, &admin, &user_b, 3);


### PR DESCRIPTION
Closes #927

# PR Description

This change unifies time period range validation across the workspace by moving the validation logic into `remitwise-common`. 

Previously, range queries in the `reporting` contract verified start and end periods internally. To prevent logic duplication and establish a single source of truth, we introduced a centralized `validate_period` function and a corresponding `TimeError::InvalidPeriod` variant within the shared crate.

Under the new flow, the `reporting` contract imports `validate_period` to verify that `start <= end` before executing queries. If the check fails, the shared error is caught and translated to the contract's public `ReportingError::InvalidPeriod` to maintain full backwards compatibility with downstream clients.

# Changes Made
- **remitwise-common/src/lib.rs**: Added the `TimeError` enum and the stateless `validate_period` helper function.
- **remitwise-common/Cargo.toml**: Added the `testutils` feature to support conditional test-time checks.
- **remitwise-common/src/tests.rs** & **emit_tests.rs**: Updated tests to handle the new utility without compiler warnings.
- **reporting/src/lib.rs**: Removed the local `validate_period` function and updated all range reads to call the common helper.
- **reporting/src/tests_archived_pagination_bound.rs**: Fixed a trait path resolution compiler issue in the test harness.
- **docs/validate-period.md**: Created documentation outlining the validation contract and computational complexity.
- **README.md**: Documented the new helper function under the shared utilities section.

# Testing
Unit tests were executed locally to confirm the correctness of the changes:
- Run common library tests:
  ```bash
  cargo test -p remitwise-common
  ```
  Result: `46 passed; 0 failed`
- Run period range rejection tests:
  ```bash
  cargo test -p reporting --lib rejects_invalid_period
  ```
  Result: `5 passed; 0 failed`
- Build release WASM targets to verify compilation:
  ```bash
  cargo build --target wasm32-unknown-unknown --release
  ```
  Result: Successful build with zero errors.

# Scope Notes
- This is a contract logic refactoring and documentation update.
- No database migrations or frontend UI updates are included.