### PR TITLE
Add CI panic assertion script to detect production panic! usage

### DIFF
--- a/scripts/check_no_panic.sh
+++ b/scripts/check_no_panic.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ensure cargo-expand is installed and available on PATH.
+export PATH="$HOME/.cargo/bin:$PATH"
+if ! command -v cargo-expand >/dev/null 2>&1; then
+  echo "Installing cargo-expand..."
+  cargo install --locked cargo-expand
+fi
+
+packages=(
+  remittance_split
+  insurance
+  orchestrator
+  emergency_killswitch
+)
+
+for package in "${packages[@]}"; do
+  echo "Inspecting expanded production lib for package: $package"
+  if cargo expand -p "$package" --lib 2>/dev/null | grep -n "panic!"; then
+    echo "\nERROR: Found production panic! in expanded lib of package: $package"
+    echo "This check ensures panic! is only present in test-only code paths."
+    exit 1
+  fi
+done
+
+echo "✅ No production panic! statements found in expanded contract libs."


### PR DESCRIPTION
Closes #941 


Adds a CI helper script to detect `panic!` usage in production Soroban contract libraries.

### What changed

- Added `scripts/check_no_panic.sh`
- The script:
  - expands selected contract packages with `cargo expand --lib`
  - searches the expanded production library output for `panic!`
  - exits non-zero if any production panic calls are found

### Why

This enforces a repository-level assertion that production contract code must not contain `panic!` outside `cfg(test)` builds, preventing unsafe runtime behavior.

### Notes

- Verified locally with `bash scripts/check_no_panic.sh`
- The branch `Assertion-in-Ci` has been pushed to `origin`