### PR TITLE
feat(security): add explicit XDR length guard on returned Bytes values

### DIFF
--- a/remittance_split/src/lib.rs
+++ b/remittance_split/src/lib.rs
@@ -9,7 +9,7 @@ mod test;
 mod tests_safe_math;
 
 use remitwise_common::{
-    clamp_limit, EventCategory, EventPriority, RemitwiseEvents, ToI128Checked,
+    clamp_limit, guard_bytes_len, EventCategory, EventPriority, RemitwiseEvents, ToI128Checked,
     INSTANCE_BUMP_AMOUNT, INSTANCE_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT,
     PERSISTENT_LIFETIME_THRESHOLD, SNAPSHOT_KEY, SNAPSHOT_VERSION,
 };
@@ -85,6 +85,9 @@ pub enum RemittanceSplitError {
     NoPendingTreasury = 26,
     /// The caller of `accept_treasury` is not the proposed treasury address.
     PendingTreasuryMismatch = 27,
+    /// The `Bytes` value about to be returned exceeds `MAX_BYTES_RETURN`.
+    /// Prevents consumers from being forced to deserialise an unbounded payload.
+    ReturnBytesTooLarge = 28,
 }
 
 #[derive(Clone)]
@@ -1443,7 +1446,7 @@ impl RemittanceSplit {
         }
 
         // Verify request hash matches computed hash (binds all signed fields + domain_id)
-        let computed_hash = Self::get_request_hash(env.clone(), request.clone());
+        let computed_hash = Self::get_request_hash(env.clone(), request.clone())?;
         if computed_hash.ne(&request_hash) {
             Self::append_audit(&env, symbol_short!("distH"), &request.from, false);
             return Err(RemittanceSplitError::RequestHashMismatch);
@@ -1995,7 +1998,10 @@ impl RemittanceSplit {
     ///
     /// Mutating *any* field in `request` yields a different 32-byte hash,
     /// guaranteeing field-substitution resistance across all signed parameters.
-    pub fn get_request_hash(env: Env, request: DistributeUsdcRequest) -> Bytes {
+    pub fn get_request_hash(
+        env: Env,
+        request: DistributeUsdcRequest,
+    ) -> Result<Bytes, RemittanceSplitError> {
         let mut preimage = Bytes::new(&env);
 
         // 1. Domain separator
@@ -2038,7 +2044,9 @@ impl RemittanceSplit {
         // 11. deadline — 8 bytes LE
         preimage.extend_from_slice(&request.deadline.to_le_bytes());
 
-        env.crypto().sha256(&preimage).into()
+        let hash: Bytes = env.crypto().sha256(&preimage).into();
+        guard_bytes_len(&hash).map_err(|_| RemittanceSplitError::ReturnBytesTooLarge)?;
+        Ok(hash)
     }
 
     /// Works in `no_std` — uses `Symbol::to_val()` to extract the raw

--- a/remittance_split/src/test.rs
+++ b/remittance_split/src/test.rs
@@ -267,6 +267,34 @@ fn test_request_hash_deterministic() {
     assert_eq!(hash1.len(), 32);
 }
 
+/// SHA-256 output (32 bytes) is well within MAX_BYTES_RETURN (8 192).
+/// The XDR length guard must never fire for valid `get_request_hash` calls.
+#[test]
+fn test_get_request_hash_passes_xdr_length_guard() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, RemittanceSplit);
+    let client = RemittanceSplitClient::new(&env, &contract_id);
+
+    let request = DistributeUsdcRequest {
+        usdc_contract: Address::generate(&env),
+        from: Address::generate(&env),
+        nonce: 0,
+        accounts: AccountGroup {
+            spending: Address::generate(&env),
+            savings: Address::generate(&env),
+            bills: Address::generate(&env),
+            insurance: Address::generate(&env),
+        },
+        total_amount: 1_000i128,
+        deadline: 9_999u64,
+    };
+
+    // client.get_request_hash() panics if the contract returns Err — this
+    // verifies that the guard does not fire for the 32-byte SHA-256 result.
+    let hash = client.get_request_hash(&request);
+    assert_eq!(hash.len(), 32, "SHA-256 must produce exactly 32 bytes");
+}
+
 /// Verifies that reading instance storage (`get_config`) bumps the instance TTL.
 ///
 /// NOTE: This test used to also assert that reading a schedule via
@@ -1739,7 +1767,7 @@ fn test_deadline_zero_is_invalid() {
     let request = make_request(&env, token_addr.clone(), owner.clone(), 1, 0);
     let result = client.try_distribute_usdc_hashed(
         &request,
-        &RemittanceSplit::get_request_hash(env.clone(), request.clone()),
+        &RemittanceSplit::get_request_hash(env.clone(), request.clone()).unwrap(),
     );
     assert_eq!(result, Err(Ok(RemittanceSplitError::InvalidDeadline)));
 }
@@ -1757,7 +1785,7 @@ fn test_deadline_equal_to_now_is_expired() {
     let request = make_request(&env, token_addr.clone(), owner.clone(), 1, now);
     let result = client.try_distribute_usdc_hashed(
         &request,
-        &RemittanceSplit::get_request_hash(env.clone(), request.clone()),
+        &RemittanceSplit::get_request_hash(env.clone(), request.clone()).unwrap(),
     );
     assert_eq!(result, Err(Ok(RemittanceSplitError::DeadlineExpired)));
 }
@@ -1775,7 +1803,7 @@ fn test_deadline_one_second_past_is_expired() {
     let request = make_request(&env, token_addr.clone(), owner.clone(), 1, now - 1);
     let result = client.try_distribute_usdc_hashed(
         &request,
-        &RemittanceSplit::get_request_hash(env.clone(), request.clone()),
+        &RemittanceSplit::get_request_hash(env.clone(), request.clone()).unwrap(),
     );
     assert_eq!(result, Err(Ok(RemittanceSplitError::DeadlineExpired)));
 }
@@ -1794,7 +1822,7 @@ fn test_deadline_one_second_future_is_accepted() {
     // Should not return DeadlineExpired or InvalidDeadline
     let result = client.try_distribute_usdc_hashed(
         &request,
-        &RemittanceSplit::get_request_hash(env.clone(), request.clone()),
+        &RemittanceSplit::get_request_hash(env.clone(), request.clone()).unwrap(),
     );
     assert!(
         result != Err(Ok(RemittanceSplitError::DeadlineExpired))
@@ -1822,7 +1850,7 @@ fn test_deadline_at_max_window_is_accepted() {
     );
     let result = client.try_distribute_usdc_hashed(
         &request,
-        &RemittanceSplit::get_request_hash(env.clone(), request.clone()),
+        &RemittanceSplit::get_request_hash(env.clone(), request.clone()).unwrap(),
     );
     assert!(
         result != Err(Ok(RemittanceSplitError::DeadlineExpired))
@@ -1850,7 +1878,7 @@ fn test_deadline_beyond_max_window_is_invalid() {
     );
     let result = client.try_distribute_usdc_hashed(
         &request,
-        &RemittanceSplit::get_request_hash(env.clone(), request.clone()),
+        &RemittanceSplit::get_request_hash(env.clone(), request.clone()).unwrap(),
     );
     assert_eq!(result, Err(Ok(RemittanceSplitError::InvalidDeadline)));
 }
@@ -1870,7 +1898,7 @@ fn test_expired_deadline_does_not_advance_nonce() {
     let request = make_request(&env, token_addr.clone(), owner.clone(), 1, now - 1);
     let _ = client.try_distribute_usdc_hashed(
         &request,
-        &RemittanceSplit::get_request_hash(env.clone(), request.clone()),
+        &RemittanceSplit::get_request_hash(env.clone(), request.clone()).unwrap(),
     );
 
     let nonce_after = client.get_nonce(&owner);
@@ -1894,7 +1922,7 @@ fn test_invalid_deadline_does_not_advance_nonce() {
     let request = make_request(&env, token_addr.clone(), owner.clone(), 1, 0);
     let _ = client.try_distribute_usdc_hashed(
         &request,
-        &RemittanceSplit::get_request_hash(env.clone(), request.clone()),
+        &RemittanceSplit::get_request_hash(env.clone(), request.clone()).unwrap(),
     );
 
     let nonce_after = client.get_nonce(&owner);

--- a/remitwise-common/src/lib.rs
+++ b/remitwise-common/src/lib.rs
@@ -112,6 +112,42 @@ pub const CONTRACT_VERSION: u32 = 1;
 /// Maximum batch size for operations
 pub const MAX_BATCH_SIZE: u32 = 50;
 
+/// Maximum byte length for `Bytes` values returned from public contract entry points.
+///
+/// XDR `ScBytes` carries no inherent host-enforced cap before deserialization.
+/// Without an explicit check, a misbehaving or compromised contract can force every
+/// downstream consumer (SDK, indexer, RPC node) to allocate memory proportional to
+/// the returned payload — a potential DoS vector.  Call [`guard_bytes_len`] before
+/// returning any variable-length `Bytes` value from a public entry point.
+pub const MAX_BYTES_RETURN: u32 = 8192;
+
+/// Error returned when a `Bytes` value about to leave a contract entry point
+/// exceeds [`MAX_BYTES_RETURN`].
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum BytesReturnError {
+    /// The byte length exceeds [`MAX_BYTES_RETURN`].
+    ReturnTooLarge = 1,
+}
+
+/// Guards `bytes` against exceeding the XDR return-size budget.
+///
+/// Call this immediately before returning any variable-length `Bytes` value from a
+/// public contract entry point.  The check costs a single `u32` comparison and
+/// ensures that downstream consumers cannot be forced to deserialise an arbitrarily
+/// large buffer.
+///
+/// # Errors
+/// Returns [`BytesReturnError::ReturnTooLarge`] when `bytes.len() > MAX_BYTES_RETURN`.
+pub fn guard_bytes_len(bytes: &Bytes) -> Result<(), BytesReturnError> {
+    if bytes.len() > MAX_BYTES_RETURN {
+        Err(BytesReturnError::ReturnTooLarge)
+    } else {
+        Ok(())
+    }
+}
+
 /// Pre-upgrade snapshot version
 pub const SNAPSHOT_VERSION: u32 = 1;
 

--- a/remitwise-common/src/tests.rs
+++ b/remitwise-common/src/tests.rs
@@ -17,7 +17,7 @@ extern crate std;
 
 use super::*;
 use proptest::prelude::*;
-use soroban_sdk::{Env, String, Vec};
+use soroban_sdk::{Bytes, Env, String, Vec};
 
 // helper: build a single-element tag Vec
 fn single(env: &Env, tag: &str) -> Vec<String> {
@@ -570,4 +570,50 @@ fn test_verify_slash_signature_invalid() {
     // Verify the invalid slash signature
     let result = verify_slash_signature(&env, message, Some(&invalid_signature), &pk);
     assert_eq!(result, Err(SlashError::InvalidSignature));
+}
+
+// ─── guard_bytes_len: XDR return-size budget ─────────────────────────────────
+
+/// Empty `Bytes` is well within the budget.
+#[test]
+fn test_guard_bytes_len_accepts_empty() {
+    let env = Env::default();
+    assert_eq!(guard_bytes_len(&Bytes::new(&env)), Ok(()));
+}
+
+/// A value exactly at `MAX_BYTES_RETURN` bytes must be accepted (inclusive upper bound).
+#[test]
+fn test_guard_bytes_len_accepts_value_at_limit() {
+    let env = Env::default();
+    let data = [0u8; 8192];
+    let b = Bytes::from_slice(&env, &data);
+    assert_eq!(guard_bytes_len(&b), Ok(()));
+}
+
+/// A value one byte over `MAX_BYTES_RETURN` must be rejected.
+///
+/// This is the negative test for the XDR length guard.  Before the guard was
+/// introduced there was no check; a consumer receiving an oversized `Bytes`
+/// value had to allocate a buffer of arbitrary size — a DoS vector.  After the
+/// fix, `guard_bytes_len` returns `BytesReturnError::ReturnTooLarge` so the
+/// contract can surface a typed error instead of silently returning oversized data.
+#[test]
+fn test_guard_bytes_len_rejects_oversized_value() {
+    let env = Env::default();
+    let data = [0u8; 8193]; // MAX_BYTES_RETURN + 1
+    let b = Bytes::from_slice(&env, &data);
+    assert_eq!(
+        guard_bytes_len(&b),
+        Err(BytesReturnError::ReturnTooLarge),
+        "values larger than MAX_BYTES_RETURN must be rejected to prevent consumer DoS"
+    );
+}
+
+/// A value far above the limit must also be rejected (not just the boundary).
+#[test]
+fn test_guard_bytes_len_rejects_large_value() {
+    let env = Env::default();
+    let data = [0u8; 65536];
+    let b = Bytes::from_slice(&env, &data);
+    assert_eq!(guard_bytes_len(&b), Err(BytesReturnError::ReturnTooLarge));
 }


### PR DESCRIPTION
## Summary

Closes #894

Add an explicit XDR byte-length guard (`guard_bytes_len`) on `Bytes` values
returned from public contract entry points so consumers cannot be DoS'd by an
unbounded allocation.

---

## Threat being mitigated

**DoS via unbounded `ScBytes` deserialization.**

The Soroban XDR `ScBytes` type carries a 4-byte unsigned length prefix with no
host-enforced upper bound before the bytes are handed to the caller. Without an
explicit check on the contract side, a misbehaving or supply-chain-compromised
contract could return an arbitrarily large `Bytes` payload. Every downstream
consumer — JavaScript SDK, Horizon indexer, RPC node, third-party integration —
must allocate a buffer proportional to `len` to deserialize the value. A 2 GiB
`len` field would OOM almost any process.

This is a **defence-in-depth** fix. There is no public incident. The gap is the
kind a careful auditor would flag before any external review, and closing it now
is cheaper than remediating it under fire.

---

## What changed

| File | Change |
|---|---|
| `remitwise-common/src/lib.rs` | `MAX_BYTES_RETURN = 8192`, typed `BytesReturnError::ReturnTooLarge` (`#[contracterror]`), `guard_bytes_len()` helper |
| `remittance_split/src/lib.rs` | `ReturnBytesTooLarge = 28` in `RemittanceSplitError`; `get_request_hash` now returns `Result<Bytes, RemittanceSplitError>`; guard applied before returning; `distribute_usdc_hashed` propagates with `?` |
| `remitwise-common/src/tests.rs` | 4 unit tests for `guard_bytes_len` (empty, at-limit, one-over-limit, far-above-limit) |
| `remittance_split/src/test.rs` | 1 new contract-level test (`test_get_request_hash_passes_xdr_length_guard`); 8 direct struct call sites updated to `.unwrap()` |

---

## Acceptance criteria

- [x] Change matches the summary — reject returns > `MAX_BYTES_RETURN`
- [x] Negative test exercises the new check (`test_guard_bytes_len_rejects_oversized_value` — could not be written before the fix, passes after)
- [x] PR description names the threat being mitigated (unbounded `ScBytes` allocation → consumer DoS)
- [x] Typed `#[contracterror]` (`BytesReturnError::ReturnTooLarge`) surfaced instead of panic or generic error
- [x] WASM build passes: `cargo build -p remittance_split --target wasm32-unknown-unknown --release`
- [x] `remitwise-common` lib clippy clean: `cargo clippy -p remitwise-common --lib -- -D warnings`
- [x] `#![no_std]` discipline maintained — no `std::` calls introduced

---

## Performance

`guard_bytes_len` is a single `u32` comparison (`bytes.len() > 8192`). SHA-256
always produces exactly 32 bytes, so the guard exits the fast path immediately.
No measurable overhead on the hot path.

---

## Out of scope

Pre-existing test failures and clippy warnings in the test file are not touched,
per the issue's out-of-scope guidance.