### PR TITLE
feat(emergency_killswitch): add admin-only clear_emergency_state recovery entrypoint

### DIFF
--- a/docs/killswitch-timelock.md
+++ b/docs/killswitch-timelock.md
@@ -25,6 +25,7 @@ stateDiagram-v2
     Paused --> Paused : schedule_unpause(time) (time >= now)
     Paused --> Active : unpause() (only when now >= time)
     Paused --> Paused : pause() (cancels/removes schedule)
+    Paused --> Active : clear_emergency_state() (admin, immediate)
 ```
 
 #### A. Global Pause (`pause`)
@@ -42,6 +43,15 @@ stateDiagram-v2
 #### D. Read-Only Query (`is_paused`)
 - **Action**: Returns the current pause status.
 - **Invariant**: The return value of `is_paused()` remains `true` throughout the incident and the cooling-off window. It only returns `false` *after* the `unpause()` function has been successfully executed by the admin after the timelock expires.
+
+#### E. Emergency Recovery (`clear_emergency_state`)
+- **Action**: Admin-only escape hatch that lifts the global pause **immediately**, bypassing the timelock.
+- **Why it exists**: The timelock can leave the contract in a *stuck-paused* state with no usable recovery short of redeploying. Because `pause()` removes any pending `DataKey::UnpauseSchedule` (invariant A), a re-pause during an incident leaves `GlobalPaused = true` with no schedule, so `unpause()` fails with `Error::InvalidSchedule` no matter how far the ledger advances. An operator who scheduled an unpause far in the future by mistake is similarly stuck until that timestamp.
+- **Behaviour**: Sets `DataKey::GlobalPaused` to `false` and removes any pending `DataKey::UnpauseSchedule` in a single call. It is **idempotent** — calling it while the contract is active is a successful no-op.
+- **Scope**: Clears only the *global* pause. Module-level (`pause_module`) and function-level (`pause_function`) pauses are intentionally preserved; lift those with `unpause_module` / `unpause_function`.
+- **Authorization**: Requires the killswitch admin (`admin.require_auth()`); returns `Error::NotInitialized` if the contract has no admin set.
+- **Trade-off**: This deliberately bypasses the cooling-off window. The timelock still governs the normal `schedule_unpause` → `unpause` path; `clear_emergency_state` is the break-glass recovery reserved for the admin when the normal path is unusable.
+- **Event**: Emits `("emergency", "cleared")` with `("GLOBAL", timestamp)`.
 
 ---
 
@@ -74,3 +84,9 @@ All invariants are verified by robust unit tests in `emergency_killswitch/tests/
 2. **`test_re_pause_cancels_schedule`**: Verifies that calling `pause()` cancels any pending unpause schedule, causing subsequent `unpause()` calls to fail with `Error::InvalidSchedule` even if the ledger moves past the originally scheduled timestamp.
 3. **`test_timelock_bypass_rejection`**: Verifies that past-dated schedules are immediately rejected by `schedule_unpause()`.
 4. **Boundary conditions**: Validates that unpause is successful exactly at the boundary of the scheduled timestamp (`ledger.timestamp() == scheduled_time`).
+5. **`test_clear_emergency_state_recovers_stuck_pause`**: Verifies that `clear_emergency_state()` lifts the global pause from the stuck state produced by a re-pause (where `unpause()` fails with `Error::InvalidSchedule`).
+6. **`test_clear_emergency_state_bypasses_timelock`**: Verifies that `clear_emergency_state()` succeeds before a scheduled unpause time and wipes the pending schedule.
+7. **`test_clear_emergency_state_is_idempotent_when_active`**: Verifies that calling `clear_emergency_state()` on an unpaused contract is a successful no-op.
+8. **`test_clear_emergency_state_requires_initialization`**: Verifies that `clear_emergency_state()` returns `Error::NotInitialized` before an admin is set.
+9. **`test_clear_emergency_state_requires_admin_auth`**: Verifies that `clear_emergency_state()` rejects callers that are not the admin.
+10. **`test_clear_emergency_state_preserves_module_and_function_pauses`**: Verifies that the recovery clears only the global pause and leaves module- and function-level pauses intact.

--- a/emergency_killswitch/src/lib.rs
+++ b/emergency_killswitch/src/lib.rs
@@ -131,6 +131,40 @@ impl EmergencyKillswitch {
         Ok(())
     }
 
+    /// Admin-only recovery path that immediately clears the global emergency
+    /// pause, bypassing the unpause timelock.
+    ///
+    /// [unpause] can only succeed once a future [schedule_unpause] has been set
+    /// *and* the ledger has reached it. A re-[pause] removes any pending
+    /// schedule (see [pause]), so a contract can be left globally paused with no
+    /// valid schedule — at which point `unpause` fails with
+    /// [Error::InvalidSchedule] and the only options were to wait out a stale
+    /// schedule or redeploy. This entrypoint lets the admin recover from that
+    /// stuck-paused state in a single call.
+    ///
+    /// Sets [DataKey::GlobalPaused] to `false` and removes any pending
+    /// [DataKey::UnpauseSchedule]. It is idempotent: calling it when the
+    /// contract is not paused is a successful no-op. Module- and function-level
+    /// pauses are intentionally left untouched — lift those with
+    /// [unpause_module] / [unpause_function].
+    ///
+    /// Emits an `emergency`/`cleared` event on success.
+    pub fn clear_emergency_state(env: Env) -> Result<(), Error> {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotInitialized)?;
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::GlobalPaused, &false);
+        env.storage().instance().remove(&DataKey::UnpauseSchedule);
+        env.events().publish(
+            (symbol_short!("emergency"), symbol_short!("cleared")),
+            (symbol_short!("GLOBAL"), env.ledger().timestamp()),
+        );
+        Ok(())
+    }
+
     pub fn schedule_unpause(env: Env, time: u64) -> Result<(), Error> {
         let admin: Address = env
             .storage()

--- a/emergency_killswitch/tests/test_killswitch.rs
+++ b/emergency_killswitch/tests/test_killswitch.rs
@@ -4,7 +4,7 @@ use emergency_killswitch::{EmergencyKillswitch, EmergencyKillswitchClient, Error
 use soroban_sdk::{
     symbol_short,
     testutils::{Address as _, Ledger},
-    Address, Env, Symbol, IntoVal,
+    Address, Env, Symbol,
 };
 
 fn setup(env: &Env) -> (Address, EmergencyKillswitchClient<'_>) {
@@ -122,6 +122,118 @@ fn test_timelock_bypass_rejection() {
     env.ledger().set_timestamp(1000);
     assert_eq!(client.try_schedule_unpause(&999), Err(Ok(Error::InvalidSchedule)));
     client.schedule_unpause(&1000);
+}
+
+#[test]
+fn test_clear_emergency_state_recovers_stuck_pause() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, EmergencyKillswitch);
+    let client = EmergencyKillswitchClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    // Reproduce the stuck-paused state: re-pause drops the schedule, so a
+    // later unpause fails with InvalidSchedule even past the original time.
+    client.pause();
+    let future = env.ledger().timestamp() + 3600;
+    client.schedule_unpause(&future);
+    client.pause();
+    env.ledger().set_timestamp(future);
+    assert_eq!(client.try_unpause(), Err(Ok(Error::InvalidSchedule)));
+    assert!(client.is_paused());
+
+    // The recovery entrypoint lifts the pause immediately.
+    client.clear_emergency_state();
+    assert!(!client.is_paused());
+}
+
+#[test]
+fn test_clear_emergency_state_bypasses_timelock() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, EmergencyKillswitch);
+    let client = EmergencyKillswitchClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    client.pause();
+    let future = env.ledger().timestamp() + 3600;
+    client.schedule_unpause(&future);
+
+    // Well before the scheduled time, unpause is rejected but clear is not.
+    assert_eq!(client.try_unpause(), Err(Ok(Error::Unauthorized)));
+    client.clear_emergency_state();
+    assert!(!client.is_paused());
+
+    // The pending schedule was wiped: a later unpause has nothing to act on.
+    env.ledger().set_timestamp(future);
+    assert_eq!(client.try_unpause(), Err(Ok(Error::InvalidSchedule)));
+}
+
+#[test]
+fn test_clear_emergency_state_is_idempotent_when_active() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, EmergencyKillswitch);
+    let client = EmergencyKillswitchClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    // Safe no-op when the contract was never paused.
+    assert!(!client.is_paused());
+    client.clear_emergency_state();
+    assert!(!client.is_paused());
+}
+
+#[test]
+fn test_clear_emergency_state_requires_initialization() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup(&env);
+    assert_eq!(
+        client.try_clear_emergency_state(),
+        Err(Ok(Error::NotInitialized))
+    );
+}
+
+#[test]
+fn test_clear_emergency_state_requires_admin_auth() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, EmergencyKillswitch);
+    let client = EmergencyKillswitchClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    env.mock_all_auths();
+    client.initialize(&admin);
+    client.pause();
+
+    // Without mocked auth the admin requirement must reject the call.
+    env.set_auths(&[]);
+    assert!(client.try_clear_emergency_state().is_err());
+    assert!(client.is_paused());
+}
+
+#[test]
+fn test_clear_emergency_state_preserves_module_and_function_pauses() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, EmergencyKillswitch);
+    let client = EmergencyKillswitchClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+    let module = symbol_short!("bill");
+    let func = symbol_short!("pay");
+
+    client.pause_module(&module);
+    client.pause_function(&module, &func);
+    client.pause();
+    assert!(client.is_paused());
+
+    client.clear_emergency_state();
+
+    // Global pause is cleared, but the narrower scopes survive.
+    assert!(!client.is_paused());
+    assert!(client.is_function_paused(&module, &func));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Adds an admin-only `clear_emergency_state` entrypoint to `emergency_killswitch` so operators can recover from a **stuck-paused** state without redeploying.

Closes #937

## The stuck-paused problem

The unpause path is timelocked: `unpause()` needs a pending `UnpauseSchedule` **and** `ledger.timestamp() >= schedule`. But `pause()` deliberately removes any pending schedule (so a re-pause can't be bypassed by a stale schedule). The consequence:

- Re-pause during an incident → `GlobalPaused = true` with **no** schedule → `unpause()` fails with `InvalidSchedule` forever, regardless of how far the ledger advances. (This is exactly what the existing `test_re_pause_cancels_schedule` locks in.)
- An unpause scheduled far in the future by mistake → no way to bring it forward.

In both cases the only recovery today is redeploying. This PR adds the break-glass admin path.

## What it does

```rust
pub fn clear_emergency_state(env: Env) -> Result<(), Error>
```

- **Admin-only** (`admin.require_auth()`); returns `NotInitialized` if no admin is set.
- Sets `GlobalPaused = false` and removes any pending `UnpauseSchedule` in one call, **bypassing the timelock**.
- **Idempotent** — a successful no-op when the contract is not paused.
- **Scoped** — clears only the *global* pause; module-level (`pause_module`) and function-level (`pause_function`) pauses are intentionally preserved (lift those with `unpause_module` / `unpause_function`).
- Emits `("emergency", "cleared")` with `("GLOBAL", timestamp)`, matching the existing event convention.

The normal `schedule_unpause` → `unpause` cooling-off path is unchanged; this is purely an additive recovery entrypoint. Public API is backwards-compatible.

## Tests (6 new, 20 total passing)

- `test_clear_emergency_state_recovers_stuck_pause` — recovers from the re-pause stuck state where `unpause()` returns `InvalidSchedule`.
- `test_clear_emergency_state_bypasses_timelock` — succeeds before the scheduled time and wipes the pending schedule.
- `test_clear_emergency_state_is_idempotent_when_active` — no-op when not paused.
- `test_clear_emergency_state_requires_initialization` — `NotInitialized` before an admin is set.
- `test_clear_emergency_state_requires_admin_auth` — rejects non-admin callers.
- `test_clear_emergency_state_preserves_module_and_function_pauses` — global clear leaves narrower scopes intact.

## Docs

`docs/killswitch-timelock.md` updated: recovery edge added to the state diagram, a dedicated "Emergency Recovery (`clear_emergency_state`)" section, and the new tests added to the verification list.

## Verification

```
cargo test -p emergency_killswitch          # 20 passed; 0 failed
cargo clippy -p emergency_killswitch --all-targets -- -D warnings   # clean
cargo build -p emergency_killswitch --target wasm32-unknown-unknown --release   # ok
```

`#![no_std]` discipline preserved (only `soroban_sdk` primitives). No new constants introduced. Diff is scoped to the three files above.

## Note for reviewers (pre-existing, not from this PR)

The `cargo fmt --all -- --check` CI job is already red on `main` — the workspace (including this crate's pre-existing test functions) was not rustfmt-clean before this change. I deliberately did **not** reformat unrelated code to keep this diff scoped to the feature, per the issue's out-of-scope guidance. The code added in this PR is itself rustfmt-clean. I also removed one unused `IntoVal` import in the test file that `clippy -D warnings` flagged. Happy to run a separate formatting pass if you'd like it bundled here.
