### PR TITLE
feat(ci): add WASM size diff workflow posting before/after per entrypoint

### DIFF
--- a/.github/workflows/wasm-size.yml
+++ b/.github/workflows/wasm-size.yml
@@ -1,0 +1,157 @@
+name: WASM Size Diff
+
+on:
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  wasm-size-diff:
+    name: WASM Size per Entrypoint
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout PR HEAD
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache Cargo (PR HEAD)
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-wasm-size-pr-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-wasm-size-
+
+      - name: Build WASM contracts (PR HEAD)
+        run: |
+          for contract in remittance_split savings_goals bill_payments insurance family_wallet orchestrator data_migration emergency_killswitch reporting; do
+            echo "Building $contract..."
+            cargo build --release --target wasm32-unknown-unknown --package "$contract" || \
+              echo "warning: $contract failed to build (size will be reported as 0)"
+          done
+
+      - name: Collect WASM sizes (after)
+        run: ./scripts/collect_wasm_sizes.sh /tmp/wasm_sizes_after.json
+
+      # Stash the script to /tmp so it is available after the branch switch below.
+      - name: Stash size script for base build
+        run: cp scripts/collect_wasm_sizes.sh /tmp/collect_wasm_sizes.sh
+
+      - name: Checkout base branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.base_ref }}
+          # Preserve target/ so the base build can reuse incremental artifacts.
+          clean: false
+
+      - name: Cache Cargo (base branch)
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-wasm-size-base-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-wasm-size-
+
+      - name: Build WASM contracts (base branch)
+        run: |
+          for contract in remittance_split savings_goals bill_payments insurance family_wallet orchestrator data_migration emergency_killswitch reporting; do
+            echo "Building $contract..."
+            cargo build --release --target wasm32-unknown-unknown --package "$contract" || \
+              echo "warning: $contract failed to build (size will be reported as 0)"
+          done
+
+      - name: Collect WASM sizes (before)
+        run: /tmp/collect_wasm_sizes.sh /tmp/wasm_sizes_before.json
+
+      - name: Post PR comment with WASM size diff
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+
+            const before = JSON.parse(fs.readFileSync('/tmp/wasm_sizes_before.json', 'utf8'));
+            const after  = JSON.parse(fs.readFileSync('/tmp/wasm_sizes_after.json',  'utf8'));
+
+            const contracts = [...new Set([...Object.keys(before), ...Object.keys(after)])].sort();
+
+            const fmt  = n => n.toLocaleString('en-US');
+            const sign = n => (n > 0 ? `+${fmt(n)}` : `${fmt(n)}`);
+
+            let rows = '';
+            let anyChange = false;
+
+            for (const c of contracts) {
+              const b = before[c] ?? 0;
+              const a = after[c]  ?? 0;
+              if (b === 0 && a === 0) continue;
+
+              const delta = a - b;
+              if (delta !== 0) anyChange = true;
+
+              let icon;
+              if (b === 0)            icon = '🆕';  // new contract in this PR
+              else if (a === 0)       icon = '🗑️';  // contract removed in this PR
+              else if (delta >  1024) icon = '⚠️';  // grew more than 1 kB
+              else if (delta < -512)  icon = '✨';  // shrank more than 512 B
+              else                    icon = '✅';
+
+              const pct  = b > 0 && a > 0 ? ((delta / b) * 100).toFixed(2) + '%' : 'N/A';
+              const bStr = b > 0 ? `${fmt(b)} B` : '—';
+              const aStr = a > 0 ? `${fmt(a)} B` : '—';
+              const dStr = b > 0 && a > 0 ? `${sign(delta)} B` : '—';
+
+              rows += `| ${icon} \`${c}\` | ${bStr} | ${aStr} | ${dStr} | ${pct} |\n`;
+            }
+
+            const marker = '<!-- wasm-size-diff -->';
+            let body = `${marker}\n## 📦 WASM Size per Entrypoint\n\n`;
+            body += '| Contract | Before | After | Δ bytes | Δ % |\n';
+            body += '|----------|-------:|------:|--------:|----:|\n';
+            body += rows;
+            if (!anyChange) body += '\n_No WASM size changes detected._\n';
+            body += '\n> Sizes are release WASM binaries before the Soroban optimizer. Values are directly comparable across commits on the same toolchain.\n';
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/docs/ci-pipeline.md
+++ b/docs/ci-pipeline.md
@@ -23,6 +23,40 @@ The **Batch-B CI Gate** targets the following crates:
     - Contracts are compiled using `--target wasm32-unknown-unknown --release`.
     - The CLI is compiled natively.
 
+## WASM Size Diff (`wasm-size.yml`)
+
+Every pull request targeting `main` triggers the **WASM Size Diff** workflow (`.github/workflows/wasm-size.yml`). It builds each Soroban contract to `wasm32-unknown-unknown` twice — once on the PR HEAD and once on the merge base — then posts (or updates) a single PR comment showing the binary-size delta per entrypoint.
+
+### What it reports
+
+| Column | Meaning |
+| ------ | ------- |
+| **Before** | WASM byte size on the base branch |
+| **After** | WASM byte size on the PR HEAD |
+| **Δ bytes** | Signed difference (negative = shrink) |
+| **Δ %** | Relative change |
+
+Icon key: ✅ no significant change · ✨ shrank > 512 B · ⚠️ grew > 1 kB · 🆕 new contract · 🗑️ contract removed.
+
+### Local equivalent
+
+```bash
+# Build all WASM contracts, then collect sizes:
+for contract in remittance_split savings_goals bill_payments insurance \
+                family_wallet orchestrator data_migration emergency_killswitch reporting; do
+  cargo build --release --target wasm32-unknown-unknown --package "$contract"
+done
+./scripts/collect_wasm_sizes.sh
+```
+
+`scripts/collect_wasm_sizes.sh` prints a JSON object of `{ "contract_name": byte_size, … }` to stdout, or to a file path passed as its first argument.
+
+### Notes
+
+- Sizes are **pre-optimizer** release WASM. On-chain deployment uses the Soroban optimizer, so absolute numbers differ from deployed contract sizes — but the delta between two commits on the same toolchain is accurate.
+- A contract that fails to build is reported as size `0`. The workflow does not fail the PR on build errors in this job; use the main `ci.yml` build gate for that.
+- The comment is updated in-place on each push to the PR (identified by a hidden HTML marker), so the thread stays clean.
+
 ## Soroban SDK Updates
 
 This pipeline acts as a regression gate for SDK upgrades. When bumping the SDK version (e.g., to `21.7.7` and beyond), the CI must pass before merging.

--- a/scripts/collect_wasm_sizes.sh
+++ b/scripts/collect_wasm_sizes.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Output a JSON object mapping each Soroban contract name to its WASM byte size.
+# Contracts that have not been built (or failed to build) are reported as 0.
+# Usage: ./scripts/collect_wasm_sizes.sh [output_file]
+#   output_file defaults to stdout ("-")
+set -euo pipefail
+
+CONTRACTS=(
+    remittance_split
+    savings_goals
+    bill_payments
+    insurance
+    family_wallet
+    orchestrator
+    data_migration
+    emergency_killswitch
+    reporting
+)
+
+OUTPUT="${1:--}"
+
+json="{"
+sep=""
+for c in "${CONTRACTS[@]}"; do
+    wasm_path="target/wasm32-unknown-unknown/release/${c}.wasm"
+    if [ -f "$wasm_path" ]; then
+        size=$(wc -c < "$wasm_path" | tr -d ' ')
+    else
+        size=0
+    fi
+    json="${json}${sep}\"${c}\":${size}"
+    sep=","
+done
+json="${json}}"
+
+if [ "$OUTPUT" = "-" ]; then
+    printf '%s\n' "$json"
+else
+    printf '%s\n' "$json" > "$OUTPUT"
+fi


### PR DESCRIPTION
Adds `.github/workflows/wasm-size.yml` which runs on every PR targeting `main`. It builds each Soroban contract to `wasm32-unknown-unknown` twice (PR HEAD and merge base), then posts—or updates—a single PR comment showing the binary-size delta per contract:

  | Contract | Before | After | Δ bytes | Δ % |

The comment is idempotent: a hidden HTML marker ensures re-pushes update the existing comment rather than creating a new thread.

Also adds `scripts/collect_wasm_sizes.sh` for local use and documents the new workflow in `docs/ci-pipeline.md`.

fixes #915