### PR TITLE
refactor(savings): return typed errors from tag mutators

### DIFF
--- a/savings_goals/src/lib.rs
+++ b/savings_goals/src/lib.rs
@@ -802,7 +802,17 @@ impl SavingsGoalContract {
     /// - Duplicate tags are preserved as provided.
     /// - Maintains canonicalized tag index; each (owner, tag) maps to goal IDs.
     /// - Emits `(savings, tags_add)` with `(goal_id, caller, tags)`.
-    pub fn add_tags_to_goal(env: Env, caller: Address, goal_id: u32, tags: Vec<String>) {
+    ///
+    /// # Errors
+    /// - `GoalNotFound` if `goal_id` does not exist.
+    /// - `Unauthorized` if `caller` is not the goal owner.
+    /// - `InvalidTagContent` if any tag contains unsupported characters.
+    pub fn add_tags_to_goal(
+        env: Env,
+        caller: Address,
+        goal_id: u32,
+        tags: Vec<String>,
+    ) -> Result<(), SavingsGoalError> {
         caller.require_auth();
         let normalized_tags = Self::validate_and_normalize_tags(&env, &tags);
         Self::extend_instance_ttl(&env);
@@ -815,13 +825,13 @@ impl SavingsGoalContract {
             Some(g) => g,
             None => {
                 Self::append_audit(&env, symbol_short!("add_tags"), &caller, false);
-                panic!("Goal not found");
+                return Err(SavingsGoalError::GoalNotFound);
             }
         };
 
         if goal.owner != caller {
             Self::append_audit(&env, symbol_short!("add_tags"), &caller, false);
-            panic!("Only the goal owner can add tags");
+            return Err(SavingsGoalError::Unauthorized);
         }
 
         for tag in normalized_tags.iter() {
@@ -852,6 +862,7 @@ impl SavingsGoalContract {
         );
 
         Self::append_audit(&env, symbol_short!("add_tags"), &caller, true);
+        Ok(())
     }
 
     /// Removes tags from a goal's metadata and updates the tag index.
@@ -864,7 +875,17 @@ impl SavingsGoalContract {
     /// - Removing a tag that is not present is a no-op.
     /// - Removes goal ID from tag index for each removed tag.
     /// - Emits `(savings, tags_rem)` with `(goal_id, caller, tags)`.
-    pub fn remove_tags_from_goal(env: Env, caller: Address, goal_id: u32, tags: Vec<String>) {
+    ///
+    /// # Errors
+    /// - `GoalNotFound` if `goal_id` does not exist.
+    /// - `Unauthorized` if `caller` is not the goal owner.
+    /// - `InvalidTagContent` if any tag contains unsupported characters.
+    pub fn remove_tags_from_goal(
+        env: Env,
+        caller: Address,
+        goal_id: u32,
+        tags: Vec<String>,
+    ) -> Result<(), SavingsGoalError> {
         caller.require_auth();
         let normalized_tags = Self::validate_and_normalize_tags(&env, &tags);
         Self::extend_instance_ttl(&env);
@@ -877,13 +898,13 @@ impl SavingsGoalContract {
             Some(g) => g,
             None => {
                 Self::append_audit(&env, symbol_short!("rem_tags"), &caller, false);
-                panic!("Goal not found");
+                return Err(SavingsGoalError::GoalNotFound);
             }
         };
 
         if goal.owner != caller {
             Self::append_audit(&env, symbol_short!("rem_tags"), &caller, false);
-            panic!("Only the goal owner can remove tags");
+            return Err(SavingsGoalError::Unauthorized);
         }
 
         let mut new_tags = Vec::new(&env);
@@ -925,6 +946,7 @@ impl SavingsGoalContract {
         );
 
         Self::append_audit(&env, symbol_short!("rem_tags"), &caller, true);
+        Ok(())
     }
 
     // -----------------------------------------------------------------------

--- a/savings_goals/src/test.rs
+++ b/savings_goals/src/test.rs
@@ -3732,7 +3732,7 @@ fn test_add_tags_to_goal_unauthorized() {
     tags.push_back(String::from_str(&env, "urgent"));
 
     let res = client.try_add_tags_to_goal(&other, &goal_id, &tags);
-    assert!(res.is_err());
+    assert_eq!(res.unwrap_err().unwrap(), SavingsGoalError::Unauthorized);
 }
 
 #[test]
@@ -3757,7 +3757,7 @@ fn test_remove_tags_from_goal_unauthorized() {
     client.add_tags_to_goal(&user, &goal_id, &tags);
 
     let res = client.try_remove_tags_from_goal(&other, &goal_id, &tags);
-    assert!(res.is_err());
+    assert_eq!(res.unwrap_err().unwrap(), SavingsGoalError::Unauthorized);
 }
 
 #[test]
@@ -3920,8 +3920,7 @@ fn test_add_tags_to_goal_invalid_char_panics() {
 }
 
 #[test]
-#[should_panic(expected = "Goal not found")]
-fn test_add_tags_to_goal_nonexistent_goal_panics() {
+fn test_add_tags_to_goal_nonexistent_goal_returns_typed_error() {
     let env = Env::default();
     let contract_id = env.register_contract(None, SavingsGoalContract);
     let client = SavingsGoalContractClient::new(&env, &contract_id);
@@ -3931,12 +3930,12 @@ fn test_add_tags_to_goal_nonexistent_goal_panics() {
     env.mock_all_auths();
     let mut tags = SorobanVec::new(&env);
     tags.push_back(String::from_str(&env, "urgent"));
-    client.add_tags_to_goal(&user, &999, &tags);
+    let res = client.try_add_tags_to_goal(&user, &999, &tags);
+    assert_eq!(res.unwrap_err().unwrap(), SavingsGoalError::GoalNotFound);
 }
 
 #[test]
-#[should_panic(expected = "Goal not found")]
-fn test_remove_tags_from_goal_nonexistent_goal_panics() {
+fn test_remove_tags_from_goal_nonexistent_goal_returns_typed_error() {
     let env = Env::default();
     let contract_id = env.register_contract(None, SavingsGoalContract);
     let client = SavingsGoalContractClient::new(&env, &contract_id);
@@ -3946,7 +3945,8 @@ fn test_remove_tags_from_goal_nonexistent_goal_panics() {
     env.mock_all_auths();
     let mut tags = SorobanVec::new(&env);
     tags.push_back(String::from_str(&env, "urgent"));
-    client.remove_tags_from_goal(&user, &999, &tags);
+    let res = client.try_remove_tags_from_goal(&user, &999, &tags);
+    assert_eq!(res.unwrap_err().unwrap(), SavingsGoalError::GoalNotFound);
 }
 
 /// Owner-only authorization: a non-owner must not be able to remove tags.
@@ -6169,7 +6169,7 @@ fn test_remove_last_tag_leaves_empty_tags_and_cleans_index() {
 
 /// Owner-only authorization: non-owner must fail removal.
 #[test]
-fn test_remove_tags_from_goal_non_owner_auth_panics() {
+fn test_remove_tags_from_goal_non_owner_returns_typed_error() {
     let env = Env::default();
     let contract_id = env.register_contract(None, SavingsGoalContract);
     let client = SavingsGoalContractClient::new(&env, &contract_id);
@@ -6202,8 +6202,8 @@ fn test_remove_tags_from_goal_non_owner_auth_panics() {
         },
     }]);
 
-    // Should panic due to auth mismatch before/at ownership check.
-    let _ = client.try_remove_tags_from_goal(&other, &goal_id, &tags);
+    let res = client.try_remove_tags_from_goal(&other, &goal_id, &tags);
+    assert_eq!(res.unwrap_err().unwrap(), SavingsGoalError::Unauthorized);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- convert add_tags_to_goal and remove_tags_from_goal missing-goal paths from panic! to SavingsGoalError::GoalNotFound
- convert owner-mismatch paths from panic! to SavingsGoalError::Unauthorized
- add error doc comments and update existing tests to assert typed errors

## Validation
- cargo fmt -p savings_goals -- --check
- git diff --check

Attempted but blocked locally:
- cargo test -p savings_goals tags_to_goal --locked -- --nocapture
- Blocker: local Cargo is 1.84.0 and cannot parse locked dependency base64ct 1.8.3 because it requires edition2024/Rust 1.85+. This environment has no rustup; the repo toolchain is stable, so CI with newer stable should be able to run it.

## Security notes
- Authorization requirement via caller.require_auth() is unchanged.
- Invalid tag content behavior is preserved.
- Only the public ABI error surface changes for goal-not-found and owner-mismatch tag mutations.

Fixes #1015