### PR TITLE
feat(remittance_split): emit DistributionCompletedEvent from distribu…

### DIFF
--- a/CHANGELOG_CONTRACTS.md
+++ b/CHANGELOG_CONTRACTS.md
@@ -4,6 +4,14 @@ This document tracks changes, versions, and migration notes for each of the smar
 
 ## Remittance Split (`remittance_split`)
 
+### v0.2.2
+
+- **Summary**: Restored structured `DistributionCompletedEvent` emission on both `distribute_usdc` and `distribute_usdc_hashed` via a shared helper (#843).
+- **New Features**:
+  - `emit_distribution_completed`: shared helper publishing unstructured `dist_ok` (backward compat) plus structured `(split, DistributionCompleted)` with per-category amounts
+- **Breaking Changes**: None — the unstructured `dist_ok` event is retained alongside the structured event.
+- **Migration Notes**: Indexers keyed on `(split, DistributionCompleted)` now receive events from the hashed path as well as the legacy path.
+
 ### v0.2.1
 
 - **Summary**: Removed orphaned `RemittanceSchedulePage` contracttype that had no producer, shrinking the exported ABI.

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -595,6 +595,45 @@ pub struct SplitCalculatedEvent {
 }
 ```
 
+### Event: Distribution Completed
+
+**Topic:** `("Remitwise", EventCategory::Transaction, EventPriority::Medium, "dist_ok")` (backward-compat unstructured)  
+**Secondary Topic:** `("split", SplitEvent::DistributionCompleted)` (structured per-category payload)
+
+**Emitted by:** `distribute_usdc`, `distribute_usdc_hashed`  
+**Trigger:** Emitted when all category transfers complete successfully
+
+Both entrypoints call the shared `emit_distribution_completed` helper so category-level
+amounts cannot drift between the legacy and request-hash-bound paths.
+
+**Data Structure:**
+```rust
+pub struct DistributionCompletedEvent {
+    pub from: Address,              // Payer address
+    pub total_amount: i128,         // Total distributed amount
+    pub spending_amount: i128,      // Amount sent to spending account
+    pub savings_amount: i128,       // Amount sent to savings account
+    pub bills_amount: i128,         // Amount sent to bills account
+    pub insurance_amount: i128,     // Amount sent to insurance account (includes dust/remainder)
+    pub timestamp: u64,             // Event timestamp
+}
+```
+
+**Constraint:** `spending_amount + savings_amount + bills_amount + insurance_amount == total_amount`
+
+**Example Event:**
+```json
+{
+  "from": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+  "total_amount": 10000,
+  "spending_amount": 5000,
+  "savings_amount": 3000,
+  "bills_amount": 1500,
+  "insurance_amount": 500,
+  "timestamp": 1234567900
+}
+```
+
 ### Event: Split Updated
 
 **Topic:** `("split", SplitEvent::Updated)`

--- a/remittance_split/src/events_schema_test.rs
+++ b/remittance_split/src/events_schema_test.rs
@@ -175,6 +175,16 @@ fn distribution_completed_event_payload_schema() {
     assert_eq!(decoded.timestamp, 1_234_567_900);
 }
 
+#[test]
+fn distribution_completed_structured_event_topic_is_stable() {
+    let env = Env::default();
+
+    // Topic tuple emitted by emit_distribution_completed for indexers that
+    // subscribe to the structured per-category payload.
+    let topic: Val = (symbol_short!("split"), SplitEvent::DistributionCompleted).into_val(&env);
+    let _: Val = topic;
+}
+
 // ---------------------------------------------------------------------------
 // Payload schemas - enum events
 // ---------------------------------------------------------------------------

--- a/remittance_split/src/lib.rs
+++ b/remittance_split/src/lib.rs
@@ -1351,18 +1351,7 @@ impl RemittanceSplit {
 
         // 10. Advance nonce, record audit, emit events.
         Self::increment_nonce(&env, &from)?;
-
-        // Emit unstructured event for backward compatibility
-        RemitwiseEvents::emit(
-            &env,
-            EventCategory::Transaction,
-            EventPriority::Medium,
-            symbol_short!("dist_ok"),
-            (from.clone(), total_amount),
-        );
-
-        // Structured distribution event removed to reduce transient memory allocations
-        // (keeps the lightweight unstructured event for backward compatibility).
+        Self::emit_distribution_completed(&env, &from, total_amount, &amounts);
 
         Ok(true)
     }
@@ -1371,6 +1360,9 @@ impl RemittanceSplit {
     ///
     /// This function provides secure USDC distribution with deterministic request hashing
     /// and deadline enforcement. Integrators sign the request hash before calling this function.
+    ///
+    /// On success emits the same structured [`DistributionCompletedEvent`] as
+    /// [`Self::distribute_usdc`] via [`Self::emit_distribution_completed`].
     ///
     /// # Arguments
     /// * `env` - Soroban environment
@@ -1500,6 +1492,12 @@ impl RemittanceSplit {
         // Increment nonce and record success
         Self::increment_nonce(&env, &request.from)?;
         Self::append_audit(&env, symbol_short!("distH"), &request.from, true);
+        Self::emit_distribution_completed(
+            &env,
+            &request.from,
+            request.total_amount,
+            &amounts,
+        );
         Ok(true)
     }
 
@@ -2107,6 +2105,45 @@ impl RemittanceSplit {
             .wrapping_add(i)
             .wrapping_add(sc_count)
             .wrapping_mul(31)
+    }
+
+    /// Emit distribution completion telemetry shared by `distribute_usdc` and
+    /// `distribute_usdc_hashed`.
+    ///
+    /// Publishes two events so indexers can choose either surface:
+    /// 1. Unstructured `dist_ok` via `RemitwiseEvents` (backward compatibility)
+    /// 2. Structured `(split, DistributionCompleted)` with per-category amounts
+    ///
+    /// Category amounts must be the post-transfer split vector returned by
+    /// [`Self::calculate_split_amounts`] so dust/remainder is reflected identically
+    /// on both entrypoints.
+    fn emit_distribution_completed(
+        env: &Env,
+        from: &Address,
+        total_amount: i128,
+        amounts: &[i128; 4],
+    ) {
+        RemitwiseEvents::emit(
+            env,
+            EventCategory::Transaction,
+            EventPriority::Medium,
+            symbol_short!("dist_ok"),
+            (from.clone(), total_amount),
+        );
+
+        let event = DistributionCompletedEvent {
+            from: from.clone(),
+            total_amount,
+            spending_amount: amounts[0],
+            savings_amount: amounts[1],
+            bills_amount: amounts[2],
+            insurance_amount: amounts[3],
+            timestamp: env.ledger().timestamp(),
+        };
+        env.events().publish(
+            (symbol_short!("split"), SplitEvent::DistributionCompleted),
+            event,
+        );
     }
 
     fn append_audit(env: &Env, operation: Symbol, caller: &Address, success: bool) {


### PR DESCRIPTION
## Summary

Closes #843.

- Adds shared `emit_distribution_completed` helper used by both `distribute_usdc` and `distribute_usdc_hashed`
- Hashed path now emits the same structured `DistributionCompletedEvent` with per-category amounts as the legacy path
- Retains the unstructured `dist_ok` RemitwiseEvents emission for backward compatibility

## Changes

| File | Change |
|------|--------|
| `remittance_split/src/lib.rs` | New `emit_distribution_completed` helper; both entrypoints call it after successful transfers |
| `remittance_split/src/events_schema_test.rs` | Pins `(split, DistributionCompleted)` topic tuple stability |
| `docs/EVENTS.md` | Documents `DistributionCompletedEvent` for both entrypoints |
| `CHANGELOG_CONTRACTS.md` | v0.2.2 entry noting structured event parity |

## Design

`emit_distribution_completed` publishes two events:

1. **Backward-compat:** `("Remitwise", Transaction, Medium, "dist_ok")` with `(from, total_amount)`
2. **Structured:** `("split", SplitEvent::DistributionCompleted)` with full `DistributionCompletedEvent` payload

Both entrypoints pass the `[i128; 4]` vector from `calculate_split_amounts`, so dust/remainder assigned to insurance is identical in both telemetry surfaces.

## Test plan

- [ ] `cargo test -p remittance_split`
- [ ] `cargo clippy -p remittance_split -- -D warnings`
- [ ] Hashed distribution emits `(split, DistributionCompleted)` with correct category breakdown
- [ ] Unhashed path still emits `dist_ok` plus structured event
- [ ] Same input produces identical category amounts on both paths