### PR TITLE
test: add regression tests for negative-amount rejection (closes #889)

### DIFF
--- a/family_wallet/src/lib.rs
+++ b/family_wallet/src/lib.rs
@@ -1163,6 +1163,9 @@ impl FamilyWallet {
         if min_balance < 0 {
             panic!("Emergency min balance must be non-negative");
         }
+        if daily_limit < 0 {
+            panic!("Emergency daily limit must be non-negative");
+        }
 
         Self::extend_instance_ttl(&env);
 

--- a/family_wallet/src/test.rs
+++ b/family_wallet/src/test.rs
@@ -6860,3 +6860,55 @@ fn test_configure_multisig_does_not_emit_on_failed_validation() {
         "no ms_conf event should be emitted on validation failure",
     );
 }
+
+#[test]
+fn test_negative_amount_rejections() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, FamilyWallet);
+    let client = FamilyWalletClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let member1 = Address::generate(&env);
+    let member2 = Address::generate(&env);
+    client.init(&owner, &vec![&env, member1.clone(), member2.clone()]);
+
+    let token = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    // 1. withdraw with negative/zero amount
+    let res1 = client.try_withdraw(&owner, &token, &recipient, &-100);
+    assert!(res1.is_err());
+    let res2 = client.try_withdraw(&owner, &token, &recipient, &0);
+    assert!(res2.is_err());
+
+    // 2. propose_emergency_transfer with negative/zero amount
+    let res3 = client.try_propose_emergency_transfer(&owner, &token, &recipient, &-50);
+    assert!(res3.is_err());
+    let res4 = client.try_propose_emergency_transfer(&owner, &token, &recipient, &0);
+    assert!(res4.is_err());
+
+    // 3. configure_emergency with negative max_amount, min_balance, or daily_limit
+    let res5 = client.try_configure_emergency(&owner, &-100, &3600, &100, &1000);
+    assert!(res5.is_err());
+    let res6 = client.try_configure_emergency(&owner, &100, &3600, &-10, &1000);
+    assert!(res6.is_err());
+    let res7 = client.try_configure_emergency(&owner, &100, &3600, &10, &-1000);
+    assert!(res7.is_err());
+
+    // 4. configure_multisig with negative limit
+    let res8 = client.try_configure_multisig(
+        &owner,
+        &TransactionType::LargeWithdrawal,
+        &2,
+        &vec![&env, member1.clone(), member2.clone()],
+        &-500,
+    );
+    assert_eq!(res8, Err(Ok(Error::InvalidSpendingLimit)));
+
+    // 5. validate_precision_spending with negative/zero amount
+    let res9 = client.try_validate_precision_spending(&owner, &-500);
+    assert_eq!(res9, Err(Ok(Error::InvalidAmount)));
+    let res10 = client.try_validate_precision_spending(&owner, &0);
+    assert_eq!(res10, Err(Ok(Error::InvalidAmount)));
+}

--- a/insurance/src/test.rs
+++ b/insurance/src/test.rs
@@ -771,4 +771,33 @@ mod tests {
             InsuranceError::NotInitialized,
         );
     }
+
+    #[test]
+    fn test_negative_amount_rejections() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let c = setup(&env);
+        let caller = Address::generate(&env);
+
+        // 1. negative monthly premium
+        let res_premium = c.try_create_policy(
+            &caller,
+            &n(&env, "P_Bad"),
+            &CoverageType::Health,
+            &-100i128,
+            &50_000_000i128,
+        );
+        assert_eq!(res_premium, Err(Ok(InsuranceError::InvalidPremium)));
+
+        // 2. negative coverage amount
+        let res_coverage = c.try_create_policy(
+            &caller,
+            &n(&env, "P_Bad2"),
+            &CoverageType::Health,
+            &5_000_000i128,
+            &-100i128,
+        );
+        assert_eq!(res_coverage, Err(Ok(InsuranceError::InvalidCoverageAmount)));
+    }
 }
+

--- a/orchestrator/src/test.rs
+++ b/orchestrator/src/test.rs
@@ -1372,3 +1372,23 @@ fn test_invalid_amount_unsigned_emits_audit_without_lifecycle_events() {
     assert_eq!(stats.successful_executions, 0);
     assert_eq!(stats.failed_executions, 0);
 }
+
+#[test]
+fn test_negative_amount_rejections() {
+    let (env, owner) = setup_test();
+    let (_, client) = register_orchestrator(&env);
+    init_orchestrator(&env, &client, &owner);
+
+    let mock_id = env.register_contract(None, MockContract);
+    let caller = Address::generate(&env);
+
+    // 1. execute_remittance_flow with negative amount
+    let res_unsigned = client.try_execute_remittance_flow(&flow_params(&env, &caller, &mock_id, -100));
+    assert_eq!(res_unsigned, Err(Ok(OrchestratorError::InvalidAmount)));
+
+    // 2. execute_remittance_flow_signed with negative amount
+    let deadline = env.ledger().timestamp() + 1000;
+    let hash = compute_test_hash(&env, symbol_short!("flow"), 0, -100, deadline);
+    let res_signed = client.try_execute_remittance_flow_signed(&caller, &-100, &0, &deadline, &hash);
+    assert_eq!(res_signed, Err(Ok(OrchestratorError::InvalidAmount)));
+}

--- a/remittance_split/src/test.rs
+++ b/remittance_split/src/test.rs
@@ -2217,3 +2217,50 @@ fn test_get_split_allocations_percentages_across_all_categories() {
     // insurance = 10 - 3 - 3 - 3 = 1  (dust absorbed)
     assert_eq!(allocs.get(3).unwrap().amount, 1);
 }
+
+#[test]
+fn test_negative_amount_rejections() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, owner, token_addr, _) = setup_split(&env, 40, 30, 20, 10);
+    let accounts = sample_accounts(&env);
+
+    let nonce = 1u64;
+    let deadline = env.ledger().timestamp() + 3600;
+    let request_hash = RemittanceSplit::compute_request_hash(
+        symbol_short!("distrib"),
+        owner.clone(),
+        nonce,
+        -100,
+        deadline,
+    );
+
+    // 1. calculate_split with negative amount
+    let res_calc = client.try_calculate_split(&-100);
+    assert_eq!(res_calc, Err(Ok(RemittanceSplitError::InvalidAmount)));
+
+    // 2. distribute_usdc with negative amount
+    let res_dist = client.try_distribute_usdc(
+        &token_addr,
+        &owner,
+        &nonce,
+        &deadline,
+        &request_hash,
+        &accounts,
+        &-100,
+    );
+    assert_eq!(res_dist, Err(Ok(RemittanceSplitError::InvalidAmount)));
+
+    // 3. distribute_usdc_hashed with negative amount
+    let request = DistributeUsdcRequest {
+        usdc_contract: token_addr,
+        from: owner.clone(),
+        nonce,
+        accounts,
+        total_amount: -100,
+        deadline,
+    };
+    let hash = client.get_request_hash(&request);
+    let res_dist_hash = client.try_distribute_usdc_hashed(&request, &hash);
+    assert_eq!(res_dist_hash, Err(Ok(RemittanceSplitError::InvalidAmount)));
+}

--- a/savings_goals/src/test.rs
+++ b/savings_goals/src/test.rs
@@ -6621,3 +6621,40 @@ fn test_import_snapshot_owner_indices_are_consistent() {
         "new goal id must be greater than snapshot's next_id"
     );
 }
+
+#[test]
+fn test_negative_amount_rejections() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, SavingsGoalContract);
+    let client = SavingsGoalContractClient::new(&env, &contract_id);
+    client.init();
+
+    let user = Address::generate(&env);
+    let name = String::from_str(&env, "Goal 1");
+    let goal_id = client.create_goal(&user, &name, &1000, &1735689600, &false);
+
+    // 1. create_goal with negative amount
+    let res_create = client.try_create_goal(&user, &name, &-100, &1735689600, &false);
+    assert_eq!(res_create, Err(Ok(SavingsGoalError::InvalidAmount)));
+
+    // 2. add_to_goal with negative amount
+    let res_add = client.try_add_to_goal(&user, &goal_id, &-50);
+    assert_eq!(res_add, Err(Ok(SavingsGoalError::InvalidAmount)));
+
+    // 3. withdraw_from_goal with negative amount
+    let res_withdraw = client.try_withdraw_from_goal(&user, &goal_id, &-50);
+    assert_eq!(res_withdraw, Err(Ok(SavingsGoalError::InvalidAmount)));
+
+    // 4. create_savings_schedule with negative/zero amount
+    let res_schedule_create1 = client.try_create_savings_schedule(&user, &goal_id, &-100, &1735689600, &3600);
+    assert!(res_schedule_create1.is_err());
+    let res_schedule_create2 = client.try_create_savings_schedule(&user, &goal_id, &0, &1735689600, &3600);
+    assert!(res_schedule_create2.is_err());
+
+    // 5. modify_savings_schedule with negative/zero amount
+    let res_schedule_modify1 = client.try_modify_savings_schedule(&user, &goal_id, &-100, &1735689600, &3600);
+    assert!(res_schedule_modify1.is_err());
+    let res_schedule_modify2 = client.try_modify_savings_schedule(&user, &goal_id, &0, &1735689600, &3600);
+    assert!(res_schedule_modify2.is_err());
+}


### PR DESCRIPTION
Closes #889

# Summary

This PR strengthens regression coverage for negative `i128` inputs across the affected Soroban contract entrypoints, ensuring invalid amounts continue to be rejected consistently and future regressions are caught by CI.

## Changes

- Added deterministic regression tests covering negative-amount rejection for affected contract entrypoints.
- Verified existing validation behavior across contract boundaries.
- Added the missing negative-value validation for `daily_limit` in `family_wallet::configure_emergency` to ensure all `i128` inputs are validated consistently.
- Kept the implementation narrowly scoped to negative-amount validation and regression coverage.

## Test Coverage

Added regression tests for:

- `family_wallet`
  - `withdraw`
  - `propose_emergency_transfer`
  - `configure_emergency`
  - `configure_multisig`
  - `validate_precision_spending`

- `savings_goals`
  - `create_goal`
  - `add_to_goal`
  - `withdraw_from_goal`
  - `create_savings_schedule`
  - `modify_savings_schedule`

- `remittance_split`
  - `calculate_split`
  - `distribute_usdc`
  - `distribute_usdc_hashed`

- `insurance`
  - `create_policy`

- `orchestrator`
  - `execute_remittance_flow`
  - `execute_remittance_flow_signed`

## Verification

```bash
cargo test -p family_wallet
cargo test -p savings_goals
cargo test -p remittance_split
cargo test -p insurance
cargo test -p orchestrator

cargo clippy --workspace --all-targets -- -D warnings

cargo build --target wasm32-unknown-unknown --release
```