### PR TITLE
Fix: Reject duplicate signatures with typed error

### DIFF
--- a/family_wallet/src/lib.rs
+++ b/family_wallet/src/lib.rs
@@ -883,10 +883,10 @@ impl FamilyWallet {
             return Err(Error::TransactionExpired);
         }
 
-        // If signer already recorded, no-op (idempotent).
+        // If signer already recorded, reject with typed error.
         for sig in pending_tx.signatures.iter() {
             if sig.clone() == signer {
-                return Ok(false);
+                return Err(Error::DuplicateSignature);
             }
         }
 

--- a/family_wallet/src/test.rs
+++ b/family_wallet/src/test.rs
@@ -343,9 +343,9 @@ fn test_duplicate_signature_prevention() {
     let pending_tx = client.get_pending_transaction(&tx_id).unwrap();
     assert_eq!(pending_tx.signatures.len(), 2);
 
-    // Second sign by same signer should be idempotent and not advance the count
+    // Second sign by same signer should be rejected with DuplicateSignature error
     let result = client.try_sign_transaction(&member1, &tx_id);
-    assert!(result.is_ok());
+    assert_eq!(result, Err(Ok(Error::DuplicateSignature)));
 
     let pending_tx = client.get_pending_transaction(&tx_id).unwrap();
     assert_eq!(pending_tx.signatures.len(), 2);
@@ -372,6 +372,37 @@ fn test_sign_transaction_non_member_rejected() {
     // non-member is not authorized as signer for this tx type
     let result = client.try_sign_transaction(&non_member, &tx_id);
     assert_eq!(result, Err(Ok(Error::SignerNotMember)));
+}
+
+#[test]
+fn test_sign_transaction_duplicate_signature_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, FamilyWallet);
+    let client = FamilyWalletClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let member1 = Address::generate(&env);
+    let member2 = Address::generate(&env);
+    client.init(&owner, &vec![&env, member1.clone(), member2.clone()]);
+    
+    // Configure multisig with threshold 2
+    let signers = vec![&env, owner.clone(), member1.clone(), member2.clone()];
+    client.configure_multisig(&owner, &TransactionType::RoleChange, &2, &signers, &0);
+
+    let tx_id = client.propose_role_change(&owner, &member1, &FamilyRole::Admin);
+
+    // First signature by member1 should succeed
+    let result = client.try_sign_transaction(&member1, &tx_id);
+    assert!(result.is_ok());
+
+    // Second signature by the same member1 should be rejected with DuplicateSignature
+    let result = client.try_sign_transaction(&member1, &tx_id);
+    assert_eq!(result, Err(Ok(Error::DuplicateSignature)));
+
+    // Verify signature count hasn't changed
+    let pending_tx = client.get_pending_transaction(&tx_id).unwrap();
+    assert_eq!(pending_tx.signatures.len(), 2); // proposer + member1
 }
 
 #[test]


### PR DESCRIPTION
Closes #910

## Summary

Changed the multisig signature deduplication logic to return a typed `Error::DuplicateSignature` error instead of silently succeeding with `Ok(false)` when a signer attempts to sign the same transaction twice.

## Threat Model

**What an attacker gains if this check is missing:**

Without explicit rejection of duplicate signatures, an attacker could:

1. **Mask signature collection progress**: By repeatedly calling `sign_transaction` with the same signer, an attacker could obscure whether a transaction has actually reached quorum from off-chain monitoring, since the contract would return success each time.

2. **Bypass monitoring alerts**: Security monitoring systems that alert on signature events would fire multiple times for the same signer, potentially desensitizing operators or creating noise that hides actual attack patterns.

3. **Exploit race conditions**: In complex multisig workflows where threshold changes or signer rotations occur, idempotent duplicate acceptance could allow an attacker to "replay" a signature after the signer's authorization has been revoked, potentially meeting quorum with stale authorizations.

4. **Confuse transaction state**: The silent success (`Ok(false)`) makes it difficult for clients to distinguish between "signature added" and "signature already present" without additional logic, increasing the risk of UI/UX bugs that could lead to incorrect user assumptions about transaction status.

By returning a typed error, we:
- Make the rejection explicit and auditable
- Force clients to handle duplicate attempts properly
- Provide clear error messages to users
- Create an audit trail of rejected duplicate attempts

## Changes

### family_wallet/src/lib.rs
- Changed duplicate signature check in `sign_transaction` to return `Err(Error::DuplicateSignature)` instead of `Ok(false)`

### family_wallet/src/test.rs
- Updated `test_duplicate_signature_prevention` to expect `DuplicateSignature` error
- Added new test `test_sign_transaction_duplicate_signature_rejected` as a dedicated negative test

## Verification

- ✅ `cargo build --target wasm32-unknown-unknown --release` passes
- ✅ `cargo clippy -p family_wallet --lib --no-deps -- -D warnings` passes
- ⚠️ `cargo test -p family_wallet` fails on Windows due to linker limitation (export ordinal too large) - this is a pre-existing Windows-specific issue unrelated to these changes

## Gas Cost

The change replaces an early return with an error return on the same code path. There is no additional computation or storage access, so the gas cost is identical to the previous implementation.

## Security Baseline

This is a defence-in-depth improvement. While there is no known exploit of the idempotent behavior, making duplicate signature rejections explicit aligns with security best practices and provides clearer semantics for both developers and monitoring systems.
