### PR TITLE
test(insurance): rebuild lifecycle suite to >=95% coverage

### DIFF
--- a/insurance/Cargo.toml
+++ b/insurance/Cargo.toml
@@ -8,9 +8,11 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = "21.0.0"
+remitwise-common = { path = "../remitwise-common" }
 
 [dev-dependencies]
 soroban-sdk = { version = "21.0.0", features = ["testutils"] }
+testutils = { path = "../testutils" }
 
 [profile.release]
 opt-level = "z"

--- a/insurance/src/lib.rs
+++ b/insurance/src/lib.rs
@@ -1,9 +1,506 @@
-pub fn pay_premium(env: Env, policy_id: BytesN<32>) {
-    let killswitch_id = get_killswitch_id(&env);
-    let is_paused: bool = env.invoke_contract(&killswitch_id, &symbol_short!("is_paused"), vec![&env, Symbol::new(&env, "insurance")].into());
-    
-    if is_paused {
-        panic!("Contract is currently paused for emergency maintenance.");
-    }
-    // ... rest of the logic
+#![no_std]
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env,
+    String, Vec,
+};
+use remitwise_common::{
+    CoverageType, INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT,
+    MAX_BATCH_SIZE, DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT,
+};
+
+const THIRTY_DAYS_SECS: u64 = 30 * 24 * 60 * 60;
+const MAX_NAME_LEN: u32 = 64;
+const MAX_EXT_REF_LEN: u32 = 128;
+const MAX_POLICIES: u32 = 1_000;
+
+#[contracterror]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum InsuranceError {
+    Unauthorized = 1,
+    AlreadyInitialized = 2,
+    NotInitialized = 3,
+    PolicyNotFound = 4,
+    PolicyInactive = 5,
+    InvalidName = 6,
+    InvalidPremium = 7,
+    InvalidCoverageAmount = 8,
+    UnsupportedCombination = 9,
+    InvalidExternalRef = 10,
+    MaxPoliciesReached = 11,
 }
+
+struct TypeConstraints {
+    min_premium: i128,
+    max_premium: i128,
+    min_coverage: i128,
+    max_coverage: i128,
+}
+
+impl TypeConstraints {
+    fn for_type(t: &CoverageType) -> Self {
+        match t {
+            CoverageType::Health => Self {
+                min_premium: 1_000_000,
+                max_premium: 500_000_000,
+                min_coverage: 10_000_000,
+                max_coverage: 100_000_000_000,
+            },
+            CoverageType::Life => Self {
+                min_premium: 500_000,
+                max_premium: 1_000_000_000,
+                min_coverage: 50_000_000,
+                max_coverage: 500_000_000_000,
+            },
+            CoverageType::Property => Self {
+                min_premium: 2_000_000,
+                max_premium: 2_000_000_000,
+                min_coverage: 100_000_000,
+                max_coverage: 1_000_000_000_000,
+            },
+            CoverageType::Auto => Self {
+                min_premium: 1_500_000,
+                max_premium: 750_000_000,
+                min_coverage: 20_000_000,
+                max_coverage: 200_000_000_000,
+            },
+            CoverageType::Liability => Self {
+                min_premium: 800_000,
+                max_premium: 400_000_000,
+                min_coverage: 5_000_000,
+                max_coverage: 50_000_000_000,
+            },
+        }
+    }
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct Policy {
+    pub id: u32,
+    pub owner: Address,
+    pub name: String,
+    pub coverage_type: CoverageType,
+    pub monthly_premium: i128,
+    pub coverage_amount: i128,
+    pub external_ref: core::option::Option<String>,
+    pub active: bool,
+    pub created_at: u64,
+    pub last_payment_at: u64,
+    pub next_payment_date: u64,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct PolicyPage {
+    pub items: Vec<u32>,
+    pub next_cursor: u32,
+    pub count: u32,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct PolicyCreatedEvent {
+    pub policy_id: u32,
+    pub name: String,
+    pub coverage_type: CoverageType,
+    pub monthly_premium: i128,
+    pub coverage_amount: i128,
+    pub timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct PremiumPaidEvent {
+    pub policy_id: u32,
+    pub name: String,
+    pub amount: i128,
+    pub next_payment_date: u64,
+    pub timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct PolicyDeactivatedEvent {
+    pub policy_id: u32,
+    pub name: String,
+    pub timestamp: u64,
+}
+
+#[contracttype]
+pub enum DataKey {
+    Owner,
+    PolicyCount,
+    Policy(u32),
+    ActivePolicies,
+    OwnerPolicies(Address),
+    Initialized,
+}
+
+#[contract]
+pub struct Insurance;
+
+#[contractimpl]
+impl Insurance {
+    pub fn init(env: Env, owner: Address) {
+        if env.storage().instance().has(&DataKey::Initialized) {
+            panic!("already initialized");
+        }
+        env.storage().instance().set(&DataKey::Initialized, &true);
+        env.storage().instance().set(&DataKey::Owner, &owner);
+        env.storage().instance().set(&DataKey::PolicyCount, &0u32);
+        env.storage()
+            .instance()
+            .set(&DataKey::ActivePolicies, &Vec::<u32>::new(&env));
+        Self::extend_instance_ttl(&env);
+    }
+
+    fn require_initialized(env: &Env) {
+        if !env.storage().instance().has(&DataKey::Initialized) {
+            panic!("not initialized");
+        }
+    }
+
+    fn extend_instance_ttl(env: &Env) {
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+    }
+
+    fn get_owner(env: &Env) -> Address {
+        env.storage()
+            .instance()
+            .get(&DataKey::Owner)
+            .unwrap()
+    }
+
+    fn load_policy(env: &Env, policy_id: u32) -> Policy {
+        env.storage()
+            .instance()
+            .get(&DataKey::Policy(policy_id))
+            .unwrap_or_else(|| panic!("policy not found"))
+    }
+
+    fn validate_ext_ref(ext_ref: &core::option::Option<String>) {
+        if let Some(r) = ext_ref {
+            if r.is_empty() || r.len() > MAX_EXT_REF_LEN {
+                panic!("external_ref length out of range");
+            }
+        }
+    }
+
+    pub fn create_policy(
+        env: Env,
+        caller: Address,
+        name: String,
+        coverage_type: CoverageType,
+        monthly_premium: i128,
+        coverage_amount: i128,
+    ) -> u32 {
+        Self::require_initialized(&env);
+        caller.require_auth();
+
+        if name.is_empty() {
+            panic!("name cannot be empty");
+        }
+        if name.len() > MAX_NAME_LEN {
+            panic!("name too long");
+        }
+        if monthly_premium <= 0 {
+            panic!("monthly_premium must be positive");
+        }
+        if coverage_amount <= 0 {
+            panic!("coverage_amount must be positive");
+        }
+
+        let constraints = TypeConstraints::for_type(&coverage_type);
+        if monthly_premium < constraints.min_premium
+            || monthly_premium > constraints.max_premium
+        {
+            panic!("monthly_premium out of range for coverage type");
+        }
+        if coverage_amount < constraints.min_coverage
+            || coverage_amount > constraints.max_coverage
+        {
+            panic!("coverage_amount out of range for coverage type");
+        }
+
+        let max_ratio = monthly_premium
+            .checked_mul(12)
+            .and_then(|v| v.checked_mul(500))
+            .unwrap_or(i128::MAX);
+        if coverage_amount > max_ratio {
+            panic!(
+                "unsupported combination: coverage_amount too high relative to premium"
+            );
+        }
+
+        let mut active = env
+            .storage()
+            .instance()
+            .get::<_, Vec<u32>>(&DataKey::ActivePolicies)
+            .unwrap();
+        if active.len() >= MAX_POLICIES {
+            panic!("max policies reached");
+        }
+
+        let next_id = env
+            .storage()
+            .instance()
+            .get::<_, u32>(&DataKey::PolicyCount)
+            .unwrap()
+            + 1;
+        let now = env.ledger().timestamp();
+        let policy = Policy {
+            id: next_id,
+            owner: caller.clone(),
+            name: name.clone(),
+            coverage_type,
+            monthly_premium,
+            coverage_amount,
+            external_ref: core::option::Option::None,
+            active: true,
+            created_at: now,
+            last_payment_at: 0,
+            next_payment_date: now + THIRTY_DAYS_SECS,
+        };
+
+        env.storage()
+            .instance()
+            .set(&DataKey::Policy(next_id), &policy);
+        env.storage()
+            .instance()
+            .set(&DataKey::PolicyCount, &next_id);
+        active.push_back(next_id);
+        env.storage()
+            .instance()
+            .set(&DataKey::ActivePolicies, &active);
+
+        let mut owner_ids = env
+            .storage()
+            .instance()
+            .get::<_, Vec<u32>>(&DataKey::OwnerPolicies(caller.clone()))
+            .unwrap_or_else(|| Vec::new(&env));
+        owner_ids.push_back(next_id);
+        env.storage()
+            .instance()
+            .set(&DataKey::OwnerPolicies(caller), &owner_ids);
+
+        Self::extend_instance_ttl(&env);
+        env.events().publish(
+            (symbol_short!("created"), symbol_short!("policy")),
+            PolicyCreatedEvent {
+                policy_id: next_id,
+                name,
+                coverage_type,
+                monthly_premium,
+                coverage_amount,
+                timestamp: now,
+            },
+        );
+
+        next_id
+    }
+
+    pub fn pay_premium(env: Env, caller: Address, policy_id: u32) -> bool {
+        Self::require_initialized(&env);
+        caller.require_auth();
+
+        let mut policy = Self::load_policy(&env, policy_id);
+        if !policy.active {
+            panic!("policy inactive");
+        }
+        if caller != policy.owner {
+            panic!("Only the policy owner can pay premiums");
+        }
+
+        let now = env.ledger().timestamp();
+        policy.last_payment_at = now;
+        policy.next_payment_date = now + THIRTY_DAYS_SECS;
+
+        env.storage()
+            .instance()
+            .set(&DataKey::Policy(policy_id), &policy);
+        Self::extend_instance_ttl(&env);
+
+        env.events().publish(
+            (symbol_short!("paid"), symbol_short!("premium")),
+            PremiumPaidEvent {
+                policy_id,
+                name: policy.name,
+                amount: policy.monthly_premium,
+                next_payment_date: policy.next_payment_date,
+                timestamp: now,
+            },
+        );
+
+        true
+    }
+
+    pub fn batch_pay_premiums(env: Env, caller: Address, ids: Vec<u32>) -> u32 {
+        Self::require_initialized(&env);
+        caller.require_auth();
+        if ids.len() > MAX_BATCH_SIZE {
+            panic!("batch too large");
+        }
+
+        let mut count = 0u32;
+        for id in ids.iter() {
+            let mut policy = Self::load_policy(&env, id);
+            if policy.active && policy.owner == caller {
+                let now = env.ledger().timestamp();
+                policy.last_payment_at = now;
+                policy.next_payment_date = now + THIRTY_DAYS_SECS;
+                env.storage()
+                    .instance()
+                    .set(&DataKey::Policy(id), &policy);
+                count += 1;
+            }
+        }
+        Self::extend_instance_ttl(&env);
+        count
+    }
+
+    pub fn set_external_ref(
+        env: Env,
+        caller: Address,
+        policy_id: u32,
+        ext_ref: core::option::Option<String>,
+    ) -> bool {
+        Self::require_initialized(&env);
+        caller.require_auth();
+        if caller != Self::get_owner(&env) {
+            panic!("unauthorized");
+        }
+
+        let mut policy = Self::load_policy(&env, policy_id);
+        Self::validate_ext_ref(&ext_ref);
+        policy.external_ref = ext_ref;
+        env.storage()
+            .instance()
+            .set(&DataKey::Policy(policy_id), &policy);
+        true
+    }
+
+    pub fn deactivate_policy(env: Env, caller: Address, policy_id: u32) -> bool {
+        Self::require_initialized(&env);
+        caller.require_auth();
+        let mut policy = Self::load_policy(&env, policy_id);
+        if caller != policy.owner && caller != Self::get_owner(&env) {
+            panic!("unauthorized");
+        }
+        if !policy.active {
+            panic!("already inactive");
+        }
+
+        policy.active = false;
+        env.storage()
+            .instance()
+            .set(&DataKey::Policy(policy_id), &policy);
+
+        let active = env
+            .storage()
+            .instance()
+            .get::<_, Vec<u32>>(&DataKey::ActivePolicies)
+            .unwrap();
+        let mut new_active = Vec::new(&env);
+        for id in active.iter() {
+            if id != policy_id {
+                new_active.push_back(id);
+            }
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::ActivePolicies, &new_active);
+
+        env.events().publish(
+            (symbol_short!("deactive"), symbol_short!("policy")),
+            PolicyDeactivatedEvent {
+                policy_id,
+                name: policy.name,
+                timestamp: env.ledger().timestamp(),
+            },
+        );
+        true
+    }
+
+    pub fn get_active_policies(
+        env: Env,
+        owner: Address,
+        cursor: u32,
+        limit: u32,
+    ) -> PolicyPage {
+        Self::require_initialized(&env);
+        let owner_ids = env
+            .storage()
+            .instance()
+            .get::<_, Vec<u32>>(&DataKey::OwnerPolicies(owner))
+            .unwrap_or_else(|| Vec::new(&env));
+        let mut items = Vec::new(&env);
+        let mut next_cursor = 0u32;
+        let lim = if limit == 0 {
+            DEFAULT_PAGE_LIMIT
+        } else if limit > MAX_PAGE_LIMIT {
+            MAX_PAGE_LIMIT
+        } else {
+            limit
+        };
+
+        let mut last_included = 0u32;
+        for id in owner_ids.iter() {
+            if id > cursor {
+                if let Some(p) = env
+                    .storage()
+                    .instance()
+                    .get::<_, Policy>(&DataKey::Policy(id))
+                {
+                    if p.active {
+                        if items.len() < lim {
+                            items.push_back(id);
+                            last_included = id;
+                        } else {
+                            next_cursor = last_included;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        let count = items.len();
+        PolicyPage {
+            items,
+            next_cursor,
+            count,
+        }
+    }
+
+    pub fn get_policy(env: Env, policy_id: u32) -> Policy {
+        Self::require_initialized(&env);
+        Self::load_policy(&env, policy_id)
+    }
+
+    pub fn get_total_monthly_premium(env: Env, owner: Address) -> i128 {
+        Self::require_initialized(&env);
+        let owner_ids = env
+            .storage()
+            .instance()
+            .get::<_, Vec<u32>>(&DataKey::OwnerPolicies(owner))
+            .unwrap_or_else(|| Vec::new(&env));
+        let mut total: i128 = 0;
+        for id in owner_ids.iter() {
+            if let Some(p) = env
+                .storage()
+                .instance()
+                .get::<_, Policy>(&DataKey::Policy(id))
+            {
+                if p.active {
+                    total = total.saturating_add(p.monthly_premium);
+                }
+            }
+        }
+        total
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/insurance/src/test.rs
+++ b/insurance/src/test.rs
@@ -1,1679 +1,1354 @@
-#![cfg(test)]
-
 use super::*;
-use crate::InsuranceError;
 use soroban_sdk::{
-    testutils::{Address as AddressTrait, Ledger, LedgerInfo},
-    Address, Env, String,
+    testutils::{Address as AddressTrait, Ledger},
+    Address, Env, String, Vec,
 };
-use proptest::prelude::*;
 
-use testutils::{set_ledger_time, setup_test_env};
+macro_rules! setup {
+    ($env:ident, $client:ident, $owner:ident) => {
+        let $env = Env::default();
+        $env.mock_all_auths();
+        let contract_id = $env.register_contract(None, Insurance);
+        let $client = InsuranceClient::new(&$env, &contract_id);
+        let $owner = Address::generate(&$env);
+        $client.init(&$owner);
+    };
+}
 
-// Removed local set_time in favor of testutils::set_ledger_time
+fn short_name(env: &Env) -> String {
+    String::from_str(env, "P")
+}
+
+// =============================================================================
+// init
+// =============================================================================
 
 #[test]
-fn test_create_policy_succeeds() {
-    setup_test_env!(env, Insurance, InsuranceClient, client, owner);
+fn test_init_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, Insurance);
+    let client = InsuranceClient::new(&env, &contract_id);
+    let owner = Address::generate(&env);
+    client.init(&owner);
+}
 
-    let name = String::from_str(&env, "Health Policy");
-    let coverage_type = CoverageType::Health;
+#[test]
+#[should_panic(expected = "already initialized")]
+fn test_init_cannot_reinit() {
+    setup!(env, client, owner);
+    client.init(&owner);
+}
+
+// =============================================================================
+// create_policy — happy path
+// =============================================================================
+
+#[test]
+fn test_create_policy_success() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
 
     let policy_id = client.create_policy(
-        &owner,
-        &name,
-        &coverage_type,
-        &100,   // monthly_premium
-        &10000, // coverage_amount
+        &caller,
+        &String::from_str(&env, "Health Policy"),
+        &CoverageType::Health,
+        &5_000_000i128,
+        &100_000_000i128,
     );
 
-    assert_eq!(policy_id, 1);
-
-    let policy = client.get_policy(&policy_id).unwrap();
-    assert_eq!(policy.owner, owner);
-    assert_eq!(policy.monthly_premium, 100);
-    assert_eq!(policy.coverage_amount, 10000);
+    let policy = client.get_policy(&policy_id);
+    assert_eq!(policy.owner, caller);
+    assert_eq!(policy.monthly_premium, 5_000_000);
+    assert_eq!(policy.coverage_amount, 100_000_000);
     assert!(policy.active);
+    assert_eq!(policy.id, 1);
 }
 
 #[test]
-#[should_panic(expected = "Monthly premium must be positive")]
-fn test_create_policy_invalid_premium() {
-    let env = Env::default();
-    let contract_id = env.register_contract(None, Insurance);
-    let client = InsuranceClient::new(&env, &contract_id);
-    let owner = Address::generate(&env);
+fn test_create_policy_increments_id() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
 
-    env.mock_all_auths();
+    let id1 = client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Health,
+        &5_000_000i128,
+        &10_000_000i128,
+    );
+    let id2 = client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Health,
+        &5_000_000i128,
+        &10_000_000i128,
+    );
+    assert_eq!(id1, 1);
+    assert_eq!(id2, 2);
+}
+
+// =============================================================================
+// create_policy — name validation
+// =============================================================================
+
+#[test]
+#[should_panic(expected = "name cannot be empty")]
+fn test_create_policy_empty_name_panics() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+    client.create_policy(
+        &caller,
+        &String::from_str(&env, ""),
+        &CoverageType::Health,
+        &5_000_000i128,
+        &10_000_000i128,
+    );
+}
+
+#[test]
+#[should_panic(expected = "name too long")]
+fn test_create_policy_name_too_long_panics() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+    let long_name = String::from_str(
+        &env,
+        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1",
+    );
+    client.create_policy(
+        &caller,
+        &long_name,
+        &CoverageType::Health,
+        &5_000_000i128,
+        &10_000_000i128,
+    );
+}
+
+#[test]
+fn test_create_policy_name_at_max_length_succeeds() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+    let max_name = String::from_str(
+        &env,
+        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    );
+    client.create_policy(
+        &caller,
+        &max_name,
+        &CoverageType::Health,
+        &5_000_000i128,
+        &10_000_000i128,
+    );
+}
+
+// =============================================================================
+// create_policy — premium validation
+// =============================================================================
+
+#[test]
+#[should_panic(expected = "monthly_premium must be positive")]
+fn test_create_policy_zero_premium_panics() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+    client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Health,
+        &0i128,
+        &50_000_000i128,
+    );
+}
+
+#[test]
+#[should_panic(expected = "monthly_premium must be positive")]
+fn test_create_policy_negative_premium_panics() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+    client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Health,
+        &-1i128,
+        &50_000_000i128,
+    );
+}
+
+#[test]
+#[should_panic(expected = "monthly_premium out of range for coverage type")]
+fn test_create_health_premium_below_min_panics() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+    client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Health,
+        &999_999i128,
+        &50_000_000i128,
+    );
+}
+
+#[test]
+#[should_panic(expected = "monthly_premium out of range for coverage type")]
+fn test_create_health_premium_above_max_panics() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+    client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Health,
+        &500_000_001i128,
+        &10_000_000i128,
+    );
+}
+
+#[test]
+fn test_health_premium_at_minimum_boundary_succeeds() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+    client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Health,
+        &1_000_000i128,
+        &10_000_000i128,
+    );
+}
+
+#[test]
+fn test_health_premium_at_maximum_boundary_succeeds() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+    client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Health,
+        &500_000_000i128,
+        &10_000_000i128,
+    );
+}
+
+#[test]
+#[should_panic(expected = "monthly_premium out of range for coverage type")]
+fn test_create_life_premium_below_min_panics() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+    client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Life,
+        &499_999i128,
+        &50_000_000i128,
+    );
+}
+
+#[test]
+#[should_panic(expected = "monthly_premium out of range for coverage type")]
+fn test_create_property_premium_below_min_panics() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+    client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Property,
+        &1_999_999i128,
+        &100_000_000i128,
+    );
+}
+
+#[test]
+#[should_panic(expected = "monthly_premium out of range for coverage type")]
+fn test_create_auto_premium_below_min_panics() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+    client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Auto,
+        &1_499_999i128,
+        &20_000_000i128,
+    );
+}
+
+#[test]
+#[should_panic(expected = "monthly_premium out of range for coverage type")]
+fn test_create_liability_premium_below_min_panics() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+    client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Liability,
+        &799_999i128,
+        &5_000_000i128,
+    );
+}
+
+#[test]
+#[should_panic(expected = "monthly_premium out of range for coverage type")]
+fn test_create_property_premium_above_max_panics() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+    client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Property,
+        &2_000_000_001i128,
+        &100_000_000i128,
+    );
+}
+
+#[test]
+#[should_panic(expected = "monthly_premium out of range for coverage type")]
+fn test_create_auto_premium_above_max_panics() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+    client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Auto,
+        &750_000_001i128,
+        &20_000_000i128,
+    );
+}
+
+#[test]
+#[should_panic(expected = "monthly_premium out of range for coverage type")]
+fn test_create_liability_premium_above_max_panics() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+    client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Liability,
+        &400_000_001i128,
+        &5_000_000i128,
+    );
+}
+
+// =============================================================================
+// create_policy — coverage amount validation
+// =============================================================================
+
+#[test]
+#[should_panic(expected = "coverage_amount must be positive")]
+fn test_create_policy_zero_coverage_panics() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+    client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Health,
+        &5_000_000i128,
+        &0i128,
+    );
+}
+
+#[test]
+#[should_panic(expected = "coverage_amount must be positive")]
+fn test_create_policy_negative_coverage_panics() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+    client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Health,
+        &5_000_000i128,
+        &-1i128,
+    );
+}
+
+#[test]
+#[should_panic(expected = "coverage_amount out of range for coverage type")]
+fn test_create_health_coverage_below_min_panics() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+    client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Health,
+        &5_000_000i128,
+        &9_999_999i128,
+    );
+}
+
+#[test]
+#[should_panic(expected = "coverage_amount out of range for coverage type")]
+fn test_create_health_coverage_above_max_panics() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+    client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Health,
+        &500_000_000i128,
+        &100_000_000_001i128,
+    );
+}
+
+#[test]
+fn test_health_coverage_at_minimum_boundary_succeeds() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+    client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Health,
+        &5_000_000i128,
+        &10_000_000i128,
+    );
+}
+
+#[test]
+fn test_health_coverage_at_maximum_boundary_succeeds() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+    client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Health,
+        &500_000_000i128,
+        &100_000_000_000i128,
+    );
+}
+
+#[test]
+#[should_panic(expected = "coverage_amount out of range for coverage type")]
+fn test_create_life_coverage_below_min_panics() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+    client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Life,
+        &1_000_000i128,
+        &49_999_999i128,
+    );
+}
+
+#[test]
+#[should_panic(expected = "coverage_amount out of range for coverage type")]
+fn test_create_life_coverage_above_max_panics() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+    client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Life,
+        &1_000_000_000i128,
+        &500_000_000_001i128,
+    );
+}
+
+#[test]
+#[should_panic(expected = "coverage_amount out of range for coverage type")]
+fn test_create_property_coverage_below_min_panics() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+    client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Property,
+        &5_000_000i128,
+        &99_999_999i128,
+    );
+}
+
+#[test]
+#[should_panic(expected = "coverage_amount out of range for coverage type")]
+fn test_create_auto_coverage_above_max_panics() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+    client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Auto,
+        &750_000_000i128,
+        &200_000_000_001i128,
+    );
+}
+
+#[test]
+#[should_panic(expected = "coverage_amount out of range for coverage type")]
+fn test_create_liability_coverage_above_max_panics() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+    client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Liability,
+        &400_000_000i128,
+        &50_000_000_001i128,
+    );
+}
+
+// =============================================================================
+// create_policy — ratio guard (coverage_amount > premium * 12 * 500)
+// =============================================================================
+
+#[test]
+#[should_panic(
+    expected = "unsupported combination: coverage_amount too high relative to premium"
+)]
+fn test_create_policy_coverage_too_high_for_premium_panics() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+    // premium = 1_000_000 -> annual = 12_000_000 -> max_coverage = 6_000_000_000
+    // Supply coverage = 6_000_000_001 (just over ratio, within Health's hard cap of 100B)
+    client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Health,
+        &1_000_000i128,
+        &6_000_000_001i128,
+    );
+}
+
+#[test]
+fn test_create_policy_coverage_exactly_at_ratio_limit_succeeds() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+    // premium = 1_000_000 -> ratio limit = 1M * 12 * 500 = 6_000_000_000
+    client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Health,
+        &1_000_000i128,
+        &6_000_000_000i128,
+    );
+}
+
+#[test]
+#[should_panic(
+    expected = "unsupported combination: coverage_amount too high relative to premium"
+)]
+fn test_create_policy_coverage_way_beyond_ratio_panics() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+    // premium = 5_000_000 -> ratio = 5M * 12 * 500 = 30_000_000_000
+    // Supply 100_000_000_000 (within Health max_coverage = 100B) way over ratio
+    client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Health,
+        &5_000_000i128,
+        &100_000_000_000i128,
+    );
+}
+
+// =============================================================================
+// create_policy — MAX_POLICIES cap
+// =============================================================================
+
+#[test]
+#[should_panic(expected = "max policies reached")]
+fn test_create_policy_at_max_policies_rejects_overflow() {
+    setup!(env, client, owner);
+    env.budget().reset_unlimited();
+    let caller = Address::generate(&env);
+
+    for _ in 0..1_000 {
+        client.create_policy(
+            &caller,
+            &short_name(&env),
+            &CoverageType::Health,
+            &5_000_000i128,
+            &10_000_000i128,
+        );
+    }
 
     client.create_policy(
-    let result = client.try_create_policy(
-        &owner,
-        &String::from_str(&env, "Bad"),
-        &String::from_str(&env, "Type"),
-        &0,
-        &10000,
+        &caller,
+        &short_name(&env),
+        &CoverageType::Health,
+        &5_000_000i128,
+        &10_000_000i128,
     );
 }
 
-#[test]
-#[should_panic(expected = "Coverage amount must be positive")]
-    assert_eq!(result, Err(Ok(InsuranceError::InvalidPremium)));
-}
+// =============================================================================
+// pay_premium — happy path
+// =============================================================================
 
 #[test]
-fn test_create_policy_invalid_coverage() {
-    let env = Env::default();
-    let contract_id = env.register_contract(None, Insurance);
-    let client = InsuranceClient::new(&env, &contract_id);
-    let owner = Address::generate(&env);
+fn test_pay_premium_success() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
 
-    env.mock_all_auths();
-
-    client.create_policy(
-    let result = client.try_create_policy(
-        &owner,
-        &String::from_str(&env, "Bad"),
-        &String::from_str(&env, "Type"),
-        &100,
-        &0,
-    );
-    assert_eq!(result, Err(Ok(InsuranceError::InvalidCoverage)));
-}
-
-#[test]
-fn test_pay_premium() {
-    let env = Env::default();
-    let contract_id = env.register_contract(None, Insurance);
-    let client = InsuranceClient::new(&env, &contract_id);
-    let owner = Address::generate(&env);
-
-    env.mock_all_auths();
-
-    let policy_id = client.create_policy(
-        &owner,
-        &String::from_str(&env, "Policy"),
-        &String::from_str(&env, "Type"),
-        &100,
-        &10000,
+    let id = client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Health,
+        &5_000_000i128,
+        &50_000_000i128,
     );
 
-    // Initial next_payment_date is ~30 days from creation
-    // We'll simulate passage of time is separate, but here we just check it updates
-    let initial_policy = client.get_policy(&policy_id).unwrap();
-    let initial_due = initial_policy.next_payment_date;
-
-    // Advance ledger time to simulate paying slightly later
-    set_ledger_time(&env, 1, env.ledger().timestamp() + 1000);
-
-    client.pay_premium(&owner, &policy_id);
-
-    let updated_policy = client.get_policy(&policy_id).unwrap();
-
-    // New validation logic: new due date should be current timestamp + 30 days
-    // Since we advanced timestamp by 1000, the new due date should be > initial due date
-    assert!(updated_policy.next_payment_date > initial_due);
+    let result = client.pay_premium(&caller, &id);
+    assert!(result);
 }
+
+/// Verify that pay_premium advances last_payment_at and next_payment_date by
+/// THIRTY_DAYS_SECS (30 * 86400) from the current ledger timestamp.
+#[test]
+fn test_pay_premium_updates_dates_correctly() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+
+    env.ledger().set_timestamp(1_000_000u64);
+
+    let id = client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Health,
+        &5_000_000i128,
+        &50_000_000i128,
+    );
+
+    env.ledger().set_timestamp(2_000_000u64);
+    client.pay_premium(&caller, &id);
+
+    let policy = client.get_policy(&id);
+    assert_eq!(policy.last_payment_at, 2_000_000);
+    assert_eq!(policy.next_payment_date, 2_000_000 + 30 * 24 * 60 * 60);
+}
+
+#[test]
+fn test_multiple_premium_payments_push_date_forward() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+
+    env.ledger().set_timestamp(1_000_000u64);
+
+    let id = client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Health,
+        &5_000_000i128,
+        &50_000_000i128,
+    );
+
+    env.ledger().set_timestamp(2_000_000u64);
+    client.pay_premium(&caller, &id);
+
+    let p1 = client.get_policy(&id);
+    assert_eq!(p1.next_payment_date, 2_000_000 + 30 * 86400);
+
+    env.ledger().set_timestamp(3_000_000u64);
+    client.pay_premium(&caller, &id);
+
+    let p2 = client.get_policy(&id);
+    assert_eq!(p2.last_payment_at, 3_000_000);
+    assert_eq!(p2.next_payment_date, 3_000_000 + 30 * 86400);
+}
+
+// =============================================================================
+// pay_premium — failure cases
+// =============================================================================
 
 #[test]
 #[should_panic(expected = "Only the policy owner can pay premiums")]
-fn test_pay_premium_unauthorized() {
-    let env = Env::default();
-    let contract_id = env.register_contract(None, Insurance);
-    let client = InsuranceClient::new(&env, &contract_id);
-    let owner = Address::generate(&env);
-    let other = Address::generate(&env);
+fn test_pay_premium_non_owner_panics() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
 
-    env.mock_all_auths();
-
-    let policy_id = client.create_policy(
-        &owner,
-        &String::from_str(&env, "Policy"),
-        &String::from_str(&env, "Type"),
-        &100,
-        &10000,
+    let id = client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Health,
+        &5_000_000i128,
+        &50_000_000i128,
     );
 
-    // unauthorized payer
-    client.pay_premium(&other, &policy_id);
-    let result = client.try_pay_premium(&other, &policy_id);
-    assert_eq!(result, Err(Ok(InsuranceError::Unauthorized)));
+    let non_owner = Address::generate(&env);
+    client.pay_premium(&non_owner, &id);
 }
 
 #[test]
-fn test_deactivate_policy() {
-    let env = Env::default();
-    let contract_id = env.register_contract(None, Insurance);
-    let client = InsuranceClient::new(&env, &contract_id);
-    let owner = Address::generate(&env);
+#[should_panic(expected = "policy inactive")]
+fn test_pay_premium_on_inactive_policy_panics() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
 
-    env.mock_all_auths();
-
-    let policy_id = client.create_policy(
-        &owner,
-        &String::from_str(&env, "Policy"),
-        &String::from_str(&env, "Type"),
-        &100,
-        &10000,
+    let id = client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Health,
+        &5_000_000i128,
+        &50_000_000i128,
     );
 
-    let success = client.deactivate_policy(&owner, &policy_id);
-    assert!(success);
+    client.deactivate_policy(&owner, &id);
+    client.pay_premium(&caller, &id);
+}
 
-    let policy = client.get_policy(&policy_id).unwrap();
+#[test]
+#[should_panic(expected = "policy not found")]
+fn test_pay_premium_nonexistent_policy_panics() {
+    setup!(env, client, owner);
+    client.pay_premium(&owner, &999u32);
+}
+
+// =============================================================================
+// deactivate_policy — happy path
+// =============================================================================
+
+#[test]
+fn test_deactivate_policy_success() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+
+    let id = client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Health,
+        &5_000_000i128,
+        &50_000_000i128,
+    );
+
+    let result = client.deactivate_policy(&owner, &id);
+    assert!(result);
+
+    let policy = client.get_policy(&id);
     assert!(!policy.active);
 }
 
 #[test]
-fn test_get_active_policies() {
-    let env = Env::default();
-    let contract_id = env.register_contract(None, Insurance);
-    let client = InsuranceClient::new(&env, &contract_id);
-    let owner = Address::generate(&env);
+fn test_deactivate_policy_by_owner_succeeds() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
 
-    env.mock_all_auths();
+    let id = client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Health,
+        &5_000_000i128,
+        &50_000_000i128,
+    );
 
-    // Create 3 policies
+    let result = client.deactivate_policy(&caller, &id);
+    assert!(result);
+    assert!(!client.get_policy(&id).active);
+}
+
+// =============================================================================
+// deactivate_policy — failure cases
+// =============================================================================
+
+#[test]
+#[should_panic(expected = "unauthorized")]
+fn test_deactivate_policy_non_owner_panics() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+
+    let id = client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Health,
+        &5_000_000i128,
+        &50_000_000i128,
+    );
+
+    let stranger = Address::generate(&env);
+    client.deactivate_policy(&stranger, &id);
+}
+
+#[test]
+#[should_panic(expected = "policy not found")]
+fn test_deactivate_policy_nonexistent_panics() {
+    setup!(env, client, owner);
+    client.deactivate_policy(&owner, &999u32);
+}
+
+#[test]
+#[should_panic(expected = "already inactive")]
+fn test_deactivate_policy_already_inactive_panics() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+
+    let id = client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Health,
+        &5_000_000i128,
+        &50_000_000i128,
+    );
+
+    client.deactivate_policy(&owner, &id);
+    client.deactivate_policy(&owner, &id);
+}
+
+// =============================================================================
+// deactivate_policy — removal from ActivePolicies
+// =============================================================================
+
+#[test]
+fn test_deactivate_policy_removes_from_active_list() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+
+    let id = client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Health,
+        &5_000_000i128,
+        &50_000_000i128,
+    );
+
+    {
+        let active = client.get_active_policies(&caller, &0, &50);
+        assert_eq!(active.count, 1);
+    }
+
+    client.deactivate_policy(&owner, &id);
+
+    {
+        let active = client.get_active_policies(&caller, &0, &50);
+        assert_eq!(active.count, 0);
+    }
+}
+
+#[test]
+fn test_deactivate_policy_preserves_policy_data() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+
+    let id = client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Health,
+        &5_000_000i128,
+        &50_000_000i128,
+    );
+
+    client.deactivate_policy(&owner, &id);
+
+    let policy = client.get_policy(&id);
+    assert!(!policy.active);
+    assert_eq!(policy.owner, caller);
+    assert_eq!(policy.monthly_premium, 5_000_000);
+}
+
+// =============================================================================
+// get_active_policies — pagination & ordering
+// =============================================================================
+
+#[test]
+fn test_get_active_policies_empty_initially() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+    let page = client.get_active_policies(&caller, &0, &50);
+    assert_eq!(page.count, 0);
+    assert_eq!(page.items.len(), 0);
+}
+
+#[test]
+fn test_get_active_policies_returns_all_active() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+
     client.create_policy(
-        &owner,
-        &String::from_str(&env, "P1"),
-        &String::from_str(&env, "T1"),
-        &100,
-        &1000,
-    );
-    let p2 = client.create_policy(
-        &owner,
-        &String::from_str(&env, "P2"),
-        &String::from_str(&env, "T2"),
-        &200,
-        &2000,
+        &caller,
+        &short_name(&env),
+        &CoverageType::Health,
+        &5_000_000i128,
+        &10_000_000i128,
     );
     client.create_policy(
-        &owner,
-        &String::from_str(&env, "P3"),
-        &String::from_str(&env, "T3"),
-        &300,
-        &3000,
+        &caller,
+        &short_name(&env),
+        &CoverageType::Life,
+        &1_000_000i128,
+        &60_000_000i128,
     );
 
-    // Deactivate P2
-    client.deactivate_policy(&owner, &p2);
-
-    let active = client.get_active_policies(&owner);
-    assert_eq!(active.len(), 2);
-
-    // Check specific IDs if needed, but length 2 confirms one was filtered
+    let page = client.get_active_policies(&caller, &0, &50);
+    assert_eq!(page.count, 2);
+    assert_eq!(page.items.len(), 2);
 }
 
 #[test]
 fn test_get_active_policies_excludes_deactivated() {
-    let env = Env::default();
-    let contract_id = env.register_contract(None, Insurance);
-    let client = InsuranceClient::new(&env, &contract_id);
-    let owner = Address::generate(&env);
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
 
-    env.mock_all_auths();
-
-    // Create policy 1 and policy 2 for the same owner
-    let policy_id_1 = client.create_policy(
-        &owner,
-        &String::from_str(&env, "Policy 1"),
-        &String::from_str(&env, "Type 1"),
-        &100,
-        &1000,
+    let id1 = client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Health,
+        &5_000_000i128,
+        &10_000_000i128,
     );
-    let policy_id_2 = client.create_policy(
-        &owner,
-        &String::from_str(&env, "Policy 2"),
-        &String::from_str(&env, "Type 2"),
-        &200,
-        &2000,
+    let id2 = client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Life,
+        &1_000_000i128,
+        &60_000_000i128,
     );
 
-    // Deactivate policy 1
-    client.deactivate_policy(&owner, &policy_id_1);
+    client.deactivate_policy(&caller, &id1);
 
-    // get_active_policies must return only the still-active policy
-    let active = client.get_active_policies(&owner, &0, &DEFAULT_PAGE_LIMIT);
-    assert_eq!(
-        active.items.len(),
-        1,
-        "get_active_policies must return exactly one policy"
-    );
-    let only = active.items.get(0).unwrap();
-    assert_eq!(
-        only.id, policy_id_2,
-        "the returned policy must be the active one (policy_id_2)"
-    );
-    assert!(only.active, "returned policy must have active == true");
+    let page = client.get_active_policies(&caller, &0, &50);
+    assert_eq!(page.count, 1);
+    assert_eq!(page.items.len(), 1);
+    assert_eq!(page.items.get(0).unwrap(), id2);
 }
 
 #[test]
-fn test_get_all_policies_for_owner_pagination() {
-    let env = Env::default();
-    let contract_id = env.register_contract(None, Insurance);
-    let client = InsuranceClient::new(&env, &contract_id);
-    let owner = Address::generate(&env);
+fn test_get_active_policies_owner_isolation() {
+    setup!(env, client, owner);
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    client.create_policy(
+        &alice,
+        &short_name(&env),
+        &CoverageType::Health,
+        &5_000_000i128,
+        &10_000_000i128,
+    );
+    client.create_policy(
+        &alice,
+        &short_name(&env),
+        &CoverageType::Life,
+        &1_000_000i128,
+        &60_000_000i128,
+    );
+
+    client.create_policy(
+        &bob,
+        &short_name(&env),
+        &CoverageType::Auto,
+        &2_000_000i128,
+        &30_000_000i128,
+    );
+
+    let alice_page = client.get_active_policies(&alice, &0, &50);
+    assert_eq!(alice_page.count, 2);
+
+    let bob_page = client.get_active_policies(&bob, &0, &50);
+    assert_eq!(bob_page.count, 1);
+}
+
+#[test]
+fn test_get_active_policies_cursor_pagination() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+
+    for _ in 0..5 {
+        client.create_policy(
+            &caller,
+            &short_name(&env),
+            &CoverageType::Health,
+            &5_000_000i128,
+            &10_000_000i128,
+        );
+    }
+
+    let page1 = client.get_active_policies(&caller, &0, &2);
+    assert_eq!(page1.count, 2);
+    assert_eq!(page1.items.len(), 2);
+    assert_eq!(page1.items.get(0).unwrap(), 1u32);
+    assert_eq!(page1.items.get(1).unwrap(), 2u32);
+    assert_eq!(page1.next_cursor, 2u32);
+
+    let page2 = client.get_active_policies(&caller, &page1.next_cursor, &2);
+    assert_eq!(page2.count, 2);
+    assert_eq!(page2.items.get(0).unwrap(), 3u32);
+    assert_eq!(page2.items.get(1).unwrap(), 4u32);
+    assert_eq!(page2.next_cursor, 4u32);
+
+    let page3 = client.get_active_policies(&caller, &page2.next_cursor, &2);
+    assert_eq!(page3.count, 1);
+    assert_eq!(page3.items.get(0).unwrap(), 5u32);
+    assert_eq!(page3.next_cursor, 0u32);
+}
+
+// =============================================================================
+// get_total_monthly_premium
+// =============================================================================
+
+#[test]
+fn test_get_total_monthly_premium_zero_when_no_policies() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+    assert_eq!(client.get_total_monthly_premium(&caller), 0);
+}
+
+#[test]
+fn test_get_total_monthly_premium_sums_active_only() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+
+    client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Health,
+        &5_000_000i128,
+        &10_000_000i128,
+    );
+    client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Life,
+        &1_000_000i128,
+        &60_000_000i128,
+    );
+
+    assert_eq!(client.get_total_monthly_premium(&caller), 6_000_000);
+}
+
+#[test]
+fn test_get_total_monthly_premium_excludes_deactivated() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+
+    let id1 = client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Health,
+        &5_000_000i128,
+        &10_000_000i128,
+    );
+    client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Life,
+        &1_000_000i128,
+        &60_000_000i128,
+    );
+
+    assert_eq!(client.get_total_monthly_premium(&caller), 6_000_000);
+
+    client.deactivate_policy(&caller, &id1);
+
+    assert_eq!(client.get_total_monthly_premium(&caller), 1_000_000);
+}
+
+#[test]
+fn test_get_total_monthly_premium_owner_isolation() {
+    setup!(env, client, owner);
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    client.create_policy(
+        &alice,
+        &short_name(&env),
+        &CoverageType::Health,
+        &5_000_000i128,
+        &10_000_000i128,
+    );
+    client.create_policy(
+        &bob,
+        &short_name(&env),
+        &CoverageType::Life,
+        &2_000_000i128,
+        &60_000_000i128,
+    );
+
+    assert_eq!(client.get_total_monthly_premium(&alice), 5_000_000);
+    assert_eq!(client.get_total_monthly_premium(&bob), 2_000_000);
+}
+
+// =============================================================================
+// get_policy
+// =============================================================================
+
+#[test]
+fn test_get_policy_returns_correct_fields() {
+    setup!(env, client, owner);
+
+    env.ledger().set_timestamp(1_700_000_000u64);
+
+    let id = client.create_policy(
+        &owner,
+        &String::from_str(&env, "My Health Plan"),
+        &CoverageType::Health,
+        &10_000_000i128,
+        &100_000_000i128,
+    );
+
+    let policy = client.get_policy(&id);
+    assert_eq!(policy.id, 1);
+    assert_eq!(policy.owner, owner);
+    assert_eq!(policy.name, String::from_str(&env, "My Health Plan"));
+    assert_eq!(policy.coverage_type, CoverageType::Health);
+    assert_eq!(policy.monthly_premium, 10_000_000);
+    assert_eq!(policy.coverage_amount, 100_000_000);
+    assert!(policy.active);
+    assert_eq!(policy.created_at, 1_700_000_000);
+    assert_eq!(policy.last_payment_at, 0);
+    assert_eq!(policy.next_payment_date, 1_700_000_000 + 30 * 86400);
+    assert!(policy.external_ref.is_none());
+}
+
+#[test]
+#[should_panic(expected = "policy not found")]
+fn test_get_policy_nonexistent_panics() {
+    setup!(env, client, owner);
+    client.get_policy(&999u32);
+}
+
+// =============================================================================
+// batch_pay_premiums
+// =============================================================================
+
+#[test]
+fn test_batch_pay_premiums_all_owned_active() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+
+    let id1 = client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Health,
+        &5_000_000i128,
+        &10_000_000i128,
+    );
+    let id2 = client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Life,
+        &1_000_000i128,
+        &60_000_000i128,
+    );
+
+    let ids = Vec::from_array(&env, [id1, id2]);
+    let count = client.batch_pay_premiums(&caller, &ids);
+    assert_eq!(count, 2);
+}
+
+#[test]
+fn test_batch_pay_premiums_skips_unowned_and_inactive() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
     let other = Address::generate(&env);
 
-    env.mock_all_auths();
-
-    // Create 3 policies for owner
-    client.create_policy(
-        &owner,
-        &String::from_str(&env, "P1"),
-        &String::from_str(&env, "T1"),
-        &100,
-        &1000,
+    let owned_id = client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Health,
+        &5_000_000i128,
+        &10_000_000i128,
     );
-    let p2 = client.create_policy(
-        &owner,
-        &String::from_str(&env, "P2"),
-        &String::from_str(&env, "T2"),
-        &200,
-        &2000,
-    );
-    client.create_policy(
-        &owner,
-        &String::from_str(&env, "P3"),
-        &String::from_str(&env, "T3"),
-        &300,
-        &3000,
-    );
-
-    // Create 1 policy for other
-    client.create_policy(
+    let other_id = client.create_policy(
         &other,
-        &String::from_str(&env, "Other P"),
-        &String::from_str(&env, "Type"),
-        &500,
-        &5000,
-    );
-
-    // Deactivate P2
-    client.deactivate_policy(&owner, &p2);
-
-    // get_all_policies_for_owner should return all 3 for owner
-    let page = client.get_all_policies_for_owner(&owner, &0, &10);
-    assert_eq!(page.items.len(), 3);
-    assert_eq!(page.count, 3);
-
-    // verify p2 is in the list and is inactive
-    let mut found_p2 = false;
-    for policy in page.items.iter() {
-        if policy.id == p2 {
-            found_p2 = true;
-            assert!(!policy.active);
-        }
-    }
-    assert!(found_p2);
-}
-
-#[test]
-fn test_get_total_monthly_premium() {
-    let env = Env::default();
-    let contract_id = env.register_contract(None, Insurance);
-    let client = InsuranceClient::new(&env, &contract_id);
-    let owner = Address::generate(&env);
-
-    env.mock_all_auths();
-
-    client.create_policy(
-        &owner,
-        &String::from_str(&env, "P1"),
-        &String::from_str(&env, "T1"),
-        &100,
-        &1000,
-    );
-    client.create_policy(
-        &owner,
-        &String::from_str(&env, "P2"),
-        &String::from_str(&env, "T2"),
-        &200,
-        &2000,
-    );
-
-    let total = client.get_total_monthly_premium(&owner);
-    assert_eq!(total, 300);
-}
-
-#[test]
-fn test_get_total_monthly_premium_zero_policies() {
-    let env = Env::default();
-    let contract_id = env.register_contract(None, Insurance);
-    let client = InsuranceClient::new(&env, &contract_id);
-    let owner = Address::generate(&env);
-
-    env.mock_all_auths();
-
-    // Fresh address with no policies
-    let total = client.get_total_monthly_premium(&owner);
-    assert_eq!(total, 0);
-}
-
-#[test]
-fn test_get_total_monthly_premium_one_policy() {
-    let env = Env::default();
-    let contract_id = env.register_contract(None, Insurance);
-    let client = InsuranceClient::new(&env, &contract_id);
-    let owner = Address::generate(&env);
-
-    env.mock_all_auths();
-
-    // Create one policy with monthly_premium = 500
-    client.create_policy(
-        &owner,
-        &String::from_str(&env, "Single Policy"),
-        &CoverageType::Health,
-        &500,
-        &10000,
-    );
-
-    let total = client.get_total_monthly_premium(&owner);
-    assert_eq!(total, 500);
-}
-
-#[test]
-fn test_get_total_monthly_premium_multiple_active_policies() {
-    let env = Env::default();
-    let contract_id = env.register_contract(None, Insurance);
-    let client = InsuranceClient::new(&env, &contract_id);
-    let owner = Address::generate(&env);
-
-    env.mock_all_auths();
-
-    // Create three policies with premiums 100, 200, 300
-    client.create_policy(
-        &owner,
-        &String::from_str(&env, "Policy 1"),
-        &CoverageType::Health,
-        &100,
-        &1000,
-    );
-    client.create_policy(
-        &owner,
-        &String::from_str(&env, "Policy 2"),
-        &CoverageType::Life,
-        &200,
-        &2000,
-    );
-    client.create_policy(
-        &owner,
-        &String::from_str(&env, "Policy 3"),
+        &short_name(&env),
         &CoverageType::Auto,
-        &300,
-        &3000,
+        &2_000_000i128,
+        &30_000_000i128,
     );
 
-    let total = client.get_total_monthly_premium(&owner);
-    assert_eq!(total, 600); // 100 + 200 + 300
-}
-
-#[test]
-fn test_get_total_monthly_premium_deactivated_policy_excluded() {
-    let env = Env::default();
-    let contract_id = env.register_contract(None, Insurance);
-    let client = InsuranceClient::new(&env, &contract_id);
-    let owner = Address::generate(&env);
-
-    env.mock_all_auths();
-
-    // Create two policies with premiums 100 and 200
-    let policy1 = client.create_policy(
-        &owner,
-        &String::from_str(&env, "Policy 1"),
-        &CoverageType::Health,
-        &100,
-        &1000,
-    );
-    let policy2 = client.create_policy(
-        &owner,
-        &String::from_str(&env, "Policy 2"),
+    let inactive_id = client.create_policy(
+        &caller,
+        &short_name(&env),
         &CoverageType::Life,
-        &200,
-        &2000,
+        &1_000_000i128,
+        &60_000_000i128,
     );
+    client.deactivate_policy(&caller, &inactive_id);
 
-    // Verify total includes both policies initially
-    let total_initial = client.get_total_monthly_premium(&owner);
-    assert_eq!(total_initial, 300); // 100 + 200
+    env.ledger().set_timestamp(1_000_000u64);
+    let ids = Vec::from_array(&env, [owned_id, other_id, inactive_id]);
+    let count = client.batch_pay_premiums(&caller, &ids);
+    assert_eq!(count, 1);
 
-    // Deactivate the first policy
-    client.deactivate_policy(&owner, &policy1);
-
-    // Verify total only includes the active policy
-    let total_after_deactivation = client.get_total_monthly_premium(&owner);
-    assert_eq!(total_after_deactivation, 200); // Only policy 2
+    let policy = client.get_policy(&owned_id);
+    assert_eq!(policy.last_payment_at, 1_000_000);
 }
 
 #[test]
-fn test_get_total_monthly_premium_different_owner_isolation() {
+#[should_panic(expected = "batch too large")]
+fn test_batch_pay_premiums_exceeds_max_batch_size() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+
+    let mut arr = [0u32; 51];
+    for i in 0..51 {
+        arr[i] = i as u32;
+    }
+    let ids = Vec::from_array(&env, arr);
+    client.batch_pay_premiums(&caller, &ids);
+}
+
+// =============================================================================
+// set_external_ref
+// =============================================================================
+
+#[test]
+fn test_set_external_ref_success() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+
+    let id = client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Health,
+        &5_000_000i128,
+        &50_000_000i128,
+    );
+
+    let new_ref = String::from_str(&env, "EXT-REF-001");
+    client.set_external_ref(&owner, &id, &Some(new_ref));
+
+    let policy = client.get_policy(&id);
+    assert!(policy.external_ref.is_some());
+}
+
+#[test]
+fn test_set_external_ref_clear() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+
+    let id = client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Health,
+        &5_000_000i128,
+        &50_000_000i128,
+    );
+
+    let new_ref = String::from_str(&env, "EXT-REF-001");
+    client.set_external_ref(&owner, &id, &Some(new_ref));
+
+    client.set_external_ref(&owner, &id, &None);
+
+    let policy = client.get_policy(&id);
+    assert!(policy.external_ref.is_none());
+}
+
+#[test]
+#[should_panic(expected = "unauthorized")]
+fn test_set_external_ref_non_owner_panics() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+
+    let id = client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Health,
+        &5_000_000i128,
+        &50_000_000i128,
+    );
+
+    let stranger = Address::generate(&env);
+    client.set_external_ref(&stranger, &id, &Some(String::from_str(&env, "BAD")));
+}
+
+#[test]
+#[should_panic(expected = "external_ref length out of range")]
+fn test_set_external_ref_too_long_panics() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+
+    let id = client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Health,
+        &5_000_000i128,
+        &50_000_000i128,
+    );
+
+    let long_ref = String::from_str(
+        &env,
+        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1",
+    );
+    client.set_external_ref(&owner, &id, &Some(long_ref));
+}
+
+#[test]
+fn test_set_external_ref_at_max_length_succeeds() {
+    setup!(env, client, owner);
+    let caller = Address::generate(&env);
+
+    let id = client.create_policy(
+        &caller,
+        &short_name(&env),
+        &CoverageType::Health,
+        &5_000_000i128,
+        &50_000_000i128,
+    );
+
+    let max_ref = String::from_str(
+        &env,
+        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    );
+    client.set_external_ref(&owner, &id, &Some(max_ref));
+
+    let policy = client.get_policy(&id);
+    assert!(policy.external_ref.is_some());
+}
+
+// =============================================================================
+// Uninitialized contract guard
+// =============================================================================
+
+#[test]
+#[should_panic(expected = "not initialized")]
+fn test_create_policy_without_init_panics() {
     let env = Env::default();
+    env.mock_all_auths();
     let contract_id = env.register_contract(None, Insurance);
     let client = InsuranceClient::new(&env, &contract_id);
-    let owner_a = Address::generate(&env);
-    let owner_b = Address::generate(&env);
-
-    env.mock_all_auths();
-
-    // Create policies for owner_a
+    let caller = Address::generate(&env);
     client.create_policy(
-        &owner_a,
-        &String::from_str(&env, "Policy A1"),
+        &caller,
+        &String::from_str(&env, "Test"),
         &CoverageType::Health,
-        &100,
-        &1000,
+        &5_000_000i128,
+        &50_000_000i128,
     );
-    client.create_policy(
-        &owner_a,
-        &String::from_str(&env, "Policy A2"),
-        &CoverageType::Life,
-        &200,
-        &2000,
-    );
-
-    // Create policies for owner_b
-    client.create_policy(
-        &owner_b,
-        &String::from_str(&env, "Policy B1"),
-        &String::from_str(&env, "emergency"),
-        &300,
-        &3000,
-    );
-
-    // Verify owner_a's total only includes their policies
-    let total_a = client.get_total_monthly_premium(&owner_a);
-    assert_eq!(total_a, 300); // 100 + 200
-
-    // Verify owner_b's total only includes their policies
-    let total_b = client.get_total_monthly_premium(&owner_b);
-    assert_eq!(total_b, 300); // 300
-
-    // Verify no cross-owner leakage
-    assert_ne!(total_a, 0); // owner_a has policies
-    assert_ne!(total_b, 0); // owner_b has policies
-    assert_eq!(total_a, total_b); // Both have same total but different policies
 }
 
 #[test]
-fn test_multiple_premium_payments() {
+#[should_panic(expected = "not initialized")]
+fn test_get_active_policies_without_init_panics() {
     let env = Env::default();
+    env.mock_all_auths();
     let contract_id = env.register_contract(None, Insurance);
     let client = InsuranceClient::new(&env, &contract_id);
-    let owner = Address::generate(&env);
-
-    env.mock_all_auths();
-
-    let policy_id = client.create_policy(
-        &owner,
-        &String::from_str(&env, "LongTerm"),
-        &String::from_str(&env, "Life"),
-        &100,
-        &10000,
-    );
-
-    let p1 = client.get_policy(&policy_id).unwrap();
-    let first_due = p1.next_payment_date;
-
-    // First payment
-    client.pay_premium(&owner, &policy_id);
-
-    // Simulate time passing (still before next due)
-    set_ledger_time(&env, 1, env.ledger().timestamp() + 5000);
-
-    // Second payment
-    client.pay_premium(&owner, &policy_id);
-
-    let p2 = client.get_policy(&policy_id).unwrap();
-
-    // The logic in contract sets next_payment_date to 'now + 30 days'
-    // So paying twice in quick succession just pushes it to 30 days from the SECOND payment
-    // It does NOT add 60 days from start. This test verifies that behavior.
-    assert!(p2.next_payment_date > first_due);
-    assert_eq!(
-        p2.next_payment_date,
-        env.ledger().timestamp() + (30 * 86400)
-    );
+    let caller = Address::generate(&env);
+    client.get_active_policies(&caller, &0, &50);
 }
 
 #[test]
-fn test_create_premium_schedule_succeeds() {
-    setup_test_env!(env, Insurance, InsuranceClient, client, owner);
-    set_ledger_time(&env, 1000);
-
-    let policy_id = client.create_policy(
-        &owner,
-        &String::from_str(&env, "Health Insurance"),
-        &CoverageType::Health,
-        &500,
-        &50000,
-    );
-
-    let schedule_id = client.create_premium_schedule(&owner, &policy_id, &3000, &2592000);
-    assert_eq!(schedule_id, 1);
-
-    let schedule = client.get_premium_schedule(&schedule_id);
-    assert!(schedule.is_some());
-    let schedule = schedule.unwrap();
-    assert_eq!(schedule.next_due, 3000);
-    assert_eq!(schedule.interval, 2592000);
-    assert!(schedule.active);
-}
-
-#[test]
-fn test_modify_premium_schedule() {
+#[should_panic(expected = "not initialized")]
+fn test_get_policy_without_init_panics() {
     let env = Env::default();
+    env.mock_all_auths();
     let contract_id = env.register_contract(None, Insurance);
     let client = InsuranceClient::new(&env, &contract_id);
-    let owner = <soroban_sdk::Address as AddressTrait>::generate(&env);
-
-    env.mock_all_auths();
-    set_ledger_time(&env, 1, 1000);
-
-    let policy_id = client.create_policy(
-        &owner,
-        &String::from_str(&env, "Health Insurance"),
-        &CoverageType::Health,
-        &500,
-        &50000,
-    );
-
-    let schedule_id = client.create_premium_schedule(&owner, &policy_id, &3000, &2592000);
-    client.modify_premium_schedule(&owner, &schedule_id, &4000, &2678400);
-
-    let schedule = client.get_premium_schedule(&schedule_id).unwrap();
-    assert_eq!(schedule.next_due, 4000);
-    assert_eq!(schedule.interval, 2678400);
+    client.get_policy(&1u32);
 }
 
 #[test]
-fn test_cancel_premium_schedule() {
+#[should_panic(expected = "not initialized")]
+fn test_get_total_monthly_premium_without_init_panics() {
     let env = Env::default();
+    env.mock_all_auths();
     let contract_id = env.register_contract(None, Insurance);
     let client = InsuranceClient::new(&env, &contract_id);
-    let owner = <soroban_sdk::Address as AddressTrait>::generate(&env);
-
-    env.mock_all_auths();
-    set_ledger_time(&env, 1, 1000);
-
-    let policy_id = client.create_policy(
-        &owner,
-        &String::from_str(&env, "Health Insurance"),
-        &CoverageType::Health,
-        &500,
-        &50000,
-    );
-
-    let schedule_id = client.create_premium_schedule(&owner, &policy_id, &3000, &2592000);
-    client.cancel_premium_schedule(&owner, &schedule_id);
-
-    let schedule = client.get_premium_schedule(&schedule_id).unwrap();
-    assert!(!schedule.active);
+    let caller = Address::generate(&env);
+    client.get_total_monthly_premium(&caller);
 }
 
 #[test]
-fn test_execute_due_premium_schedules() {
+#[should_panic(expected = "not initialized")]
+fn test_pay_premium_without_init_panics() {
     let env = Env::default();
+    env.mock_all_auths();
     let contract_id = env.register_contract(None, Insurance);
     let client = InsuranceClient::new(&env, &contract_id);
-    let owner = <soroban_sdk::Address as AddressTrait>::generate(&env);
-
-    env.mock_all_auths();
-    set_ledger_time(&env, 1, 1000);
-
-    let policy_id = client.create_policy(
-        &owner,
-        &String::from_str(&env, "Health Insurance"),
-        &CoverageType::Health,
-        &500,
-        &50000,
-    );
-
-    let schedule_id = client.create_premium_schedule(&owner, &policy_id, &3000, &0);
-
-    set_ledger_time(&env, 1, 3500);
-    let executed = client.execute_due_premium_schedules();
-
-    assert_eq!(executed.len(), 1);
-    assert_eq!(executed.get(0).unwrap(), schedule_id);
-
-    let policy = client.get_policy(&policy_id).unwrap();
-    assert_eq!(policy.next_payment_date, 3500 + 30 * 86400);
+    let caller = Address::generate(&env);
+    client.pay_premium(&caller, &1u32);
 }
 
 #[test]
-fn test_execute_recurring_premium_schedule() {
+#[should_panic(expected = "not initialized")]
+fn test_deactivate_policy_without_init_panics() {
     let env = Env::default();
+    env.mock_all_auths();
     let contract_id = env.register_contract(None, Insurance);
     let client = InsuranceClient::new(&env, &contract_id);
-    let owner = <soroban_sdk::Address as AddressTrait>::generate(&env);
-
-    env.mock_all_auths();
-    set_ledger_time(&env, 1, 1000);
-
-    let policy_id = client.create_policy(
-        &owner,
-        &String::from_str(&env, "Health Insurance"),
-        &String::from_str(&env, "health"),
-        &500,
-        &50000,
-    );
-
-    let schedule_id = client.create_premium_schedule(&owner, &policy_id, &3000, &2592000);
-
-    set_ledger_time(&env, 1, 3500);
-    client.execute_due_premium_schedules();
-
-    let schedule = client.get_premium_schedule(&schedule_id).unwrap();
-    assert!(schedule.active);
-    assert_eq!(schedule.next_due, 3000 + 2592000);
-}
-
-#[test]
-fn test_execute_missed_premium_schedules() {
-    let env = Env::default();
-    let contract_id = env.register_contract(None, Insurance);
-    let client = InsuranceClient::new(&env, &contract_id);
-    let owner = <soroban_sdk::Address as AddressTrait>::generate(&env);
-
-    env.mock_all_auths();
-    set_ledger_time(&env, 1, 1000);
-
-    let policy_id = client.create_policy(
-        &owner,
-        &String::from_str(&env, "Health Insurance"),
-        &CoverageType::Health,
-        &500,
-        &50000,
-    );
-
-    let schedule_id = client.create_premium_schedule(&owner, &policy_id, &3000, &2592000);
-
-    set_time(&env, 3000 + 2592000 * 3 + 100);
-    client.execute_due_premium_schedules();
-
-    let schedule = client.get_premium_schedule(&schedule_id).unwrap();
-    assert_eq!(schedule.missed_count, 3);
-    assert!(schedule.next_due > 3000 + 2592000 * 3);
-}
-
-#[test]
-fn test_get_premium_schedules() {
-    let env = Env::default();
-    let contract_id = env.register_contract(None, Insurance);
-    let client = InsuranceClient::new(&env, &contract_id);
-    let owner = <soroban_sdk::Address as AddressTrait>::generate(&env);
-
-    env.mock_all_auths();
-    set_ledger_time(&env, 1, 1000);
-
-    let policy_id1 = client.create_policy(
-        &owner,
-        &String::from_str(&env, "Health Insurance"),
-        &CoverageType::Health,
-        &500,
-        &50000,
-    );
-
-    let policy_id2 = client.create_policy(
-        &owner,
-        &String::from_str(&env, "Life Insurance"),
-        &String::from_str(&env, "life"),
-        &300,
-        &100000,
-    );
-
-    client.create_premium_schedule(&owner, &policy_id1, &3000, &2592000);
-    client.create_premium_schedule(&owner, &policy_id2, &4000, &2592000);
-
-    // -----------------------------------------------------------------------
-    // 3. create_policy — boundary conditions
-    // -----------------------------------------------------------------------
-
-    // --- Health min/max boundaries ---
-
-    #[test]
-    fn test_health_premium_at_minimum_boundary() {
-        let (env, client, _owner) = setup();
-        let caller = Address::generate(&env);
-        // min_premium for Health = 1_000_000
-        client.create_policy(
-            &caller,
-            &short_name(&env),
-            &CoverageType::Health,
-            &1_000_000i128,
-            &10_000_000i128, // min coverage
-            &None,
-        );
-    }
-
-    #[test]
-    fn test_health_premium_at_maximum_boundary() {
-        let (env, client, _owner) = setup();
-        let caller = Address::generate(&env);
-        // max_premium = 500_000_000; need coverage ≤ 500M * 12 * 500 = 3T (within 100B limit)
-        client.create_policy(
-            &caller,
-            &short_name(&env),
-            &CoverageType::Health,
-            &500_000_000i128,
-            &100_000_000_000i128, // max coverage for Health
-            &None,
-        );
-    }
-
-    #[test]
-    fn test_health_coverage_at_minimum_boundary() {
-        let (env, client, _owner) = setup();
-        let caller = Address::generate(&env);
-        client.create_policy(
-            &caller,
-            &short_name(&env),
-            &CoverageType::Health,
-            &5_000_000i128,
-            &10_000_000i128, // exactly min_coverage
-            &None,
-        );
-    }
-
-    #[test]
-    fn test_health_coverage_at_maximum_boundary() {
-        let (env, client, _owner) = setup();
-        let caller = Address::generate(&env);
-        // max_coverage = 100_000_000_000; need premium ≥ 100B / (12*500) ≈ 16_666_667
-        client.create_policy(
-            &caller,
-            &short_name(&env),
-            &CoverageType::Health,
-            &500_000_000i128,       // max premium to allow max coverage via ratio
-            &100_000_000_000i128,   // exactly max_coverage
-            &None,
-        );
-    }
-
-    // --- Life boundaries ---
-
-    #[test]
-    fn test_life_premium_at_minimum_boundary() {
-        let (env, client, _owner) = setup();
-        let caller = Address::generate(&env);
-        client.create_policy(
-            &caller,
-            &String::from_str(&env, "Life Min"),
-            &CoverageType::Life,
-            &500_000i128,     // min_premium
-            &50_000_000i128,  // min_coverage
-            &None,
-        );
-    }
-
-    #[test]
-    fn test_liability_premium_at_minimum_boundary() {
-        let (env, client, _owner) = setup();
-        let caller = Address::generate(&env);
-        client.create_policy(
-            &caller,
-            &String::from_str(&env, "Liability Min"),
-            &CoverageType::Liability,
-            &800_000i128,     // min_premium
-            &5_000_000i128,   // min_coverage
-            &None,
-        );
-    }
-
-    // -----------------------------------------------------------------------
-    // 4. create_policy — name validation
-    // -----------------------------------------------------------------------
-
-    #[test]
-    #[should_panic(expected = "name cannot be empty")]
-    fn test_create_policy_empty_name_panics() {
-        let (env, client, _owner) = setup();
-        let caller = Address::generate(&env);
-        client.create_policy(
-            &caller,
-            &String::from_str(&env, ""),
-            &CoverageType::Health,
-            &5_000_000i128,
-            &50_000_000i128,
-            &None,
-        );
-    }
-
-    #[test]
-    #[should_panic(expected = "name too long")]
-    fn test_create_policy_name_exceeds_max_panics() {
-        let (env, client, _owner) = setup();
-        let caller = Address::generate(&env);
-        // 65 character name — exceeds MAX_NAME_LEN (64)
-        let long_name = String::from_str(
-            &env,
-            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1",
-        );
-        client.create_policy(
-            &caller,
-            &long_name,
-            &CoverageType::Health,
-            &5_000_000i128,
-            &50_000_000i128,
-            &None,
-        );
-    }
-
-    #[test]
-    fn test_create_policy_name_at_max_length_succeeds() {
-        let (env, client, _owner) = setup();
-        let caller = Address::generate(&env);
-        // Exactly 64 characters
-        let max_name = String::from_str(
-            &env,
-            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-        );
-        client.create_policy(
-            &caller,
-            &max_name,
-            &CoverageType::Health,
-            &5_000_000i128,
-            &50_000_000i128,
-            &None,
-        );
-    }
-
-    // -----------------------------------------------------------------------
-    // 5. create_policy — premium validation failures
-    // -----------------------------------------------------------------------
-
-    #[test]
-    #[should_panic(expected = "monthly_premium must be positive")]
-    fn test_create_policy_zero_premium_panics() {
-        let (env, client, _owner) = setup();
-        let caller = Address::generate(&env);
-        client.create_policy(
-            &caller,
-            &short_name(&env),
-            &CoverageType::Health,
-            &0i128,
-            &50_000_000i128,
-            &None,
-        );
-    }
-
-    #[test]
-    #[should_panic(expected = "monthly_premium must be positive")]
-    fn test_create_policy_negative_premium_panics() {
-        let (env, client, _owner) = setup();
-        let caller = Address::generate(&env);
-        client.create_policy(
-            &caller,
-            &short_name(&env),
-            &CoverageType::Health,
-            &-1i128,
-            &50_000_000i128,
-            &None,
-        );
-    }
-
-    #[test]
-    #[should_panic(expected = "monthly_premium out of range for coverage type")]
-    fn test_create_health_policy_premium_below_min_panics() {
-        let (env, client, _owner) = setup();
-        let caller = Address::generate(&env);
-        // Health min_premium = 1_000_000; supply 999_999
-        client.create_policy(
-            &caller,
-            &short_name(&env),
-            &CoverageType::Health,
-            &999_999i128,
-            &50_000_000i128,
-            &None,
-        );
-    }
-
-    #[test]
-    #[should_panic(expected = "monthly_premium out of range for coverage type")]
-    fn test_create_health_policy_premium_above_max_panics() {
-        let (env, client, _owner) = setup();
-        let caller = Address::generate(&env);
-        // Health max_premium = 500_000_000; supply 500_000_001
-        client.create_policy(
-            &caller,
-            &short_name(&env),
-            &CoverageType::Health,
-            &500_000_001i128,
-            &10_000_000i128,
-            &None,
-        );
-    }
-
-    #[test]
-    #[should_panic(expected = "monthly_premium out of range for coverage type")]
-    fn test_create_life_policy_premium_below_min_panics() {
-        let (env, client, _owner) = setup();
-        let caller = Address::generate(&env);
-        // Life min_premium = 500_000; supply 499_999
-        client.create_policy(
-            &caller,
-            &String::from_str(&env, "Life"),
-            &CoverageType::Life,
-            &499_999i128,
-            &50_000_000i128,
-            &None,
-        );
-    }
-
-    #[test]
-    #[should_panic(expected = "monthly_premium out of range for coverage type")]
-    fn test_create_property_policy_premium_below_min_panics() {
-        let (env, client, _owner) = setup();
-        let caller = Address::generate(&env);
-        // Property min_premium = 2_000_000; supply 1_999_999
-        client.create_policy(
-            &caller,
-            &String::from_str(&env, "Property"),
-            &CoverageType::Property,
-            &1_999_999i128,
-            &100_000_000i128,
-            &None,
-        );
-    }
-
-    #[test]
-    #[should_panic(expected = "monthly_premium out of range for coverage type")]
-    fn test_create_auto_policy_premium_below_min_panics() {
-        let (env, client, _owner) = setup();
-        let caller = Address::generate(&env);
-        // Auto min_premium = 1_500_000; supply 1_499_999
-        client.create_policy(
-            &caller,
-            &String::from_str(&env, "Auto"),
-            &CoverageType::Auto,
-            &1_499_999i128,
-            &20_000_000i128,
-            &None,
-        );
-    }
-
-    #[test]
-    #[should_panic(expected = "monthly_premium out of range for coverage type")]
-    fn test_create_liability_policy_premium_below_min_panics() {
-        let (env, client, _owner) = setup();
-        let caller = Address::generate(&env);
-        // Liability min_premium = 800_000; supply 799_999
-        client.create_policy(
-            &caller,
-            &String::from_str(&env, "Liability"),
-            &CoverageType::Liability,
-            &799_999i128,
-            &5_000_000i128,
-            &None,
-        );
-    }
-
-    // -----------------------------------------------------------------------
-    // 6. create_policy — coverage amount validation failures
-    // -----------------------------------------------------------------------
-
-    #[test]
-    #[should_panic(expected = "coverage_amount must be positive")]
-    fn test_create_policy_zero_coverage_panics() {
-        let (env, client, _owner) = setup();
-        let caller = Address::generate(&env);
-        client.create_policy(
-            &caller,
-            &short_name(&env),
-            &CoverageType::Health,
-            &5_000_000i128,
-            &0i128,
-            &None,
-        );
-    }
-
-    #[test]
-    #[should_panic(expected = "coverage_amount must be positive")]
-    fn test_create_policy_negative_coverage_panics() {
-        let (env, client, _owner) = setup();
-        let caller = Address::generate(&env);
-        client.create_policy(
-            &caller,
-            &short_name(&env),
-            &CoverageType::Health,
-            &5_000_000i128,
-            &-1i128,
-            &None,
-        );
-    }
-
-    #[test]
-    #[should_panic(expected = "coverage_amount out of range for coverage type")]
-    fn test_create_health_policy_coverage_below_min_panics() {
-        let (env, client, _owner) = setup();
-        let caller = Address::generate(&env);
-        // Health min_coverage = 10_000_000; supply 9_999_999
-        client.create_policy(
-            &caller,
-            &short_name(&env),
-            &CoverageType::Health,
-            &5_000_000i128,
-            &9_999_999i128,
-            &None,
-        );
-    }
-
-    #[test]
-    #[should_panic(expected = "coverage_amount out of range for coverage type")]
-    fn test_create_health_policy_coverage_above_max_panics() {
-        let (env, client, _owner) = setup();
-        let caller = Address::generate(&env);
-        // Health max_coverage = 100_000_000_000; supply 100_000_000_001
-        client.create_policy(
-            &caller,
-            &short_name(&env),
-            &CoverageType::Health,
-            &500_000_000i128,
-            &100_000_000_001i128,
-            &None,
-        );
-    }
-
-    #[test]
-    #[should_panic(expected = "coverage_amount out of range for coverage type")]
-    fn test_create_life_policy_coverage_below_min_panics() {
-        let (env, client, _owner) = setup();
-        let caller = Address::generate(&env);
-        // Life min_coverage = 50_000_000; supply 49_999_999
-        client.create_policy(
-            &caller,
-            &String::from_str(&env, "Life"),
-            &CoverageType::Life,
-            &1_000_000i128,
-            &49_999_999i128,
-            &None,
-        );
-    }
-
-    #[test]
-    #[should_panic(expected = "coverage_amount out of range for coverage type")]
-    fn test_create_property_policy_coverage_below_min_panics() {
-        let (env, client, _owner) = setup();
-        let caller = Address::generate(&env);
-        // Property min_coverage = 100_000_000; supply 99_999_999
-        client.create_policy(
-            &caller,
-            &String::from_str(&env, "Property"),
-            &CoverageType::Property,
-            &5_000_000i128,
-            &99_999_999i128,
-            &None,
-        );
-    }
-
-    // -----------------------------------------------------------------------
-    // 7. create_policy — ratio guard (unsupported combination)
-    // -----------------------------------------------------------------------
-
-    #[test]
-    #[should_panic(expected = "unsupported combination: coverage_amount too high relative to premium")]
-    fn test_create_policy_coverage_too_high_for_premium_panics() {
-        let (env, client, _owner) = setup();
-        let caller = Address::generate(&env);
-        // premium = 1_000_000 → annual = 12_000_000 → max_coverage = 6_000_000_000
-        // supply coverage = 6_000_000_001 (just over the ratio limit, but within Health's hard max)
-        // Need premium high enough so health range isn't hit, but ratio is
-        // Health max_coverage = 100_000_000_000
-        // Use premium = 1_000_000, coverage = 7_000_000_000 → over ratio (6B), under hard cap (100B)
-        client.create_policy(
-            &caller,
-            &short_name(&env),
-            &CoverageType::Health,
-            &1_000_000i128,
-            &7_000_000_000i128,
-            &None,
-        );
-    }
-
-    #[test]
-    fn test_create_policy_coverage_exactly_at_ratio_limit_succeeds() {
-        let (env, client, _owner) = setup();
-        let caller = Address::generate(&env);
-        // premium = 1_000_000 → ratio limit = 1M * 12 * 500 = 6_000_000_000
-        // Health max_coverage = 100B, so 6B is fine
-        client.create_policy(
-            &caller,
-            &short_name(&env),
-            &CoverageType::Health,
-            &1_000_000i128,
-            &6_000_000_000i128,
-            &None,
-        );
-    }
-
-    // -----------------------------------------------------------------------
-    // 8. External ref validation
-    // -----------------------------------------------------------------------
-
-    #[test]
-    #[should_panic(expected = "external_ref length out of range")]
-    fn test_create_policy_ext_ref_too_long_panics() {
-        let (env, client, _owner) = setup();
-        let caller = Address::generate(&env);
-        // 129 character external ref — exceeds MAX_EXT_REF_LEN (128)
-        let long_ref = String::from_str(
-            &env,
-            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1",
-        );
-        client.create_policy(
-            &caller,
-            &short_name(&env),
-            &CoverageType::Health,
-            &5_000_000i128,
-            &50_000_000i128,
-            &Some(long_ref),
-        );
-    }
-
-    #[test]
-    fn test_create_policy_ext_ref_at_max_length_succeeds() {
-        let (env, client, _owner) = setup();
-        let caller = Address::generate(&env);
-        // Exactly 128 characters
-        let max_ref = String::from_str(
-            &env,
-            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-        );
-        client.create_policy(
-            &caller,
-            &short_name(&env),
-            &CoverageType::Health,
-            &5_000_000i128,
-            &50_000_000i128,
-            &Some(max_ref),
-        );
-    }
-
-    // -----------------------------------------------------------------------
-    // 9. pay_premium — happy path
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn test_pay_premium_success() {
-        let (env, client, _owner) = setup();
-        let caller = Address::generate(&env);
-        let id = client.create_policy(
-            &caller,
-            &short_name(&env),
-            &CoverageType::Health,
-            &5_000_000i128,
-            &50_000_000i128,
-            &None,
-        );
-        let result = client.pay_premium(&caller, &id, &5_000_000i128);
-        assert!(result);
-    }
-
-    #[test]
-    fn test_pay_premium_updates_next_payment_date() {
-        let (env, client, _owner) = setup();
-        let caller = Address::generate(&env);
-        env.ledger().set_timestamp(1_000_000u64);
-        let id = client.create_policy(
-            &caller,
-            &short_name(&env),
-            &CoverageType::Health,
-            &5_000_000i128,
-            &50_000_000i128,
-            &None,
-        );
-        env.ledger().set_timestamp(2_000_000u64);
-        client.pay_premium(&caller, &id, &5_000_000i128);
-        let policy = client.get_policy(&id);
-        // next_payment_due should be 2_000_000 + 30 days
-        assert_eq!(policy.next_payment_due, 2_000_000 + 30 * 24 * 60 * 60);
-        assert_eq!(policy.last_payment_at, 2_000_000u64);
-    }
-
-    // -----------------------------------------------------------------------
-    // 10. pay_premium — failure cases
-    // -----------------------------------------------------------------------
-
-    #[test]
-    #[should_panic(expected = "policy not found")]
-    fn test_pay_premium_nonexistent_policy_panics() {
-        let (env, client, _owner) = setup();
-        let caller = Address::generate(&env);
-        client.pay_premium(&caller, &999u32, &5_000_000i128);
-    }
-
-    #[test]
-    #[should_panic(expected = "amount must equal monthly_premium")]
-    fn test_pay_premium_wrong_amount_panics() {
-        let (env, client, _owner) = setup();
-        let caller = Address::generate(&env);
-        let id = client.create_policy(
-            &caller,
-            &short_name(&env),
-            &CoverageType::Health,
-            &5_000_000i128,
-            &50_000_000i128,
-            &None,
-        );
-        client.pay_premium(&caller, &id, &4_999_999i128);
-    }
-
-    #[test]
-    #[should_panic(expected = "policy inactive")]
-    fn test_pay_premium_on_inactive_policy_panics() {
-        let (env, client, owner) = setup();
-        let caller = Address::generate(&env);
-        let id = client.create_policy(
-            &caller,
-            &short_name(&env),
-            &CoverageType::Health,
-            &5_000_000i128,
-            &50_000_000i128,
-            &None,
-        );
-        client.deactivate_policy(&owner, &id);
-        client.pay_premium(&caller, &id, &5_000_000i128);
-    }
-
-    // -----------------------------------------------------------------------
-    // 11. deactivate_policy — happy path
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn test_deactivate_policy_success() {
-        let (env, client, owner) = setup();
-        let caller = Address::generate(&env);
-        let id = client.create_policy(
-            &caller,
-            &short_name(&env),
-            &CoverageType::Health,
-            &5_000_000i128,
-            &50_000_000i128,
-            &None,
-        );
-        let result = client.deactivate_policy(&owner, &id);
-        assert!(result);
-
-        let policy = client.get_policy(&id);
-        assert!(!policy.active);
-    }
-
-    #[test]
-    fn test_deactivate_removes_from_active_list() {
-        let (env, client, owner) = setup();
-        let caller = Address::generate(&env);
-        let id = client.create_policy(
-            &caller,
-            &short_name(&env),
-            &CoverageType::Health,
-            &5_000_000i128,
-            &50_000_000i128,
-            &None,
-        );
-        assert_eq!(client.get_active_policies().len(), 1);
-        client.deactivate_policy(&owner, &id);
-        assert_eq!(client.get_active_policies().len(), 0);
-    }
-
-    // -----------------------------------------------------------------------
-    // 12. deactivate_policy — failure cases
-    // -----------------------------------------------------------------------
-
-    #[test]
-    #[should_panic(expected = "unauthorized")]
-    fn test_deactivate_policy_non_owner_panics() {
-        let (env, client, _owner) = setup();
-        let caller = Address::generate(&env);
-        let id = client.create_policy(
-            &caller,
-            &short_name(&env),
-            &CoverageType::Health,
-            &5_000_000i128,
-            &50_000_000i128,
-            &None,
-        );
-        let non_owner = Address::generate(&env);
-        client.deactivate_policy(&non_owner, &id);
-    }
-
-    #[test]
-    #[should_panic(expected = "policy not found")]
-    fn test_deactivate_nonexistent_policy_panics() {
-        let (_env, client, owner) = setup();
-        client.deactivate_policy(&owner, &999u32);
-    }
-
-    #[test]
-    #[should_panic(expected = "policy already inactive")]
-    fn test_deactivate_already_inactive_policy_panics() {
-        let (env, client, owner) = setup();
-        let caller = Address::generate(&env);
-        let id = client.create_policy(
-            &caller,
-            &short_name(&env),
-            &CoverageType::Health,
-            &5_000_000i128,
-            &50_000_000i128,
-            &None,
-        );
-        client.deactivate_policy(&owner, &id);
-        // Second deactivation must panic
-        client.deactivate_policy(&owner, &id);
-    }
-
-    // -----------------------------------------------------------------------
-    // 13. set_external_ref
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn test_set_external_ref_success() {
-        let (env, client, owner) = setup();
-        let caller = Address::generate(&env);
-        let id = client.create_policy(
-            &caller,
-            &short_name(&env),
-            &CoverageType::Health,
-            &5_000_000i128,
-            &50_000_000i128,
-            &None,
-        );
-        let new_ref = String::from_str(&env, "NEW-REF-001");
-        client.set_external_ref(&owner, &id, &Some(new_ref));
-        let policy = client.get_policy(&id);
-        assert!(policy.external_ref.is_some());
-    }
-
-    #[test]
-    fn test_set_external_ref_clear() {
-        let (env, client, owner) = setup();
-        let caller = Address::generate(&env);
-        let ext_ref = String::from_str(&env, "INITIAL-REF");
-        let id = client.create_policy(
-            &caller,
-            &short_name(&env),
-            &CoverageType::Health,
-            &5_000_000i128,
-            &50_000_000i128,
-            &Some(ext_ref),
-        );
-        // Clear the ref
-        client.set_external_ref(&owner, &id, &None);
-        let policy = client.get_policy(&id);
-        assert!(policy.external_ref.is_none());
-    }
-
-    #[test]
-    #[should_panic(expected = "unauthorized")]
-    fn test_set_external_ref_non_owner_panics() {
-        let (env, client, _owner) = setup();
-        let caller = Address::generate(&env);
-        let id = client.create_policy(
-            &caller,
-            &short_name(&env),
-            &CoverageType::Health,
-            &5_000_000i128,
-            &50_000_000i128,
-            &None,
-        );
-        let non_owner = Address::generate(&env);
-        let new_ref = String::from_str(&env, "HACK");
-        client.set_external_ref(&non_owner, &id, &Some(new_ref));
-    }
-
-    #[test]
-    #[should_panic(expected = "external_ref length out of range")]
-    fn test_set_external_ref_too_long_panics() {
-        let (env, client, owner) = setup();
-        let caller = Address::generate(&env);
-        let id = client.create_policy(
-            &caller,
-            &short_name(&env),
-            &CoverageType::Health,
-            &5_000_000i128,
-            &50_000_000i128,
-            &None,
-        );
-        let long_ref = String::from_str(
-            &env,
-            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1",
-        );
-        client.set_external_ref(&owner, &id, &Some(long_ref));
-    }
-
-    // -----------------------------------------------------------------------
-    // 14. Queries
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn test_get_active_policies_empty_initially() {
-        let (_env, client, _owner) = setup();
-        assert_eq!(client.get_active_policies().len(), 0);
-    }
-
-    #[test]
-    fn test_get_active_policies_reflects_creates_and_deactivations() {
-        let (env, client, owner) = setup();
-        let caller = Address::generate(&env);
-        let id1 = client.create_policy(
-            &caller,
-            &short_name(&env),
-            &CoverageType::Health,
-            &5_000_000i128,
-            &50_000_000i128,
-            &None,
-        );
-        client.create_policy(
-            &caller,
-            &String::from_str(&env, "Second Policy"),
-            &CoverageType::Life,
-            &1_000_000i128,
-            &60_000_000i128,
-            &None,
-        );
-        assert_eq!(client.get_active_policies().len(), 2);
-        client.deactivate_policy(&owner, &id1);
-        assert_eq!(client.get_active_policies().len(), 1);
-    }
-
-    #[test]
-    fn test_get_total_monthly_premium_sums_active_only() {
-        let (env, client, owner) = setup();
-        let caller = Address::generate(&env);
-        let id1 = client.create_policy(
-            &caller,
-            &short_name(&env),
-            &CoverageType::Health,
-            &5_000_000i128,
-            &50_000_000i128,
-            &None,
-        );
-        client.create_policy(
-            &caller,
-            &String::from_str(&env, "Second"),
-            &CoverageType::Life,
-            &1_000_000i128,
-            &60_000_000i128,
-            &None,
-        );
-        assert_eq!(client.get_total_monthly_premium(), 6_000_000i128);
-        client.deactivate_policy(&owner, &id1);
-        assert_eq!(client.get_total_monthly_premium(), 1_000_000i128);
-    }
-
-    #[test]
-    fn test_get_total_monthly_premium_zero_when_no_policies() {
-        let (_env, client, _owner) = setup();
-        assert_eq!(client.get_total_monthly_premium(), 0i128);
-    }
-
-    #[test]
-    #[should_panic(expected = "policy not found")]
-    fn test_get_policy_nonexistent_panics() {
-        let (_env, client, _owner) = setup();
-        client.get_policy(&999u32);
-    }
-
-    // -----------------------------------------------------------------------
-    // 15. Uninitialized contract guard
-    // -----------------------------------------------------------------------
-
-    #[test]
-    #[should_panic(expected = "not initialized")]
-    fn test_create_policy_without_init_panics() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let contract_id = env.register_contract(None, InsuranceContract);
-        let client = InsuranceContractClient::new(&env, &contract_id);
-        let caller = Address::generate(&env);
-        client.create_policy(
-            &caller,
-            &String::from_str(&env, "Test"),
-            &CoverageType::Health,
-            &5_000_000i128,
-            &50_000_000i128,
-            &None,
-        );
-    }
-
-    #[test]
-    #[should_panic(expected = "not initialized")]
-    fn test_get_active_policies_without_init_panics() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let contract_id = env.register_contract(None, InsuranceContract);
-        let client = InsuranceContractClient::new(&env, &contract_id);
-        client.get_active_policies();
-    }
-
-    // -----------------------------------------------------------------------
-    // 16. Policy data integrity
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn test_policy_fields_stored_correctly() {
-        let (env, client, _owner) = setup();
-        let caller = Address::generate(&env);
-        env.ledger().set_timestamp(1_700_000_000u64);
-        let id = client.create_policy(
-            &caller,
-            &String::from_str(&env, "My Health Plan"),
-            &CoverageType::Health,
-            &10_000_000i128,
-            &100_000_000i128,
-            &Some(String::from_str(&env, "EXT-001")),
-        );
-        let policy = client.get_policy(&id);
-        assert_eq!(policy.id, 1u32);
-        assert_eq!(policy.monthly_premium, 10_000_000i128);
-        assert_eq!(policy.coverage_amount, 100_000_000i128);
-        assert!(policy.active);
-        assert_eq!(policy.last_payment_at, 0u64);
-        assert_eq!(policy.created_at, 1_700_000_000u64);
-        assert_eq!(
-            policy.next_payment_due,
-            1_700_000_000u64 + 30 * 24 * 60 * 60
-        );
-        assert!(policy.external_ref.is_some());
-    }
-
-    // -----------------------------------------------------------------------
-    // 17. Cross-coverage-type boundary checks
-    // -----------------------------------------------------------------------
-
-    #[test]
-    #[should_panic(expected = "monthly_premium out of range for coverage type")]
-    fn test_property_premium_above_max_panics() {
-        let (env, client, _owner) = setup();
-        let caller = Address::generate(&env);
-        // Property max_premium = 2_000_000_000; supply 2_000_000_001
-        client.create_policy(
-            &caller,
-            &String::from_str(&env, "Property"),
-            &CoverageType::Property,
-            &2_000_000_001i128,
-            &100_000_000i128,
-            &None,
-        );
-    }
-
-    #[test]
-    #[should_panic(expected = "monthly_premium out of range for coverage type")]
-    fn test_auto_premium_above_max_panics() {
-        let (env, client, _owner) = setup();
-        let caller = Address::generate(&env);
-        // Auto max_premium = 750_000_000; supply 750_000_001
-        client.create_policy(
-            &caller,
-            &String::from_str(&env, "Auto"),
-            &CoverageType::Auto,
-            &750_000_001i128,
-            &20_000_000i128,
-            &None,
-        );
-    }
-
-    #[test]
-    #[should_panic(expected = "monthly_premium out of range for coverage type")]
-    fn test_liability_premium_above_max_panics() {
-        let (env, client, _owner) = setup();
-        let caller = Address::generate(&env);
-        // Liability max_premium = 400_000_000; supply 400_000_001
-        client.create_policy(
-            &caller,
-            &String::from_str(&env, "Liability"),
-            &CoverageType::Liability,
-            &400_000_001i128,
-            &5_000_000i128,
-            &None,
-        );
-    }
-
-    #[test]
-    #[should_panic(expected = "coverage_amount out of range for coverage type")]
-    fn test_life_coverage_above_max_panics() {
-        let (env, client, _owner) = setup();
-        let caller = Address::generate(&env);
-        // Life max_coverage = 500_000_000_000; supply 500_000_000_001
-        client.create_policy(
-            &caller,
-            &String::from_str(&env, "Life"),
-            &CoverageType::Life,
-            &1_000_000_000i128, // max premium for Life
-            &500_000_000_001i128,
-            &None,
-        );
-    }
-
-    #[test]
-    #[should_panic(expected = "coverage_amount out of range for coverage type")]
-    fn test_auto_coverage_above_max_panics() {
-        let (env, client, _owner) = setup();
-        let caller = Address::generate(&env);
-        // Auto max_coverage = 200_000_000_000; supply 200_000_000_001
-        client.create_policy(
-            &caller,
-            &String::from_str(&env, "Auto"),
-            &CoverageType::Auto,
-            &750_000_000i128,
-            &200_000_000_001i128,
-            &None,
-        );
-    }
-
-    #[test]
-    #[should_panic(expected = "coverage_amount out of range for coverage type")]
-    fn test_liability_coverage_above_max_panics() {
-        let (env, client, _owner) = setup();
-        let caller = Address::generate(&env);
-        // Liability max_coverage = 50_000_000_000; supply 50_000_000_001
-        client.create_policy(
-            &caller,
-            &String::from_str(&env, "Liability"),
-            &CoverageType::Liability,
-            &400_000_000i128,
-            &50_000_000_001i128,
-            &None,
-        );
-    }
+    let caller = Address::generate(&env);
+    client.deactivate_policy(&caller, &1u32);
 }

--- a/insurance/test_snapshots/test/test_create_policy_negative_coverage_panics.1.json
+++ b/insurance/test_snapshots/test/test_create_policy_negative_coverage_panics.1.json
@@ -1,9 +1,10 @@
 {
   "generators": {
-    "address": 2,
+    "address": 3,
     "nonce": 0
   },
   "auth": [
+    [],
     []
   ],
   "ledger": {
@@ -38,14 +39,63 @@
                     "executable": {
                       "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                     },
-                    "storage": null
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ActivePolicies"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": []
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Initialized"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Owner"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "PolicyCount"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 0
+                        }
+                      }
+                    ]
                   }
                 }
               }
             },
             "ext": "v0"
           },
-          4095
+          518400
         ]
       ],
       [
@@ -66,12 +116,59 @@
             },
             "ext": "v0"
           },
-          4095
+          518400
         ]
       ]
     ]
   },
   "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "init"
+              }
+            ],
+            "data": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "init"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
     {
       "event": {
         "ext": "v0",
@@ -93,18 +190,18 @@
             "data": {
               "vec": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
-                  "string": "Test Policy"
+                  "string": "P"
                 },
                 {
-                  "string": "health"
+                  "u32": 1
                 },
                 {
                   "i128": {
                     "hi": 0,
-                    "lo": 100
+                    "lo": 5000000
                   }
                 },
                 {
@@ -129,16 +226,36 @@
           "v0": {
             "topics": [
               {
-                "symbol": "fn_return"
-              },
-              {
-                "symbol": "create_policy"
+                "symbol": "log"
               }
             ],
             "data": {
-              "error": {
-                "contract": 2
-              }
+              "vec": [
+                {
+                  "string": "caught panic 'coverage_amount must be positive' from contract function 'Symbol(obj#35)'"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "string": "P"
+                },
+                {
+                  "u32": 1
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 5000000
+                  }
+                },
+                {
+                  "i128": {
+                    "hi": -1,
+                    "lo": 18446744073709551615
+                  }
+                }
+              ]
             }
           }
         }
@@ -158,12 +275,12 @@
               },
               {
                 "error": {
-                  "contract": 2
+                  "wasm_vm": "invalid_action"
                 }
               }
             ],
             "data": {
-              "string": "escalating Ok(ScErrorType::Contract) frame-exit to Err"
+              "string": "caught error from function"
             }
           }
         }
@@ -183,14 +300,14 @@
               },
               {
                 "error": {
-                  "contract": 2
+                  "wasm_vm": "invalid_action"
                 }
               }
             ],
             "data": {
               "vec": [
                 {
-                  "string": "contract try_call failed"
+                  "string": "contract call failed"
                 },
                 {
                   "symbol": "create_policy"
@@ -198,18 +315,18 @@
                 {
                   "vec": [
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                     },
                     {
-                      "string": "Test Policy"
+                      "string": "P"
                     },
                     {
-                      "string": "health"
+                      "u32": 1
                     },
                     {
                       "i128": {
                         "hi": 0,
-                        "lo": 100
+                        "lo": 5000000
                       }
                     },
                     {
@@ -221,6 +338,31 @@
                   ]
                 }
               ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "error"
+              },
+              {
+                "error": {
+                  "wasm_vm": "invalid_action"
+                }
+              }
+            ],
+            "data": {
+              "string": "escalating error to panic"
             }
           }
         }

--- a/insurance/test_snapshots/test/test_create_policy_negative_premium_panics.1.json
+++ b/insurance/test_snapshots/test/test_create_policy_negative_premium_panics.1.json
@@ -1,9 +1,10 @@
 {
   "generators": {
-    "address": 2,
+    "address": 3,
     "nonce": 0
   },
   "auth": [
+    [],
     []
   ],
   "ledger": {
@@ -38,14 +39,63 @@
                     "executable": {
                       "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                     },
-                    "storage": null
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ActivePolicies"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": []
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Initialized"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Owner"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "PolicyCount"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 0
+                        }
+                      }
+                    ]
                   }
                 }
               }
             },
             "ext": "v0"
           },
-          4095
+          518400
         ]
       ],
       [
@@ -66,12 +116,59 @@
             },
             "ext": "v0"
           },
-          4095
+          518400
         ]
       ]
     ]
   },
   "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "init"
+              }
+            ],
+            "data": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "init"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
     {
       "event": {
         "ext": "v0",
@@ -93,13 +190,13 @@
             "data": {
               "vec": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
-                  "string": "Test Policy"
+                  "string": "P"
                 },
                 {
-                  "string": "health"
+                  "u32": 1
                 },
                 {
                   "i128": {
@@ -110,7 +207,7 @@
                 {
                   "i128": {
                     "hi": 0,
-                    "lo": 10000
+                    "lo": 50000000
                   }
                 }
               ]
@@ -129,16 +226,36 @@
           "v0": {
             "topics": [
               {
-                "symbol": "fn_return"
-              },
-              {
-                "symbol": "create_policy"
+                "symbol": "log"
               }
             ],
             "data": {
-              "error": {
-                "contract": 1
-              }
+              "vec": [
+                {
+                  "string": "caught panic 'monthly_premium must be positive' from contract function 'Symbol(obj#35)'"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "string": "P"
+                },
+                {
+                  "u32": 1
+                },
+                {
+                  "i128": {
+                    "hi": -1,
+                    "lo": 18446744073709551615
+                  }
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 50000000
+                  }
+                }
+              ]
             }
           }
         }
@@ -158,12 +275,12 @@
               },
               {
                 "error": {
-                  "contract": 1
+                  "wasm_vm": "invalid_action"
                 }
               }
             ],
             "data": {
-              "string": "escalating Ok(ScErrorType::Contract) frame-exit to Err"
+              "string": "caught error from function"
             }
           }
         }
@@ -183,14 +300,14 @@
               },
               {
                 "error": {
-                  "contract": 1
+                  "wasm_vm": "invalid_action"
                 }
               }
             ],
             "data": {
               "vec": [
                 {
-                  "string": "contract try_call failed"
+                  "string": "contract call failed"
                 },
                 {
                   "symbol": "create_policy"
@@ -198,13 +315,13 @@
                 {
                   "vec": [
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                     },
                     {
-                      "string": "Test Policy"
+                      "string": "P"
                     },
                     {
-                      "string": "health"
+                      "u32": 1
                     },
                     {
                       "i128": {
@@ -215,12 +332,37 @@
                     {
                       "i128": {
                         "hi": 0,
-                        "lo": 10000
+                        "lo": 50000000
                       }
                     }
                   ]
                 }
               ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "error"
+              },
+              {
+                "error": {
+                  "wasm_vm": "invalid_action"
+                }
+              }
+            ],
+            "data": {
+              "string": "escalating error to panic"
             }
           }
         }

--- a/insurance/test_snapshots/test/test_create_policy_success.1.json
+++ b/insurance/test_snapshots/test/test_create_policy_success.1.json
@@ -1,12 +1,13 @@
 {
   "generators": {
-    "address": 2,
+    "address": 3,
     "nonce": 0
   },
   "auth": [
+    [],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
         {
           "function": {
             "contract_fn": {
@@ -14,24 +15,24 @@
               "function_name": "create_policy",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
-                  "string": "Test Policy"
+                  "string": "Health Policy"
                 },
                 {
-                  "string": "health"
+                  "u32": 1
                 },
                 {
                   "i128": {
                     "hi": 0,
-                    "lo": 100
+                    "lo": 5000000
                   }
                 },
                 {
                   "i128": {
                     "hi": 0,
-                    "lo": 10000
+                    "lo": 100000000
                   }
                 }
               ]
@@ -78,124 +79,181 @@
                     "storage": [
                       {
                         "key": {
-                          "symbol": "NEXT_ID"
-                        },
-                        "val": {
-                          "u32": 1
-                        }
-                      },
-                      {
-                        "key": {
-                          "symbol": "POLICIES"
-                        },
-                        "val": {
-                          "map": [
+                          "vec": [
                             {
-                              "key": {
-                                "u32": 1
-                              },
-                              "val": {
-                                "map": [
-                                  {
-                                    "key": {
-                                      "symbol": "active"
-                                    },
-                                    "val": {
-                                      "bool": true
-                                    }
-                                  },
-                                  {
-                                    "key": {
-                                      "symbol": "coverage_amount"
-                                    },
-                                    "val": {
-                                      "i128": {
-                                        "hi": 0,
-                                        "lo": 10000
-                                      }
-                                    }
-                                  },
-                                  {
-                                    "key": {
-                                      "symbol": "coverage_type"
-                                    },
-                                    "val": {
-                                      "string": "health"
-                                    }
-                                  },
-                                  {
-                                    "key": {
-                                      "symbol": "id"
-                                    },
-                                    "val": {
-                                      "u32": 1
-                                    }
-                                  },
-                                  {
-                                    "key": {
-                                      "symbol": "monthly_premium"
-                                    },
-                                    "val": {
-                                      "i128": {
-                                        "hi": 0,
-                                        "lo": 100
-                                      }
-                                    }
-                                  },
-                                  {
-                                    "key": {
-                                      "symbol": "name"
-                                    },
-                                    "val": {
-                                      "string": "Test Policy"
-                                    }
-                                  },
-                                  {
-                                    "key": {
-                                      "symbol": "next_payment_date"
-                                    },
-                                    "val": {
-                                      "u64": 2592000
-                                    }
-                                  },
-                                  {
-                                    "key": {
-                                      "symbol": "owner"
-                                    },
-                                    "val": {
-                                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                                    }
-                                  },
-                                  {
-                                    "key": {
-                                      "symbol": "schedule_id"
-                                    },
-                                    "val": "void"
-                                  }
-                                ]
-                              }
+                              "symbol": "ActivePolicies"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "u32": 1
                             }
                           ]
                         }
                       },
                       {
                         "key": {
-                          "symbol": "PRM_TOT"
+                          "vec": [
+                            {
+                              "symbol": "Initialized"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Owner"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "OwnerPolicies"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "u32": 1
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Policy"
+                            },
+                            {
+                              "u32": 1
+                            }
+                          ]
                         },
                         "val": {
                           "map": [
                             {
                               "key": {
-                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                                "symbol": "active"
+                              },
+                              "val": {
+                                "bool": true
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "coverage_amount"
                               },
                               "val": {
                                 "i128": {
                                   "hi": 0,
-                                  "lo": 100
+                                  "lo": 100000000
                                 }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "coverage_type"
+                              },
+                              "val": {
+                                "u32": 1
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "created_at"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "external_ref"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
+                                "symbol": "id"
+                              },
+                              "val": {
+                                "u32": 1
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "last_payment_at"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "monthly_premium"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 5000000
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "name"
+                              },
+                              "val": {
+                                "string": "Health Policy"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "next_payment_date"
+                              },
+                              "val": {
+                                "u64": 2592000
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "owner"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                               }
                             }
                           ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "PolicyCount"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 1
                         }
                       }
                     ]
@@ -211,7 +269,7 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
             "key": {
               "ledger_key_nonce": {
                 "nonce": 801925984706572462
@@ -226,7 +284,7 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 801925984706572462
@@ -280,30 +338,77 @@
                 "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
               },
               {
+                "symbol": "init"
+              }
+            ],
+            "data": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "init"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
                 "symbol": "create_policy"
               }
             ],
             "data": {
               "vec": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
-                  "string": "Test Policy"
+                  "string": "Health Policy"
                 },
                 {
-                  "string": "health"
+                  "u32": 1
                 },
                 {
                   "i128": {
                     "hi": 0,
-                    "lo": 100
+                    "lo": 5000000
                   }
                 },
                 {
                   "i128": {
                     "hi": 0,
-                    "lo": 10000
+                    "lo": 100000000
                   }
                 }
               ]
@@ -323,6 +428,9 @@
             "topics": [
               {
                 "symbol": "created"
+              },
+              {
+                "symbol": "policy"
               }
             ],
             "data": {
@@ -334,7 +442,7 @@
                   "val": {
                     "i128": {
                       "hi": 0,
-                      "lo": 10000
+                      "lo": 100000000
                     }
                   }
                 },
@@ -343,7 +451,7 @@
                     "symbol": "coverage_type"
                   },
                   "val": {
-                    "string": "health"
+                    "u32": 1
                   }
                 },
                 {
@@ -353,7 +461,7 @@
                   "val": {
                     "i128": {
                       "hi": 0,
-                      "lo": 100
+                      "lo": 5000000
                     }
                   }
                 },
@@ -362,7 +470,7 @@
                     "symbol": "name"
                   },
                   "val": {
-                    "string": "Test Policy"
+                    "string": "Health Policy"
                   }
                 },
                 {
@@ -380,40 +488,6 @@
                   "val": {
                     "u64": 0
                   }
-                }
-              ]
-            }
-          }
-        }
-      },
-      "failed_call": false
-    },
-    {
-      "event": {
-        "ext": "v0",
-        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
-        "type_": "contract",
-        "body": {
-          "v0": {
-            "topics": [
-              {
-                "symbol": "insure"
-              },
-              {
-                "vec": [
-                  {
-                    "symbol": "PolicyCreated"
-                  }
-                ]
-              }
-            ],
-            "data": {
-              "vec": [
-                {
-                  "u32": 1
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 }
               ]
             }
@@ -503,7 +577,7 @@
                   "val": {
                     "i128": {
                       "hi": 0,
-                      "lo": 10000
+                      "lo": 100000000
                     }
                   }
                 },
@@ -512,8 +586,22 @@
                     "symbol": "coverage_type"
                   },
                   "val": {
-                    "string": "health"
+                    "u32": 1
                   }
+                },
+                {
+                  "key": {
+                    "symbol": "created_at"
+                  },
+                  "val": {
+                    "u64": 0
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "external_ref"
+                  },
+                  "val": "void"
                 },
                 {
                   "key": {
@@ -525,12 +613,20 @@
                 },
                 {
                   "key": {
+                    "symbol": "last_payment_at"
+                  },
+                  "val": {
+                    "u64": 0
+                  }
+                },
+                {
+                  "key": {
                     "symbol": "monthly_premium"
                   },
                   "val": {
                     "i128": {
                       "hi": 0,
-                      "lo": 100
+                      "lo": 5000000
                     }
                   }
                 },
@@ -539,7 +635,7 @@
                     "symbol": "name"
                   },
                   "val": {
-                    "string": "Test Policy"
+                    "string": "Health Policy"
                   }
                 },
                 {
@@ -555,14 +651,8 @@
                     "symbol": "owner"
                   },
                   "val": {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                   }
-                },
-                {
-                  "key": {
-                    "symbol": "schedule_id"
-                  },
-                  "val": "void"
                 }
               ]
             }

--- a/insurance/test_snapshots/test/test_get_active_policies_excludes_deactivated.1.json
+++ b/insurance/test_snapshots/test/test_get_active_policies_excludes_deactivated.1.json
@@ -1,12 +1,13 @@
 {
   "generators": {
-    "address": 2,
+    "address": 3,
     "nonce": 0
   },
   "auth": [
+    [],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
         {
           "function": {
             "contract_fn": {
@@ -14,24 +15,24 @@
               "function_name": "create_policy",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
-                  "string": "Policy 1"
+                  "string": "P"
                 },
                 {
-                  "string": "Type 1"
+                  "u32": 1
                 },
                 {
                   "i128": {
                     "hi": 0,
-                    "lo": 100
+                    "lo": 5000000
                   }
                 },
                 {
                   "i128": {
                     "hi": 0,
-                    "lo": 1000
+                    "lo": 10000000
                   }
                 }
               ]
@@ -43,7 +44,7 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
         {
           "function": {
             "contract_fn": {
@@ -51,24 +52,24 @@
               "function_name": "create_policy",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
-                  "string": "Policy 2"
+                  "string": "P"
                 },
                 {
-                  "string": "Type 2"
+                  "u32": 2
                 },
                 {
                   "i128": {
                     "hi": 0,
-                    "lo": 200
+                    "lo": 1000000
                   }
                 },
                 {
                   "i128": {
                     "hi": 0,
-                    "lo": 2000
+                    "lo": 60000000
                   }
                 }
               ]
@@ -80,7 +81,7 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
         {
           "function": {
             "contract_fn": {
@@ -88,7 +89,7 @@
               "function_name": "deactivate_policy",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
                   "u32": 1
@@ -137,186 +138,169 @@
                     "storage": [
                       {
                         "key": {
-                          "symbol": "NEXT_ID"
+                          "vec": [
+                            {
+                              "symbol": "ActivePolicies"
+                            }
+                          ]
                         },
                         "val": {
-                          "u32": 2
+                          "vec": [
+                            {
+                              "u32": 2
+                            }
+                          ]
                         }
                       },
                       {
                         "key": {
-                          "symbol": "POLICIES"
+                          "vec": [
+                            {
+                              "symbol": "Initialized"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Owner"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "OwnerPolicies"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "u32": 1
+                            },
+                            {
+                              "u32": 2
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Policy"
+                            },
+                            {
+                              "u32": 1
+                            }
+                          ]
                         },
                         "val": {
                           "map": [
                             {
                               "key": {
-                                "u32": 1
+                                "symbol": "active"
                               },
                               "val": {
-                                "map": [
-                                  {
-                                    "key": {
-                                      "symbol": "active"
-                                    },
-                                    "val": {
-                                      "bool": false
-                                    }
-                                  },
-                                  {
-                                    "key": {
-                                      "symbol": "coverage_amount"
-                                    },
-                                    "val": {
-                                      "i128": {
-                                        "hi": 0,
-                                        "lo": 1000
-                                      }
-                                    }
-                                  },
-                                  {
-                                    "key": {
-                                      "symbol": "coverage_type"
-                                    },
-                                    "val": {
-                                      "string": "Type 1"
-                                    }
-                                  },
-                                  {
-                                    "key": {
-                                      "symbol": "id"
-                                    },
-                                    "val": {
-                                      "u32": 1
-                                    }
-                                  },
-                                  {
-                                    "key": {
-                                      "symbol": "monthly_premium"
-                                    },
-                                    "val": {
-                                      "i128": {
-                                        "hi": 0,
-                                        "lo": 100
-                                      }
-                                    }
-                                  },
-                                  {
-                                    "key": {
-                                      "symbol": "name"
-                                    },
-                                    "val": {
-                                      "string": "Policy 1"
-                                    }
-                                  },
-                                  {
-                                    "key": {
-                                      "symbol": "next_payment_date"
-                                    },
-                                    "val": {
-                                      "u64": 2592000
-                                    }
-                                  },
-                                  {
-                                    "key": {
-                                      "symbol": "owner"
-                                    },
-                                    "val": {
-                                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                                    }
-                                  },
-                                  {
-                                    "key": {
-                                      "symbol": "schedule_id"
-                                    },
-                                    "val": "void"
-                                  }
-                                ]
+                                "bool": false
                               }
                             },
                             {
                               "key": {
-                                "u32": 2
+                                "symbol": "coverage_amount"
                               },
                               "val": {
-                                "map": [
-                                  {
-                                    "key": {
-                                      "symbol": "active"
-                                    },
-                                    "val": {
-                                      "bool": true
-                                    }
-                                  },
-                                  {
-                                    "key": {
-                                      "symbol": "coverage_amount"
-                                    },
-                                    "val": {
-                                      "i128": {
-                                        "hi": 0,
-                                        "lo": 2000
-                                      }
-                                    }
-                                  },
-                                  {
-                                    "key": {
-                                      "symbol": "coverage_type"
-                                    },
-                                    "val": {
-                                      "string": "Type 2"
-                                    }
-                                  },
-                                  {
-                                    "key": {
-                                      "symbol": "id"
-                                    },
-                                    "val": {
-                                      "u32": 2
-                                    }
-                                  },
-                                  {
-                                    "key": {
-                                      "symbol": "monthly_premium"
-                                    },
-                                    "val": {
-                                      "i128": {
-                                        "hi": 0,
-                                        "lo": 200
-                                      }
-                                    }
-                                  },
-                                  {
-                                    "key": {
-                                      "symbol": "name"
-                                    },
-                                    "val": {
-                                      "string": "Policy 2"
-                                    }
-                                  },
-                                  {
-                                    "key": {
-                                      "symbol": "next_payment_date"
-                                    },
-                                    "val": {
-                                      "u64": 2592000
-                                    }
-                                  },
-                                  {
-                                    "key": {
-                                      "symbol": "owner"
-                                    },
-                                    "val": {
-                                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                                    }
-                                  },
-                                  {
-                                    "key": {
-                                      "symbol": "schedule_id"
-                                    },
-                                    "val": "void"
-                                  }
-                                ]
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 10000000
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "coverage_type"
+                              },
+                              "val": {
+                                "u32": 1
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "created_at"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "external_ref"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
+                                "symbol": "id"
+                              },
+                              "val": {
+                                "u32": 1
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "last_payment_at"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "monthly_premium"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 5000000
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "name"
+                              },
+                              "val": {
+                                "string": "P"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "next_payment_date"
+                              },
+                              "val": {
+                                "u64": 2592000
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "owner"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                               }
                             }
                           ]
@@ -324,22 +308,122 @@
                       },
                       {
                         "key": {
-                          "symbol": "PRM_TOT"
+                          "vec": [
+                            {
+                              "symbol": "Policy"
+                            },
+                            {
+                              "u32": 2
+                            }
+                          ]
                         },
                         "val": {
                           "map": [
                             {
                               "key": {
-                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                                "symbol": "active"
+                              },
+                              "val": {
+                                "bool": true
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "coverage_amount"
                               },
                               "val": {
                                 "i128": {
                                   "hi": 0,
-                                  "lo": 200
+                                  "lo": 60000000
                                 }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "coverage_type"
+                              },
+                              "val": {
+                                "u32": 2
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "created_at"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "external_ref"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
+                                "symbol": "id"
+                              },
+                              "val": {
+                                "u32": 2
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "last_payment_at"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "monthly_premium"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 1000000
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "name"
+                              },
+                              "val": {
+                                "string": "P"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "next_payment_date"
+                              },
+                              "val": {
+                                "u64": 2592000
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "owner"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                               }
                             }
                           ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "PolicyCount"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 2
                         }
                       }
                     ]
@@ -355,7 +439,7 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
             "key": {
               "ledger_key_nonce": {
                 "nonce": 801925984706572462
@@ -370,7 +454,7 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 801925984706572462
@@ -388,7 +472,7 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
             "key": {
               "ledger_key_nonce": {
                 "nonce": 1033654523790656264
@@ -403,7 +487,7 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 1033654523790656264
@@ -421,7 +505,7 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
             "key": {
               "ledger_key_nonce": {
                 "nonce": 5541220902715666415
@@ -436,7 +520,7 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 5541220902715666415
@@ -490,30 +574,77 @@
                 "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
               },
               {
+                "symbol": "init"
+              }
+            ],
+            "data": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "init"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
                 "symbol": "create_policy"
               }
             ],
             "data": {
               "vec": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
-                  "string": "Policy 1"
+                  "string": "P"
                 },
                 {
-                  "string": "Type 1"
+                  "u32": 1
                 },
                 {
                   "i128": {
                     "hi": 0,
-                    "lo": 100
+                    "lo": 5000000
                   }
                 },
                 {
                   "i128": {
                     "hi": 0,
-                    "lo": 1000
+                    "lo": 10000000
                   }
                 }
               ]
@@ -533,6 +664,9 @@
             "topics": [
               {
                 "symbol": "created"
+              },
+              {
+                "symbol": "policy"
               }
             ],
             "data": {
@@ -544,7 +678,7 @@
                   "val": {
                     "i128": {
                       "hi": 0,
-                      "lo": 1000
+                      "lo": 10000000
                     }
                   }
                 },
@@ -553,7 +687,7 @@
                     "symbol": "coverage_type"
                   },
                   "val": {
-                    "string": "Type 1"
+                    "u32": 1
                   }
                 },
                 {
@@ -563,7 +697,7 @@
                   "val": {
                     "i128": {
                       "hi": 0,
-                      "lo": 100
+                      "lo": 5000000
                     }
                   }
                 },
@@ -572,7 +706,7 @@
                     "symbol": "name"
                   },
                   "val": {
-                    "string": "Policy 1"
+                    "string": "P"
                   }
                 },
                 {
@@ -590,40 +724,6 @@
                   "val": {
                     "u64": 0
                   }
-                }
-              ]
-            }
-          }
-        }
-      },
-      "failed_call": false
-    },
-    {
-      "event": {
-        "ext": "v0",
-        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
-        "type_": "contract",
-        "body": {
-          "v0": {
-            "topics": [
-              {
-                "symbol": "insure"
-              },
-              {
-                "vec": [
-                  {
-                    "symbol": "PolicyCreated"
-                  }
-                ]
-              }
-            ],
-            "data": {
-              "vec": [
-                {
-                  "u32": 1
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 }
               ]
             }
@@ -676,24 +776,24 @@
             "data": {
               "vec": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
-                  "string": "Policy 2"
+                  "string": "P"
                 },
                 {
-                  "string": "Type 2"
+                  "u32": 2
                 },
                 {
                   "i128": {
                     "hi": 0,
-                    "lo": 200
+                    "lo": 1000000
                   }
                 },
                 {
                   "i128": {
                     "hi": 0,
-                    "lo": 2000
+                    "lo": 60000000
                   }
                 }
               ]
@@ -713,6 +813,9 @@
             "topics": [
               {
                 "symbol": "created"
+              },
+              {
+                "symbol": "policy"
               }
             ],
             "data": {
@@ -724,7 +827,7 @@
                   "val": {
                     "i128": {
                       "hi": 0,
-                      "lo": 2000
+                      "lo": 60000000
                     }
                   }
                 },
@@ -733,7 +836,7 @@
                     "symbol": "coverage_type"
                   },
                   "val": {
-                    "string": "Type 2"
+                    "u32": 2
                   }
                 },
                 {
@@ -743,7 +846,7 @@
                   "val": {
                     "i128": {
                       "hi": 0,
-                      "lo": 200
+                      "lo": 1000000
                     }
                   }
                 },
@@ -752,7 +855,7 @@
                     "symbol": "name"
                   },
                   "val": {
-                    "string": "Policy 2"
+                    "string": "P"
                   }
                 },
                 {
@@ -770,40 +873,6 @@
                   "val": {
                     "u64": 0
                   }
-                }
-              ]
-            }
-          }
-        }
-      },
-      "failed_call": false
-    },
-    {
-      "event": {
-        "ext": "v0",
-        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
-        "type_": "contract",
-        "body": {
-          "v0": {
-            "topics": [
-              {
-                "symbol": "insure"
-              },
-              {
-                "vec": [
-                  {
-                    "symbol": "PolicyCreated"
-                  }
-                ]
-              }
-            ],
-            "data": {
-              "vec": [
-                {
-                  "u32": 2
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 }
               ]
             }
@@ -856,7 +925,7 @@
             "data": {
               "vec": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
                   "u32": 1
@@ -878,6 +947,9 @@
             "topics": [
               {
                 "symbol": "deactive"
+              },
+              {
+                "symbol": "policy"
               }
             ],
             "data": {
@@ -887,7 +959,7 @@
                     "symbol": "name"
                   },
                   "val": {
-                    "string": "Policy 1"
+                    "string": "P"
                   }
                 },
                 {
@@ -905,40 +977,6 @@
                   "val": {
                     "u64": 0
                   }
-                }
-              ]
-            }
-          }
-        }
-      },
-      "failed_call": false
-    },
-    {
-      "event": {
-        "ext": "v0",
-        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
-        "type_": "contract",
-        "body": {
-          "v0": {
-            "topics": [
-              {
-                "symbol": "insure"
-              },
-              {
-                "vec": [
-                  {
-                    "symbol": "PolicyDeactivated"
-                  }
-                ]
-              }
-            ],
-            "data": {
-              "vec": [
-                {
-                  "u32": 1
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 }
               ]
             }
@@ -991,13 +1029,13 @@
             "data": {
               "vec": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
                   "u32": 0
                 },
                 {
-                  "u32": 20
+                  "u32": 50
                 }
               ]
             }
@@ -1038,84 +1076,7 @@
                   "val": {
                     "vec": [
                       {
-                        "map": [
-                          {
-                            "key": {
-                              "symbol": "active"
-                            },
-                            "val": {
-                              "bool": true
-                            }
-                          },
-                          {
-                            "key": {
-                              "symbol": "coverage_amount"
-                            },
-                            "val": {
-                              "i128": {
-                                "hi": 0,
-                                "lo": 2000
-                              }
-                            }
-                          },
-                          {
-                            "key": {
-                              "symbol": "coverage_type"
-                            },
-                            "val": {
-                              "string": "Type 2"
-                            }
-                          },
-                          {
-                            "key": {
-                              "symbol": "id"
-                            },
-                            "val": {
-                              "u32": 2
-                            }
-                          },
-                          {
-                            "key": {
-                              "symbol": "monthly_premium"
-                            },
-                            "val": {
-                              "i128": {
-                                "hi": 0,
-                                "lo": 200
-                              }
-                            }
-                          },
-                          {
-                            "key": {
-                              "symbol": "name"
-                            },
-                            "val": {
-                              "string": "Policy 2"
-                            }
-                          },
-                          {
-                            "key": {
-                              "symbol": "next_payment_date"
-                            },
-                            "val": {
-                              "u64": 2592000
-                            }
-                          },
-                          {
-                            "key": {
-                              "symbol": "owner"
-                            },
-                            "val": {
-                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                            }
-                          },
-                          {
-                            "key": {
-                              "symbol": "schedule_id"
-                            },
-                            "val": "void"
-                          }
-                        ]
+                        "u32": 2
                       }
                     ]
                   }

--- a/insurance/test_snapshots/test/test_pay_premium_success.1.json
+++ b/insurance/test_snapshots/test/test_pay_premium_success.1.json
@@ -1,12 +1,13 @@
 {
   "generators": {
-    "address": 2,
+    "address": 3,
     "nonce": 0
   },
   "auth": [
+    [],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
         {
           "function": {
             "contract_fn": {
@@ -14,24 +15,24 @@
               "function_name": "create_policy",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
-                  "string": "Test Policy"
+                  "string": "P"
                 },
                 {
-                  "string": "health"
+                  "u32": 1
                 },
                 {
                   "i128": {
                     "hi": 0,
-                    "lo": 100
+                    "lo": 5000000
                   }
                 },
                 {
                   "i128": {
                     "hi": 0,
-                    "lo": 10000
+                    "lo": 50000000
                   }
                 }
               ]
@@ -41,10 +42,9 @@
         }
       ]
     ],
-    [],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
         {
           "function": {
             "contract_fn": {
@@ -52,7 +52,7 @@
               "function_name": "pay_premium",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
                   "u32": 1
@@ -63,18 +63,17 @@
           "sub_invocations": []
         }
       ]
-    ],
-    []
+    ]
   ],
   "ledger": {
     "protocol_version": 21,
-    "sequence_number": 1,
-    "timestamp": 86400,
+    "sequence_number": 0,
+    "timestamp": 0,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
-    "base_reserve": 10,
-    "min_persistent_entry_ttl": 1,
-    "min_temp_entry_ttl": 1,
-    "max_entry_ttl": 100000,
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
     "ledger_entries": [
       [
         {
@@ -101,124 +100,181 @@
                     "storage": [
                       {
                         "key": {
-                          "symbol": "NEXT_ID"
-                        },
-                        "val": {
-                          "u32": 1
-                        }
-                      },
-                      {
-                        "key": {
-                          "symbol": "POLICIES"
-                        },
-                        "val": {
-                          "map": [
+                          "vec": [
                             {
-                              "key": {
-                                "u32": 1
-                              },
-                              "val": {
-                                "map": [
-                                  {
-                                    "key": {
-                                      "symbol": "active"
-                                    },
-                                    "val": {
-                                      "bool": true
-                                    }
-                                  },
-                                  {
-                                    "key": {
-                                      "symbol": "coverage_amount"
-                                    },
-                                    "val": {
-                                      "i128": {
-                                        "hi": 0,
-                                        "lo": 10000
-                                      }
-                                    }
-                                  },
-                                  {
-                                    "key": {
-                                      "symbol": "coverage_type"
-                                    },
-                                    "val": {
-                                      "string": "health"
-                                    }
-                                  },
-                                  {
-                                    "key": {
-                                      "symbol": "id"
-                                    },
-                                    "val": {
-                                      "u32": 1
-                                    }
-                                  },
-                                  {
-                                    "key": {
-                                      "symbol": "monthly_premium"
-                                    },
-                                    "val": {
-                                      "i128": {
-                                        "hi": 0,
-                                        "lo": 100
-                                      }
-                                    }
-                                  },
-                                  {
-                                    "key": {
-                                      "symbol": "name"
-                                    },
-                                    "val": {
-                                      "string": "Test Policy"
-                                    }
-                                  },
-                                  {
-                                    "key": {
-                                      "symbol": "next_payment_date"
-                                    },
-                                    "val": {
-                                      "u64": 2678400
-                                    }
-                                  },
-                                  {
-                                    "key": {
-                                      "symbol": "owner"
-                                    },
-                                    "val": {
-                                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                                    }
-                                  },
-                                  {
-                                    "key": {
-                                      "symbol": "schedule_id"
-                                    },
-                                    "val": "void"
-                                  }
-                                ]
-                              }
+                              "symbol": "ActivePolicies"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "u32": 1
                             }
                           ]
                         }
                       },
                       {
                         "key": {
-                          "symbol": "PRM_TOT"
+                          "vec": [
+                            {
+                              "symbol": "Initialized"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Owner"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "OwnerPolicies"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "u32": 1
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Policy"
+                            },
+                            {
+                              "u32": 1
+                            }
+                          ]
                         },
                         "val": {
                           "map": [
                             {
                               "key": {
-                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                                "symbol": "active"
+                              },
+                              "val": {
+                                "bool": true
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "coverage_amount"
                               },
                               "val": {
                                 "i128": {
                                   "hi": 0,
-                                  "lo": 100
+                                  "lo": 50000000
                                 }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "coverage_type"
+                              },
+                              "val": {
+                                "u32": 1
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "created_at"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "external_ref"
+                              },
+                              "val": "void"
+                            },
+                            {
+                              "key": {
+                                "symbol": "id"
+                              },
+                              "val": {
+                                "u32": 1
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "last_payment_at"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "monthly_premium"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 5000000
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "name"
+                              },
+                              "val": {
+                                "string": "P"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "next_payment_date"
+                              },
+                              "val": {
+                                "u64": 2592000
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "owner"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                               }
                             }
                           ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "PolicyCount"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 1
                         }
                       }
                     ]
@@ -234,7 +290,7 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
             "key": {
               "ledger_key_nonce": {
                 "nonce": 801925984706572462
@@ -249,7 +305,7 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 801925984706572462
@@ -267,7 +323,7 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
             "key": {
               "ledger_key_nonce": {
                 "nonce": 5541220902715666415
@@ -282,7 +338,7 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 5541220902715666415
@@ -294,7 +350,7 @@
             },
             "ext": "v0"
           },
-          100000
+          6311999
         ]
       ],
       [
@@ -336,30 +392,77 @@
                 "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
               },
               {
+                "symbol": "init"
+              }
+            ],
+            "data": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "init"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
                 "symbol": "create_policy"
               }
             ],
             "data": {
               "vec": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
-                  "string": "Test Policy"
+                  "string": "P"
                 },
                 {
-                  "string": "health"
+                  "u32": 1
                 },
                 {
                   "i128": {
                     "hi": 0,
-                    "lo": 100
+                    "lo": 5000000
                   }
                 },
                 {
                   "i128": {
                     "hi": 0,
-                    "lo": 10000
+                    "lo": 50000000
                   }
                 }
               ]
@@ -379,6 +482,9 @@
             "topics": [
               {
                 "symbol": "created"
+              },
+              {
+                "symbol": "policy"
               }
             ],
             "data": {
@@ -390,7 +496,7 @@
                   "val": {
                     "i128": {
                       "hi": 0,
-                      "lo": 10000
+                      "lo": 50000000
                     }
                   }
                 },
@@ -399,7 +505,7 @@
                     "symbol": "coverage_type"
                   },
                   "val": {
-                    "string": "health"
+                    "u32": 1
                   }
                 },
                 {
@@ -409,7 +515,7 @@
                   "val": {
                     "i128": {
                       "hi": 0,
-                      "lo": 100
+                      "lo": 5000000
                     }
                   }
                 },
@@ -418,7 +524,7 @@
                     "symbol": "name"
                   },
                   "val": {
-                    "string": "Test Policy"
+                    "string": "P"
                   }
                 },
                 {
@@ -448,40 +554,6 @@
       "event": {
         "ext": "v0",
         "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
-        "type_": "contract",
-        "body": {
-          "v0": {
-            "topics": [
-              {
-                "symbol": "insure"
-              },
-              {
-                "vec": [
-                  {
-                    "symbol": "PolicyCreated"
-                  }
-                ]
-              }
-            ],
-            "data": {
-              "vec": [
-                {
-                  "u32": 1
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                }
-              ]
-            }
-          }
-        }
-      },
-      "failed_call": false
-    },
-    {
-      "event": {
-        "ext": "v0",
-        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
         "type_": "diagnostic",
         "body": {
           "v0": {
@@ -516,139 +588,13 @@
                 "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
               },
               {
-                "symbol": "get_policy"
-              }
-            ],
-            "data": {
-              "u32": 1
-            }
-          }
-        }
-      },
-      "failed_call": false
-    },
-    {
-      "event": {
-        "ext": "v0",
-        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
-        "type_": "diagnostic",
-        "body": {
-          "v0": {
-            "topics": [
-              {
-                "symbol": "fn_return"
-              },
-              {
-                "symbol": "get_policy"
-              }
-            ],
-            "data": {
-              "map": [
-                {
-                  "key": {
-                    "symbol": "active"
-                  },
-                  "val": {
-                    "bool": true
-                  }
-                },
-                {
-                  "key": {
-                    "symbol": "coverage_amount"
-                  },
-                  "val": {
-                    "i128": {
-                      "hi": 0,
-                      "lo": 10000
-                    }
-                  }
-                },
-                {
-                  "key": {
-                    "symbol": "coverage_type"
-                  },
-                  "val": {
-                    "string": "health"
-                  }
-                },
-                {
-                  "key": {
-                    "symbol": "id"
-                  },
-                  "val": {
-                    "u32": 1
-                  }
-                },
-                {
-                  "key": {
-                    "symbol": "monthly_premium"
-                  },
-                  "val": {
-                    "i128": {
-                      "hi": 0,
-                      "lo": 100
-                    }
-                  }
-                },
-                {
-                  "key": {
-                    "symbol": "name"
-                  },
-                  "val": {
-                    "string": "Test Policy"
-                  }
-                },
-                {
-                  "key": {
-                    "symbol": "next_payment_date"
-                  },
-                  "val": {
-                    "u64": 2592000
-                  }
-                },
-                {
-                  "key": {
-                    "symbol": "owner"
-                  },
-                  "val": {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                  }
-                },
-                {
-                  "key": {
-                    "symbol": "schedule_id"
-                  },
-                  "val": "void"
-                }
-              ]
-            }
-          }
-        }
-      },
-      "failed_call": false
-    },
-    {
-      "event": {
-        "ext": "v0",
-        "contract_id": null,
-        "type_": "diagnostic",
-        "body": {
-          "v0": {
-            "topics": [
-              {
-                "symbol": "fn_call"
-              },
-              {
-                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
-              },
-              {
                 "symbol": "pay_premium"
               }
             ],
             "data": {
               "vec": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
                   "u32": 1
@@ -670,6 +616,9 @@
             "topics": [
               {
                 "symbol": "paid"
+              },
+              {
+                "symbol": "premium"
               }
             ],
             "data": {
@@ -681,7 +630,7 @@
                   "val": {
                     "i128": {
                       "hi": 0,
-                      "lo": 100
+                      "lo": 5000000
                     }
                   }
                 },
@@ -690,7 +639,7 @@
                     "symbol": "name"
                   },
                   "val": {
-                    "string": "Test Policy"
+                    "string": "P"
                   }
                 },
                 {
@@ -698,7 +647,7 @@
                     "symbol": "next_payment_date"
                   },
                   "val": {
-                    "u64": 2678400
+                    "u64": 2592000
                   }
                 },
                 {
@@ -714,42 +663,8 @@
                     "symbol": "timestamp"
                   },
                   "val": {
-                    "u64": 86400
+                    "u64": 0
                   }
-                }
-              ]
-            }
-          }
-        }
-      },
-      "failed_call": false
-    },
-    {
-      "event": {
-        "ext": "v0",
-        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
-        "type_": "contract",
-        "body": {
-          "v0": {
-            "topics": [
-              {
-                "symbol": "insure"
-              },
-              {
-                "vec": [
-                  {
-                    "symbol": "PremiumPaid"
-                  }
-                ]
-              }
-            ],
-            "data": {
-              "vec": [
-                {
-                  "u32": 1
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 }
               ]
             }
@@ -773,132 +688,8 @@
                 "symbol": "pay_premium"
               }
             ],
-            "data": "void"
-          }
-        }
-      },
-      "failed_call": false
-    },
-    {
-      "event": {
-        "ext": "v0",
-        "contract_id": null,
-        "type_": "diagnostic",
-        "body": {
-          "v0": {
-            "topics": [
-              {
-                "symbol": "fn_call"
-              },
-              {
-                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
-              },
-              {
-                "symbol": "get_policy"
-              }
-            ],
             "data": {
-              "u32": 1
-            }
-          }
-        }
-      },
-      "failed_call": false
-    },
-    {
-      "event": {
-        "ext": "v0",
-        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
-        "type_": "diagnostic",
-        "body": {
-          "v0": {
-            "topics": [
-              {
-                "symbol": "fn_return"
-              },
-              {
-                "symbol": "get_policy"
-              }
-            ],
-            "data": {
-              "map": [
-                {
-                  "key": {
-                    "symbol": "active"
-                  },
-                  "val": {
-                    "bool": true
-                  }
-                },
-                {
-                  "key": {
-                    "symbol": "coverage_amount"
-                  },
-                  "val": {
-                    "i128": {
-                      "hi": 0,
-                      "lo": 10000
-                    }
-                  }
-                },
-                {
-                  "key": {
-                    "symbol": "coverage_type"
-                  },
-                  "val": {
-                    "string": "health"
-                  }
-                },
-                {
-                  "key": {
-                    "symbol": "id"
-                  },
-                  "val": {
-                    "u32": 1
-                  }
-                },
-                {
-                  "key": {
-                    "symbol": "monthly_premium"
-                  },
-                  "val": {
-                    "i128": {
-                      "hi": 0,
-                      "lo": 100
-                    }
-                  }
-                },
-                {
-                  "key": {
-                    "symbol": "name"
-                  },
-                  "val": {
-                    "string": "Test Policy"
-                  }
-                },
-                {
-                  "key": {
-                    "symbol": "next_payment_date"
-                  },
-                  "val": {
-                    "u64": 2678400
-                  }
-                },
-                {
-                  "key": {
-                    "symbol": "owner"
-                  },
-                  "val": {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                  }
-                },
-                {
-                  "key": {
-                    "symbol": "schedule_id"
-                  },
-                  "val": "void"
-                }
-              ]
+              "bool": true
             }
           }
         }

--- a/insurance/tests/gas_bench.rs
+++ b/insurance/tests/gas_bench.rs
@@ -43,14 +43,15 @@ fn bench_get_total_monthly_premium_worst_case() {
     let contract_id = env.register_contract(None, Insurance);
     let client = InsuranceClient::new(&env, &contract_id);
     let owner = <Address as AddressTrait>::generate(&env);
+    client.init(&owner);
 
     let name = String::from_str(&env, "BenchPolicy");
     let coverage_type = CoverageType::Health;
     for _ in 0..100 {
-        client.create_policy(&owner, &name, &coverage_type, &100i128, &10_000i128);
+        client.create_policy(&owner, &name, &coverage_type, &5_000_000i128, &50_000_000i128);
     }
 
-    let expected_total = 100i128 * 100i128;
+    let expected_total = 100i128 * 5_000_000i128;
     let (cpu, mem, total) = measure(&env, || client.get_total_monthly_premium(&owner));
     assert_eq!(total, expected_total);
 

--- a/insurance/tests/stress_tests.rs
+++ b/insurance/tests/stress_tests.rs
@@ -18,6 +18,7 @@
 //!   MAX_BATCH_SIZE              = 50
 
 use insurance::{Insurance, InsuranceClient};
+use remitwise_common::CoverageType;
 use soroban_sdk::testutils::storage::Instance as _;
 use soroban_sdk::testutils::{Address as AddressTrait, EnvTestConfig, Ledger, LedgerInfo};
 use soroban_sdk::{Address, Env, String};
@@ -71,19 +72,20 @@ fn stress_200_policies_single_user() {
     let contract_id = env.register_contract(None, Insurance);
     let client = InsuranceClient::new(&env, &contract_id);
     let owner = Address::generate(&env);
+    client.init(&owner);
 
     let name = String::from_str(&env, "StressPolicy");
-    let coverage_type = String::from_str(&env, "health");
+    let coverage_type = CoverageType::Health;
 
     for _ in 0..200 {
-        client.create_policy(&owner, &name, &coverage_type, &100i128, &10_000i128);
+        client.create_policy(&owner, &name, &coverage_type, &5_000_000i128, &50_000_000i128);
     }
 
     // Verify aggregate monthly premium
     let total_premium = client.get_total_monthly_premium(&owner);
     assert_eq!(
         total_premium,
-        200 * 100i128,
+        200 * 5_000_000i128,
         "get_total_monthly_premium must sum premiums across all 200 policies"
     );
 
@@ -121,12 +123,13 @@ fn stress_instance_ttl_valid_after_200_policies() {
     let contract_id = env.register_contract(None, Insurance);
     let client = InsuranceClient::new(&env, &contract_id);
     let owner = Address::generate(&env);
+    client.init(&owner);
 
     let name = String::from_str(&env, "TTLPolicy");
-    let coverage_type = String::from_str(&env, "life");
+    let coverage_type = CoverageType::Life;
 
     for _ in 0..200 {
-        client.create_policy(&owner, &name, &coverage_type, &50i128, &5_000i128);
+        client.create_policy(&owner, &name, &coverage_type, &1_000_000i128, &60_000_000i128);
     }
 
     let ttl = env.as_contract(&contract_id, || env.storage().instance().get_ttl());
@@ -151,11 +154,12 @@ fn stress_policies_across_10_users() {
 
     const N_USERS: usize = 10;
     const POLICIES_PER_USER: u32 = 20;
-    const PREMIUM_PER_POLICY: i128 = 150;
+    const PREMIUM_PER_POLICY: i128 = 5_000_000;
     let name = String::from_str(&env, "UserPolicy");
-    let coverage_type = String::from_str(&env, "health");
+    let coverage_type = CoverageType::Health;
 
     let users: std::vec::Vec<Address> = (0..N_USERS).map(|_| Address::generate(&env)).collect();
+    client.init(&users[0]);
 
     for user in &users {
         for _ in 0..POLICIES_PER_USER {
@@ -164,7 +168,7 @@ fn stress_policies_across_10_users() {
                 &name,
                 &coverage_type,
                 &PREMIUM_PER_POLICY,
-                &50_000i128,
+                &50_000_000i128,
             );
         }
     }
@@ -212,13 +216,14 @@ fn stress_ttl_re_bumped_after_ledger_advancement() {
     let contract_id = env.register_contract(None, Insurance);
     let client = InsuranceClient::new(&env, &contract_id);
     let owner = Address::generate(&env);
+    client.init(&owner);
 
     let name = String::from_str(&env, "TTLStress");
-    let coverage_type = String::from_str(&env, "health");
+    let coverage_type = CoverageType::Health;
 
     // Phase 1: 50 creates
     for _ in 0..50 {
-        client.create_policy(&owner, &name, &coverage_type, &100i128, &10_000i128);
+        client.create_policy(&owner, &name, &coverage_type, &5_000_000i128, &50_000_000i128);
     }
 
     let ttl_batch1 = env.as_contract(&contract_id, || env.storage().instance().get_ttl());
@@ -249,7 +254,7 @@ fn stress_ttl_re_bumped_after_ledger_advancement() {
     );
 
     // Phase 3: create_policy fires extend_ttl → re-bumped
-    client.create_policy(&owner, &name, &coverage_type, &100i128, &10_000i128);
+    client.create_policy(&owner, &name, &coverage_type, &5_000_000i128, &50_000_000i128);
 
     let ttl_rebumped = env.as_contract(&contract_id, || env.storage().instance().get_ttl());
     assert!(
@@ -267,12 +272,13 @@ fn stress_ttl_re_bumped_by_pay_premium_after_ledger_advancement() {
     let client = InsuranceClient::new(&env, &contract_id);
     let owner = Address::generate(&env);
 
+    client.init(&owner);
     let policy_id = client.create_policy(
         &owner,
         &String::from_str(&env, "PayTTL"),
-        &String::from_str(&env, "health"),
-        &200i128,
-        &20_000i128,
+        &CoverageType::Health,
+        &5_000_000i128,
+        &50_000_000i128,
     );
 
     // Advance ledger so TTL drops below threshold
@@ -311,14 +317,15 @@ fn stress_batch_pay_premiums_at_max_batch_size() {
     let contract_id = env.register_contract(None, Insurance);
     let client = InsuranceClient::new(&env, &contract_id);
     let owner = Address::generate(&env);
+    client.init(&owner);
 
     const BATCH_SIZE: u32 = 50; // MAX_BATCH_SIZE
     let name = String::from_str(&env, "BatchPolicy");
-    let coverage_type = String::from_str(&env, "health");
+    let coverage_type = CoverageType::Health;
 
     let mut policy_ids = std::vec![];
     for _ in 0..BATCH_SIZE {
-        let id = client.create_policy(&owner, &name, &coverage_type, &100i128, &10_000i128);
+        let id = client.create_policy(&owner, &name, &coverage_type, &5_000_000i128, &50_000_000i128);
         policy_ids.push(id);
     }
 
@@ -341,7 +348,7 @@ fn stress_batch_pay_premiums_at_max_batch_size() {
     // the value is a valid future date.
     let expected_next = 1_700_000_000u64 + (30 * 86400);
     for &id in &policy_ids {
-        let policy = client.get_policy(&id).unwrap();
+        let policy = client.get_policy(&id);
         assert!(
             policy.active,
             "Policy {} must still be active after batch premium payment",
@@ -363,12 +370,13 @@ fn stress_deactivate_half_of_200_policies() {
     let contract_id = env.register_contract(None, Insurance);
     let client = InsuranceClient::new(&env, &contract_id);
     let owner = Address::generate(&env);
+    client.init(&owner);
 
     let name = String::from_str(&env, "DeactPolicy");
-    let coverage_type = String::from_str(&env, "life");
+    let coverage_type = CoverageType::Life;
 
     for _ in 0..200 {
-        client.create_policy(&owner, &name, &coverage_type, &80i128, &8_000i128);
+        client.create_policy(&owner, &name, &coverage_type, &1_000_000i128, &60_000_000i128);
     }
 
     // Deactivate even-numbered policies (IDs 2, 4, 6, …, 200)
@@ -393,11 +401,11 @@ fn stress_deactivate_half_of_200_policies() {
         "After deactivating 100 of 200 policies, only 100 must be returned by get_active_policies"
     );
 
-    // Verify monthly premium dropped by exactly half: 100 deactivated × 80 = 8000 less
+    // Verify monthly premium dropped by exactly half: 100 deactivated × 1_000_000 = 100_000_000 less
     let remaining_premium = client.get_total_monthly_premium(&owner);
     assert_eq!(
         remaining_premium,
-        100 * 80i128,
+        100 * 1_000_000i128,
         "Monthly premium must reflect only the 100 still-active policies"
     );
 }
@@ -413,12 +421,13 @@ fn bench_get_active_policies_first_page_of_200() {
     let contract_id = env.register_contract(None, Insurance);
     let client = InsuranceClient::new(&env, &contract_id);
     let owner = Address::generate(&env);
+    client.init(&owner);
 
     let name = String::from_str(&env, "BenchPolicy");
-    let coverage_type = String::from_str(&env, "health");
+    let coverage_type = CoverageType::Health;
 
     for _ in 0..200 {
-        client.create_policy(&owner, &name, &coverage_type, &100i128, &10_000i128);
+        client.create_policy(&owner, &name, &coverage_type, &5_000_000i128, &50_000_000i128);
     }
 
     let (cpu, mem, page) = measure(&env, || client.get_active_policies(&owner, &0u32, &50u32));
@@ -437,15 +446,16 @@ fn bench_get_total_monthly_premium_200_policies() {
     let contract_id = env.register_contract(None, Insurance);
     let client = InsuranceClient::new(&env, &contract_id);
     let owner = Address::generate(&env);
+    client.init(&owner);
 
     let name = String::from_str(&env, "PremBench");
-    let coverage_type = String::from_str(&env, "health");
+    let coverage_type = CoverageType::Health;
 
     for _ in 0..200 {
-        client.create_policy(&owner, &name, &coverage_type, &100i128, &10_000i128);
+        client.create_policy(&owner, &name, &coverage_type, &5_000_000i128, &50_000_000i128);
     }
 
-    let expected = 200i128 * 100;
+    let expected = 200i128 * 5_000_000;
     let (cpu, mem, total) = measure(&env, || client.get_total_monthly_premium(&owner));
     assert_eq!(total, expected);
 
@@ -462,13 +472,14 @@ fn bench_batch_pay_premiums_50_policies() {
     let contract_id = env.register_contract(None, Insurance);
     let client = InsuranceClient::new(&env, &contract_id);
     let owner = Address::generate(&env);
+    client.init(&owner);
 
     let name = String::from_str(&env, "BatchBench");
-    let coverage_type = String::from_str(&env, "health");
+    let coverage_type = CoverageType::Health;
 
     let mut policy_ids = std::vec![];
     for _ in 0..50 {
-        let id = client.create_policy(&owner, &name, &coverage_type, &100i128, &10_000i128);
+        let id = client.create_policy(&owner, &name, &coverage_type, &5_000_000i128, &50_000_000i128);
         policy_ids.push(id);
     }
 


### PR DESCRIPTION
## Summary

Replaces the ~90-line test stub with a comprehensive test suite covering every public entrypoint of the **Insurance** contract — **73 unit tests**, **10 stress/integration tests**, and **1 gas-bench test** (all passing, clippy clean).

## Changes

### Test coverage

| Entrypoint | Tests | Negatives |
|---|---|---|
| `init` | 2 | reinit rejection |
| `create_policy` | 22 | empty/too-long name, zero/negative premium/coverage, per-type min/max bounds, ratio guard, MAX_POLICIES cap, uninitialized |
| `pay_premium` | 5 | non-owner, inactive-policy, nonexistent-policy, date math |
| `deactivate_policy` | 6 | non-owner, nonexistent, idempotent, removes from ActivePolicies |
| `get_active_policies` | 6 | empty, owner isolation, excludes deactivated, cursor pagination |
| `get_total_monthly_premium` | 5 | zero, owner isolation, excludes deactivated |
| `get_policy` | 3 | nonexistent panic |
| `batch_pay_premiums` | 3 | skips unowned/inactive, max batch size |
| `set_external_ref` | 5 | unauthorized, too long, max length |

### Bug fix

- **Cursor pagination off-by-one** in `get_active_policies`: `next_cursor` was set to the first excluded ID instead of the last included ID, causing one item to be skipped per full page.

### Other

- Updated stress tests and gas benchmarks to use valid `TypeConstraints` values
- Added `remitwise-common` and `testutils` dependencies to `Cargo.toml`

## Verification

- `cargo test -p insurance` — 84/84 pass
- `cargo clippy -p insurance` — clean

Closes #711