### PR TITLE
fix: return InvalidAmount on unpaid total overflow

### DIFF
--- a/bill_payments/src/events_schema_test.rs
+++ b/bill_payments/src/events_schema_test.rs
@@ -182,10 +182,16 @@ fn reserved_bill_event_variants_serialize_as_enum_not_symbol() {
         // Round-trip: decode back to BillEvent — must succeed (not be a raw Symbol).
         let decoded = BillEvent::try_from_val(&env, &val)
             .expect("BillEvent variant must deserialize from its own serialized form");
-        // Ensure the decoded variant matches the original by comparing wire payload.
-        let orig_val: Val = variant.into_val(&env);
-        assert_eq!(val.get_payload(), orig_val.get_payload());
-        let _ = decoded;
+        let matches_original = matches!(
+            (&variant, &decoded),
+            (BillEvent::Cancelled, BillEvent::Cancelled)
+                | (BillEvent::Restored, BillEvent::Restored)
+                | (BillEvent::ExternalRefUpdated, BillEvent::ExternalRefUpdated)
+        );
+        assert!(
+            matches_original,
+            "BillEvent variant decoded to a different enum case"
+        );
     }
 }
 

--- a/bill_payments/src/lib.rs
+++ b/bill_payments/src/lib.rs
@@ -1523,10 +1523,13 @@ impl BillPayments {
                         tags: Vec::new(&env),
                         currency: schedule.currency.clone(),
                     };
+                    if Self::adjust_unpaid_total(&env, &schedule.owner, schedule.amount).is_err()
+                    {
+                        continue;
+                    }
                     bills.set(next_id, child);
                     Self::index_add_active(&env, &schedule.owner, next_id);
                     Self::index_add_currency(&env, &schedule.owner, &schedule.currency, next_id);
-                    Self::adjust_unpaid_total(&env, &schedule.owner, schedule.amount);
 
                     env.events().publish(
                         (symbol_short!("bill"), BillEvent::RecurringBillCreated),
@@ -1682,6 +1685,7 @@ impl BillPayments {
             .get(&symbol_short!("NEXT_ID"))
             .unwrap_or(0u32)
             + 1;
+        let next_unpaid_total = Self::checked_unpaid_total_after(&env, &owner, amount)?;
 
         // Enforce uniqueness for external_ref if provided
         if let Some(ref r) = validated_ext_ref {
@@ -1720,7 +1724,7 @@ impl BillPayments {
         Self::index_add_active(&env, &bill_owner, next_id);
         // Update currency index
         Self::index_add_currency(&env, &bill_owner, &bill_currency, next_id);
-        Self::adjust_unpaid_total(&env, &bill_owner, amount);
+        Self::store_unpaid_total(&env, &bill_owner, next_unpaid_total);
 
         // Emit event for audit trail
         env.events().publish(
@@ -1790,6 +1794,15 @@ impl BillPayments {
         }
 
         let current_time = env.ledger().timestamp();
+        let next_unpaid_total = if bill.recurring {
+            None
+        } else {
+            Some(Self::checked_unpaid_total_after(
+                &env,
+                &caller,
+                -bill.amount,
+            )?)
+        };
         bill.paid = true;
         bill.paid_at = Some(current_time);
 
@@ -1834,7 +1847,6 @@ impl BillPayments {
                 tags: bill.tags.clone(),
                 currency: bill.currency.clone(),
             };
-            let next_bill_amount = next_bill.amount;
             bills.set(next_id, next_bill);
             env.storage()
                 .instance()
@@ -1843,8 +1855,6 @@ impl BillPayments {
             Self::index_add_active(&env, &caller, next_id);
             // Update currency index for the newly created recurring bill
             Self::index_add_currency(&env, &caller, &bill.currency, next_id);
-            // Update unpaid total for the new recurring bill
-            Self::adjust_unpaid_total(&env, &caller, next_bill_amount);
             env.events().publish(
                 (symbol_short!("bill"), BillEvent::RecurringBillCreated),
                 (next_id, bill_id, next_due_date),
@@ -1858,8 +1868,9 @@ impl BillPayments {
         env.storage()
             .instance()
             .set(&symbol_short!("BILLS"), &bills);
-        // Always adjust unpaid total when a bill is paid, even if it's recurring
-        Self::adjust_unpaid_total(&env, &caller, -paid_amount);
+        if let Some(next_total) = next_unpaid_total {
+            Self::store_unpaid_total(&env, &caller, next_total);
+        }
         env.events().publish(
             (symbol_short!("bill"), BillEvent::Paid),
             (bill_id, caller.clone(), bill_ext_ref),
@@ -2641,7 +2652,7 @@ impl BillPayments {
             .instance()
             .set(&symbol_short!("BILLS"), &bills);
         if removed_unpaid_amount > 0 {
-            Self::adjust_unpaid_total(&env, &caller, -removed_unpaid_amount);
+            Self::adjust_unpaid_total(&env, &caller, -removed_unpaid_amount)?;
         }
         // Remove from owner index
         Self::index_remove_active(&env, &caller, bill_id);
@@ -2940,8 +2951,38 @@ impl BillPayments {
             .get(&symbol_short!("BILLS"))
             .unwrap_or_else(|| Map::new(&env));
 
-        let mut success_count = 0u32;
+        let mut preview_bills = bills.clone();
         let mut unpaid_delta = 0i128;
+        for bill_id in bill_ids.iter() {
+            let mut bill = match preview_bills.get(bill_id) {
+                Some(b) => b,
+                None => continue,
+            };
+
+            if bill.owner != caller || bill.paid {
+                continue;
+            }
+
+            if !bill.recurring {
+                unpaid_delta = unpaid_delta
+                    .checked_sub(bill.amount)
+                    .ok_or(Error::InvalidAmount)?;
+            }
+
+            bill.paid = true;
+            preview_bills.set(bill_id, bill);
+        }
+        let next_unpaid_total = if unpaid_delta != 0 {
+            Some(Self::checked_unpaid_total_after(
+                &env,
+                &caller,
+                unpaid_delta,
+            )?)
+        } else {
+            None
+        };
+
+        let mut success_count = 0u32;
         let current_time = env.ledger().timestamp();
         let mut next_id = env
             .storage()
@@ -3002,8 +3043,6 @@ impl BillPayments {
                     (symbol_short!("bill"), BillEvent::RecurringBillCreated),
                     (next_id, bill_id, next_due_date),
                 );
-            } else {
-                unpaid_delta = unpaid_delta.saturating_sub(amount);
             }
 
             let external_ref = bill.external_ref.clone();
@@ -3030,8 +3069,8 @@ impl BillPayments {
             .instance()
             .set(&symbol_short!("BILLS"), &bills);
 
-        if unpaid_delta != 0 {
-            Self::adjust_unpaid_total(&env, &caller, unpaid_delta);
+        if let Some(next_total) = next_unpaid_total {
+            Self::store_unpaid_total(&env, &caller, next_total);
         }
 
         Self::update_storage_stats(&env);
@@ -3325,21 +3364,64 @@ impl BillPayments {
         idx.get(owner.clone()).unwrap_or_else(|| Vec::new(env))
     }
 
-    fn adjust_unpaid_total(env: &Env, owner: &Address, delta: i128) {
-        if delta == 0 {
-            return;
-        }
-        let mut totals: Map<Address, i128> = env
+    fn checked_unpaid_total_after(
+        env: &Env,
+        owner: &Address,
+        delta: i128,
+    ) -> Result<i128, BillPaymentsError> {
+        let totals: Map<Address, i128> = env
             .storage()
             .instance()
             .get(&STORAGE_UNPAID_TOTALS)
             .unwrap_or_else(|| Map::new(env));
         let current = totals.get(owner.clone()).unwrap_or(0);
-        let next = current.saturating_add(delta);
+        if current < 0 {
+            return Err(BillPaymentsError::InvalidAmount);
+        }
+
+        let next = if delta >= 0 {
+            current
+                .checked_add(delta)
+                .ok_or(BillPaymentsError::InvalidAmount)?
+        } else {
+            let decrement = delta
+                .checked_neg()
+                .ok_or(BillPaymentsError::InvalidAmount)?;
+            let next = current
+                .checked_sub(decrement)
+                .ok_or(BillPaymentsError::InvalidAmount)?;
+            if next < 0 {
+                return Err(BillPaymentsError::InvalidAmount);
+            }
+            next
+        };
+
+        Ok(next)
+    }
+
+    fn store_unpaid_total(env: &Env, owner: &Address, next: i128) {
+        let mut totals: Map<Address, i128> = env
+            .storage()
+            .instance()
+            .get(&STORAGE_UNPAID_TOTALS)
+            .unwrap_or_else(|| Map::new(env));
         totals.set(owner.clone(), next);
         env.storage()
             .instance()
             .set(&STORAGE_UNPAID_TOTALS, &totals);
+    }
+
+    fn adjust_unpaid_total(
+        env: &Env,
+        owner: &Address,
+        delta: i128,
+    ) -> Result<(), BillPaymentsError> {
+        if delta == 0 {
+            return Ok(());
+        }
+        let next = Self::checked_unpaid_total_after(env, owner, delta)?;
+        Self::store_unpaid_total(env, owner, next);
+        Ok(())
     }
 }
 

--- a/bill_payments/src/lib.rs
+++ b/bill_payments/src/lib.rs
@@ -2951,10 +2951,14 @@ impl BillPayments {
             .get(&symbol_short!("BILLS"))
             .unwrap_or_else(|| Map::new(&env));
 
-        let mut preview_bills = bills.clone();
+        let mut preflight_paid_ids: Vec<u32> = Vec::new(&env);
         let mut unpaid_delta = 0i128;
         for bill_id in bill_ids.iter() {
-            let mut bill = match preview_bills.get(bill_id) {
+            if preflight_paid_ids.contains(bill_id) {
+                continue;
+            }
+
+            let bill = match bills.get(bill_id) {
                 Some(b) => b,
                 None => continue,
             };
@@ -2969,8 +2973,7 @@ impl BillPayments {
                     .ok_or(Error::InvalidAmount)?;
             }
 
-            bill.paid = true;
-            preview_bills.set(bill_id, bill);
+            preflight_paid_ids.push_back(bill_id);
         }
         let next_unpaid_total = if unpaid_delta != 0 {
             Some(Self::checked_unpaid_total_after(

--- a/bill_payments/src/test.rs
+++ b/bill_payments/src/test.rs
@@ -1135,7 +1135,7 @@ mod testsuit {
 
         create_n_bills(&client, &env, &owner, 12);
 
-        let page = client.get_all_bills_page(&admin, &0, &5).unwrap();
+        let page = client.get_all_bills_page(&admin, &0, &5);
         assert_eq!(page.items.len(), 5, "first page must have exactly 5 items");
         assert!(page.next_cursor > 0, "must have a non-zero next_cursor when more pages exist");
     }
@@ -1156,7 +1156,7 @@ mod testsuit {
         let mut cursor = 0u32;
         let mut total_seen = 0u32;
         for _ in 0..10 {
-            let page = client.get_all_bills_page(&admin, &cursor, &3).unwrap();
+            let page = client.get_all_bills_page(&admin, &cursor, &3);
             total_seen += page.items.len();
             if page.next_cursor == 0 {
                 break;
@@ -1181,7 +1181,7 @@ mod testsuit {
         create_n_bills(&client, &env, &alice, 3);
         create_n_bills(&client, &env, &bob, 3);
 
-        let page = client.get_all_bills_page(&admin, &0, &100).unwrap();
+        let page = client.get_all_bills_page(&admin, &0, &100);
         assert_eq!(
             page.items.len(), 6,
             "admin should see bills from all 6 owners combined"
@@ -1198,7 +1198,7 @@ mod testsuit {
         env.mock_all_auths();
         client.set_pause_admin(&admin, &admin);
 
-        let page = client.get_all_bills_page(&admin, &0, &10).unwrap();
+        let page = client.get_all_bills_page(&admin, &0, &10);
         assert_eq!(page.items.len(), 0, "empty contract must return 0 items");
         assert_eq!(page.next_cursor, 0, "empty page must have cursor 0");
     }
@@ -2976,6 +2976,133 @@ mod testsuit {
         );
     }
 
+    fn seed_cached_unpaid_total(env: &Env, contract_id: &Address, owner: &Address, total: i128) {
+        env.as_contract(contract_id, || {
+            let mut totals: Map<Address, i128> = Map::new(env);
+            totals.set(owner.clone(), total);
+            env.storage()
+                .instance()
+                .set(&STORAGE_UNPAID_TOTALS, &totals);
+        });
+    }
+
+    fn seed_storage_stats(env: &Env, contract_id: &Address, total_unpaid_amount: i128) {
+        env.as_contract(contract_id, || {
+            env.storage().instance().set(
+                &symbol_short!("STOR_STAT"),
+                &StorageStats {
+                    active_bills: 7,
+                    archived_bills: 2,
+                    total_unpaid_amount,
+                    total_archived_amount: 11,
+                    last_updated: 42,
+                },
+            );
+        });
+    }
+
+    #[test]
+    fn test_create_bill_rejects_unpaid_total_overflow_without_state_change() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, BillPayments);
+        let client = BillPaymentsClient::new(&env, &contract_id);
+        let owner = <soroban_sdk::Address as AddressTrait>::generate(&env);
+        env.mock_all_auths();
+
+        seed_cached_unpaid_total(&env, &contract_id, &owner, i128::MAX);
+        seed_storage_stats(&env, &contract_id, i128::MAX);
+
+        let result = client.try_create_bill(
+            &owner,
+            &String::from_str(&env, "Overflow"),
+            &1,
+            &1_000_000,
+            &false,
+            &0,
+            &None,
+            &String::from_str(&env, "XLM"),
+            &None,
+        );
+
+        assert_eq!(result, Err(Ok(Error::InvalidAmount)));
+        assert!(
+            client.get_bill(&1).is_none(),
+            "overflow rejection must not create a bill"
+        );
+        assert_eq!(client.get_total_unpaid(&owner), i128::MAX);
+        let stats = client.get_storage_stats();
+        assert_eq!(stats.total_unpaid_amount, i128::MAX);
+        assert_eq!(stats.active_bills, 7);
+    }
+
+    #[test]
+    fn test_pay_bill_rejects_unpaid_total_underflow_without_state_change() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, BillPayments);
+        let client = BillPaymentsClient::new(&env, &contract_id);
+        let owner = <soroban_sdk::Address as AddressTrait>::generate(&env);
+        env.mock_all_auths();
+
+        let bill_id = client.create_bill(
+            &owner,
+            &String::from_str(&env, "Underflow"),
+            &100,
+            &1_000_000,
+            &false,
+            &0,
+            &None,
+            &String::from_str(&env, "XLM"),
+            &None,
+        );
+        seed_cached_unpaid_total(&env, &contract_id, &owner, 0);
+        seed_storage_stats(&env, &contract_id, 0);
+
+        let result = client.try_pay_bill(&owner, &bill_id);
+
+        assert_eq!(result, Err(Ok(Error::InvalidAmount)));
+        assert!(
+            !client.get_bill(&bill_id).unwrap().paid,
+            "underflow rejection must not mark the bill paid"
+        );
+        assert_eq!(client.get_total_unpaid(&owner), 0);
+        assert_eq!(client.get_storage_stats().total_unpaid_amount, 0);
+    }
+
+    #[test]
+    fn test_batch_pay_bills_rejects_unpaid_total_underflow_without_state_change() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, BillPayments);
+        let client = BillPaymentsClient::new(&env, &contract_id);
+        let owner = <soroban_sdk::Address as AddressTrait>::generate(&env);
+        env.mock_all_auths();
+
+        let bill_id = client.create_bill(
+            &owner,
+            &String::from_str(&env, "Batch Underflow"),
+            &100,
+            &1_000_000,
+            &false,
+            &0,
+            &None,
+            &String::from_str(&env, "XLM"),
+            &None,
+        );
+        let mut ids = Vec::new(&env);
+        ids.push_back(bill_id);
+        seed_cached_unpaid_total(&env, &contract_id, &owner, 0);
+        seed_storage_stats(&env, &contract_id, 0);
+
+        let result = client.try_batch_pay_bills(&owner, &ids);
+
+        assert_eq!(result, Err(Ok(Error::InvalidAmount)));
+        assert!(
+            !client.get_bill(&bill_id).unwrap().paid,
+            "batch underflow rejection must not mark the bill paid"
+        );
+        assert_eq!(client.get_total_unpaid(&owner), 0);
+        assert_eq!(client.get_storage_stats().total_unpaid_amount, 0);
+    }
+
     // --- Recurring bill creates a new unpaid bill: total includes the new one ---
 
     #[test]
@@ -3302,6 +3429,7 @@ mod testsuit {
         assert_eq!(result, Err(Ok(Error::Unauthorized)));
     }
 
+    #[allow(clippy::enum_variant_names)]
     #[derive(Debug, Clone)]
     enum Operation {
         CreateBill {
@@ -3369,7 +3497,7 @@ mod testsuit {
                         if active_bill_ids.contains(&bill_id) {
                             let _ = client.try_pay_bill(&owner, &bill_id);
                             // When you pay a recurring bill, it might create a new bill, so let's check
-                            if let Some(next) = client.get_bill(&(next_bill_id)) {
+                            if let Some(_next) = client.get_bill(&(next_bill_id)) {
                                 active_bill_ids.push_back(next_bill_id);
                                 next_bill_id +=1;
                             }

--- a/bill_payments/src/tests_bill_schedule_exec.rs
+++ b/bill_payments/src/tests_bill_schedule_exec.rs
@@ -4,7 +4,7 @@ extern crate std;
 
 use bill_payments::{BillEvent, BillPayments, BillPaymentsClient, BillPaymentsError};
 use soroban_sdk::{
-    testutils::{Address as AddressTrait, EnvTestConfig, Events},
+    testutils::{EnvTestConfig, Events},
     Address, Env, String, TryFromVal,
 };
 use testutils::{generate_test_address, set_ledger_time};
@@ -263,7 +263,7 @@ fn test_execution_respects_max_bills_per_owner() {
 
     let bills = client.get_all_unpaid_bills_legacy(&owner);
     assert_eq!(
-        bills.len() as u32,
+        bills.len(),
         bill_payments::MAX_BILLS_PER_OWNER,
         "no new bill should be created when owner is at cap"
     );
@@ -292,7 +292,7 @@ fn test_get_bill_schedules_returns_owner_schedules() {
 
 #[test]
 fn test_get_bill_schedule_returns_none_for_missing() {
-    let (env, client, _owner) = setup();
+    let (_env, client, _owner) = setup();
 
     let sched = client.get_bill_schedule(&9999);
     assert!(sched.is_none());
@@ -354,7 +354,7 @@ fn test_modify_bill_schedule_unauthorized_fails() {
 
 #[test]
 fn test_cancel_bill_schedule_schedule_not_found_fails() {
-    let (env, client, owner) = setup();
+    let (_env, client, owner) = setup();
 
     let result = client.try_cancel_bill_schedule(&owner, &9999);
     assert_eq!(result, Err(Ok(BillPaymentsError::ScheduleNotFound)));
@@ -397,12 +397,11 @@ fn count_bill_event_variant(env: &Env, expected: &BillEvent) -> u32 {
             continue;
         }
         if let Ok(event) = BillEvent::try_from_val(env, &topics.get(1).unwrap()) {
-            let matches = match (&event, expected) {
-                (BillEvent::ScheduleCreated, BillEvent::ScheduleCreated) => true,
-                (BillEvent::ScheduleExecuted, BillEvent::ScheduleExecuted) => true,
-                _ => false,
-            };
-            if matches {
+            if matches!(
+                (&event, expected),
+                (BillEvent::ScheduleCreated, BillEvent::ScheduleCreated)
+                    | (BillEvent::ScheduleExecuted, BillEvent::ScheduleExecuted)
+            ) {
                 count += 1;
             }
         }

--- a/bill_payments/tests/stress_test_large_amounts.rs
+++ b/bill_payments/tests/stress_test_large_amounts.rs
@@ -9,9 +9,9 @@
 //!
 //! ## Documented Limitations
 //! - Maximum safe bill amount: i128::MAX/2 (to allow for safe addition operations)
-//! - get_total_unpaid and unpaid-total cache updates use saturating arithmetic
+//! - unpaid-total cache updates reject overflow instead of saturating
 
-use bill_payments::{BillPayments, BillPaymentsClient};
+use bill_payments::{BillPayments, BillPaymentsClient, Error};
 use soroban_sdk::testutils::{Address as AddressTrait, Ledger, LedgerInfo};
 use soroban_sdk::{Env, String};
 
@@ -168,7 +168,7 @@ fn test_get_total_unpaid_with_two_large_bills() {
 }
 
 #[test]
-fn test_get_total_unpaid_saturates_on_overflow() {
+fn test_get_total_unpaid_rejects_create_overflow() {
     let env = Env::default();
     let contract_id = env.register_contract(None, BillPayments);
     let client = BillPaymentsClient::new(&env, &contract_id);
@@ -192,7 +192,7 @@ fn test_get_total_unpaid_saturates_on_overflow() {
     );
 
     env.mock_all_auths();
-    client.create_bill(
+    let result = client.try_create_bill(
         &owner,
         &String::from_str(&env, "Bill2"),
         &amount,
@@ -204,18 +204,18 @@ fn test_get_total_unpaid_saturates_on_overflow() {
         &None,
     );
 
-    // get_total_unpaid should saturate instead of panicking
-    // When overflow would occur, result should be i128::MAX
+    assert_eq!(result, Err(Ok(Error::InvalidAmount)));
     let total = client.get_total_unpaid(&owner);
     assert_eq!(
         total,
-        i128::MAX,
-        "get_total_unpaid should saturate to i128::MAX on overflow, not panic"
+        amount,
+        "overflow rejection must preserve the existing unpaid total"
     );
+    assert!(client.get_bill(&2).is_none());
 }
 
 #[test]
-fn test_get_total_unpaid_by_currency_saturates_on_overflow() {
+fn test_get_total_unpaid_by_currency_rejects_create_overflow() {
     let env = Env::default();
     let contract_id = env.register_contract(None, BillPayments);
     let client = BillPaymentsClient::new(&env, &contract_id);
@@ -239,7 +239,7 @@ fn test_get_total_unpaid_by_currency_saturates_on_overflow() {
     );
 
     env.mock_all_auths();
-    client.create_bill(
+    let result = client.try_create_bill(
         &owner,
         &String::from_str(&env, "USDC Bill 2"),
         &amount,
@@ -251,12 +251,12 @@ fn test_get_total_unpaid_by_currency_saturates_on_overflow() {
         &None,
     );
 
-    // get_total_unpaid_by_currency should saturate on overflow
+    assert_eq!(result, Err(Ok(Error::InvalidAmount)));
     let total = client.get_total_unpaid_by_currency(&owner, &String::from_str(&env, "USDC"));
     assert_eq!(
         total,
-        i128::MAX,
-        "get_total_unpaid_by_currency should saturate to i128::MAX on overflow"
+        amount,
+        "overflow rejection must preserve the existing USDC total"
     );
 
     // Create a XLM bill and verify it's not included in USDC total
@@ -273,9 +273,9 @@ fn test_get_total_unpaid_by_currency_saturates_on_overflow() {
         &None,
     );
 
-    // USDC total should still be saturated
+    // USDC total should be unchanged by the rejected second USDC bill.
     let usdc_total = client.get_total_unpaid_by_currency(&owner, &String::from_str(&env, "USDC"));
-    assert_eq!(usdc_total, i128::MAX);
+    assert_eq!(usdc_total, amount);
 
     // XLM total should only include XLM bills
     let xlm_total = client.get_total_unpaid_by_currency(&owner, &String::from_str(&env, "XLM"));
@@ -564,7 +564,6 @@ fn test_recurring_bill_frequency_overflow_protection() {
     );
 
     // Should fail with InvalidFrequency
-    use bill_payments::Error;
     assert_eq!(result, Err(Ok(Error::InvalidFrequency)));
 }
 

--- a/bill_payments/tests/unpaid_by_currency_pagination.rs
+++ b/bill_payments/tests/unpaid_by_currency_pagination.rs
@@ -58,6 +58,20 @@ fn make_env() -> Env {
     env
 }
 
+fn set_ledger_time(env: &Env, timestamp: u64) {
+    let proto = env.ledger().protocol_version();
+    env.ledger().set(LedgerInfo {
+        protocol_version: proto,
+        sequence_number: env.ledger().sequence() + 1,
+        timestamp,
+        network_id: [0; 32],
+        base_reserve: 10,
+        min_temp_entry_ttl: 1,
+        min_persistent_entry_ttl: 1,
+        max_entry_ttl: 700_000,
+    });
+}
+
 fn setup(env: &Env) -> (BillPaymentsClient<'_>, Address) {
     let id = env.register_contract(None, BillPayments);
     let client = BillPaymentsClient::new(env, &id);
@@ -83,6 +97,12 @@ fn create_bill_currency(
         &String::from_str(env, currency),
         &None,
     )
+}
+
+fn advance_create_rate_limit_window(env: &Env, iteration: u32) {
+    if iteration > 0 && iteration.is_multiple_of(50) {
+        set_ledger_time(env, env.ledger().timestamp() + 86_401);
+    }
 }
 
 /// Exhaust `get_unpaid_bills_by_currency` via cursor pagination and return all
@@ -144,6 +164,8 @@ fn seed_mixed(
     let mut expected_ids: std::vec::Vec<u32> = std::vec::Vec::new();
 
     for i in 0..n_target {
+        advance_create_rate_limit_window(env, i);
+
         // Unpaid USDC bill (target)
         let id = create_bill_currency(env, client, owner, "USDC");
         expected_ids.push(id);
@@ -242,6 +264,8 @@ fn union_equals_set_n1000() {
     // Use n_target = 500 with interleaving ratio trimmed to stay under cap.
     let mut expected_ids: std::vec::Vec<u32> = std::vec::Vec::new();
     for i in 0u32..500 {
+        advance_create_rate_limit_window(&env, i);
+
         let id = create_bill_currency(&env, &client, &owner, "USDC");
         expected_ids.push(id);
         // Only add paid bill every 4th to stay under the 1000-bill cap


### PR DESCRIPTION
Closes #1018

Summary:
- replace saturating unpaid-total cache updates with checked arithmetic that returns InvalidAmount on overflow or underflow
- propagate checked unpaid-total failures through create_bill, pay_bill, batch_pay_bills, cancel_bill, and schedule execution
- add regression coverage for overflow/underflow state preservation and update stale large-amount/pagination baseline tests

Tests:
- PATH="$HOME/.cargo/bin:$PATH" cargo test -p bill_payments
- PATH="$HOME/.cargo/bin:$PATH" cargo clippy -p bill_payments --all-targets -- -D warnings

CI note:
- Public workspace CI is currently failing in unrelated reporting crate checks before this bill_payments patch is implicated. The focused bill_payments test/clippy commands above pass locally.