### PR TITLE
feat(remittance): add signed split allocation quotes

### DIFF
--- a/remittance_split/src/lib.rs
+++ b/remittance_split/src/lib.rs
@@ -15,7 +15,7 @@ use remitwise_common::{
 };
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, symbol_short, token::TokenClient, vec,
-    Address, Bytes, BytesN, Env, IntoVal, Map, Symbol, Vec,
+    xdr::ToXdr, Address, Bytes, BytesN, Env, IntoVal, Map, Symbol, Vec,
 };
 
 // Event topics
@@ -116,6 +116,32 @@ pub struct DistributeUsdcRequest {
     /// Total USDC amount to distribute
     pub total_amount: i128,
     /// Deadline timestamp (Unix seconds) - request is invalid after this time
+    pub deadline: u64,
+}
+
+/// Domain-separated payload for signed allocation quotes.
+///
+/// The payload binds the functional quote domain, network, contract instance,
+/// caller, requested total amount, and deadline. Off-chain integrators can call
+/// [`RemittanceSplit::get_split_allocations_hash`] to derive the exact hash,
+/// sign it with `caller`, and then pass it to
+/// [`RemittanceSplit::get_split_allocations_signed`] for an authenticated quote
+/// that is deadline-bound and parity-checked against the unsigned allocation
+/// read path.
+#[derive(Clone)]
+#[contracttype]
+pub struct SplitAllocationsQuotePayload {
+    /// Domain identifier for allocation quote separation.
+    pub domain_id: Symbol,
+    /// Network ID to prevent replay across Stellar networks.
+    pub network_id: BytesN<32>,
+    /// Contract address to prevent replay across contract instances.
+    pub contract_addr: Address,
+    /// Address authorizing the quote.
+    pub caller: Address,
+    /// Total amount being quoted.
+    pub total_amount: i128,
+    /// Ledger timestamp after which the quote is invalid.
     pub deadline: u64,
 }
 
@@ -1527,6 +1553,64 @@ impl RemittanceSplit {
         Ok(result)
     }
 
+    /// Compute the canonical SHA-256 binding hash for a signed allocation quote.
+    ///
+    /// Hash preimage layout (concatenated, in order):
+    /// 1. `DISTRIBUTE_USDC_DOMAIN` — shared signing domain separator
+    /// 2. `domain_id = symbol_short!("alloc")` — allocation-quote functional tag
+    /// 3. current network id
+    /// 4. current contract address as XDR bytes
+    /// 5. `caller` address as XDR bytes
+    /// 6. `total_amount` as 16 little-endian bytes
+    /// 7. `deadline` as 8 little-endian bytes
+    pub fn get_split_allocations_hash(
+        env: Env,
+        caller: Address,
+        total_amount: i128,
+        deadline: u64,
+    ) -> Result<Bytes, RemittanceSplitError> {
+        Self::compute_split_allocations_hash(&env, &caller, total_amount, deadline)
+    }
+
+    /// Return a signed, deadline-bound allocation quote.
+    ///
+    /// The caller must authorize the exact quote payload, and `request_hash`
+    /// must match [`Self::get_split_allocations_hash`] for the same caller,
+    /// total amount, deadline, network, and contract. The returned allocation
+    /// vector is delegated to [`Self::get_split_allocations`] so signed and
+    /// unsigned quote paths stay in lockstep.
+    pub fn get_split_allocations_signed(
+        env: Env,
+        caller: Address,
+        total_amount: i128,
+        deadline: u64,
+        request_hash: Bytes,
+    ) -> Result<Vec<Allocation>, RemittanceSplitError> {
+        if total_amount <= 0 {
+            return Err(RemittanceSplitError::InvalidAmount);
+        }
+
+        Self::validate_quote_deadline(&env, deadline)?;
+
+        let expected_hash =
+            Self::compute_split_allocations_hash(&env, &caller, total_amount, deadline)?;
+        if expected_hash.ne(&request_hash) {
+            return Err(RemittanceSplitError::RequestHashMismatch);
+        }
+
+        let payload = SplitAllocationsQuotePayload {
+            domain_id: symbol_short!("alloc"),
+            network_id: env.ledger().network_id(),
+            contract_addr: env.current_contract_address(),
+            caller: caller.clone(),
+            total_amount,
+            deadline,
+        };
+        caller.require_auth_for_args(vec![&env, payload.into_val(&env)]);
+
+        Self::get_split_allocations(&env, total_amount)
+    }
+
     pub fn get_nonce(env: Env, address: Address) -> u64 {
         Self::get_nonce_value(&env, &address)
     }
@@ -2073,6 +2157,54 @@ impl RemittanceSplit {
             .wrapping_add(amt_hi)
             .wrapping_add(deadline)
             .wrapping_mul(1_000_000_007)
+    }
+
+    /// Validate quote deadlines with the same public semantics as
+    /// `distribute_usdc_hashed`: zero and too-far deadlines are
+    /// `InvalidDeadline`, while deadlines at or before the current ledger
+    /// timestamp are `DeadlineExpired`.
+    fn validate_quote_deadline(env: &Env, deadline: u64) -> Result<(), RemittanceSplitError> {
+        let now = env.ledger().timestamp();
+        if deadline == 0 {
+            return Err(RemittanceSplitError::InvalidDeadline);
+        }
+        if now >= deadline {
+            return Err(RemittanceSplitError::DeadlineExpired);
+        }
+        if deadline - now > MAX_DEADLINE_WINDOW_SECS {
+            return Err(RemittanceSplitError::InvalidDeadline);
+        }
+        Ok(())
+    }
+
+    fn compute_split_allocations_hash(
+        env: &Env,
+        caller: &Address,
+        total_amount: i128,
+        deadline: u64,
+    ) -> Result<Bytes, RemittanceSplitError> {
+        let mut preimage = Bytes::new(env);
+
+        preimage.extend_from_slice(DISTRIBUTE_USDC_DOMAIN);
+
+        let domain_bits: u64 = symbol_short!("alloc").to_val().get_payload();
+        preimage.extend_from_slice(&domain_bits.to_le_bytes());
+
+        let network_id = env.ledger().network_id();
+        preimage.append(network_id.as_ref());
+
+        let contract_xdr = env.current_contract_address().to_xdr(env);
+        preimage.append(&contract_xdr);
+
+        let caller_xdr = caller.clone().to_xdr(env);
+        preimage.append(&caller_xdr);
+
+        preimage.extend_from_slice(&total_amount.to_le_bytes());
+        preimage.extend_from_slice(&deadline.to_le_bytes());
+
+        let hash: Bytes = env.crypto().sha256(&preimage).into();
+        guard_bytes_len(&hash).map_err(|_| RemittanceSplitError::ReturnBytesTooLarge)?;
+        Ok(hash)
     }
 
     fn increment_nonce(env: &Env, address: &Address) -> Result<(), RemittanceSplitError> {

--- a/remittance_split/src/test.rs
+++ b/remittance_split/src/test.rs
@@ -2044,6 +2044,43 @@ fn test_get_schedules_paginated_full_scale_cursor_monotonicity() {
 //   7. Max categories at 100    → percentages across all 4 slots summing to 100.
 // ============================================================================
 
+fn quote_hash(
+    env: &Env,
+    contract_id: &Address,
+    caller: &Address,
+    total_amount: i128,
+    deadline: u64,
+) -> soroban_sdk::Bytes {
+    env.as_contract(contract_id, || {
+        RemittanceSplit::get_split_allocations_hash(
+            env.clone(),
+            caller.clone(),
+            total_amount,
+            deadline,
+        )
+    })
+    .expect("quote hash must be computable")
+}
+
+fn signed_allocations(
+    env: &Env,
+    contract_id: &Address,
+    caller: &Address,
+    total_amount: i128,
+    deadline: u64,
+    request_hash: soroban_sdk::Bytes,
+) -> Result<soroban_sdk::Vec<Allocation>, RemittanceSplitError> {
+    env.as_contract(contract_id, || {
+        RemittanceSplit::get_split_allocations_signed(
+            env.clone(),
+            caller.clone(),
+            total_amount,
+            deadline,
+            request_hash,
+        )
+    })
+}
+
 /// Helper: assert the four returned category symbols are in canonical order.
 fn assert_canonical_order(_env: &Env, allocs: &soroban_sdk::Vec<Allocation>) {
     assert_eq!(allocs.len(), 4, "must return exactly 4 allocations");
@@ -2057,6 +2094,165 @@ fn assert_canonical_order(_env: &Env, allocs: &soroban_sdk::Vec<Allocation>) {
 fn assert_conservation(allocs: &soroban_sdk::Vec<Allocation>, total: i128) {
     let sum: i128 = allocs.iter().map(|a| a.amount).sum();
     assert_eq!(sum, total, "allocation amounts must sum to total_amount");
+}
+
+/// Signed quote path: valid caller/amount/deadline/hash returns the same
+/// canonical allocation vector as the unsigned read path.
+#[test]
+fn test_get_split_allocations_signed_matches_unsigned_quote() {
+    let env = Env::default();
+    env.mock_all_auths();
+    set_time(&env, 10_000);
+
+    let harness = setup_split(&env, 4_000, 3_000, 2_000, 1_000);
+    let caller = Address::generate(&env);
+    let total: i128 = 1_234;
+    let deadline = env.ledger().timestamp() + 600;
+    let request_hash = quote_hash(&env, &harness.client.address, &caller, total, deadline);
+
+    let signed = signed_allocations(
+        &env,
+        &harness.client.address,
+        &caller,
+        total,
+        deadline,
+        request_hash,
+    )
+    .expect("valid signed quote must succeed");
+    let unsigned = env
+        .as_contract(&harness.client.address, || {
+            RemittanceSplit::get_split_allocations(&env, total)
+        })
+        .expect("unsigned quote must succeed");
+
+    assert_eq!(signed, unsigned);
+    assert_canonical_order(&env, &signed);
+    assert_conservation(&signed, total);
+}
+
+/// Signed quote deadline semantics: the upper boundary is inclusive at
+/// now + MAX_DEADLINE_WINDOW_SECS, matching the hashed distribution path.
+#[test]
+fn test_get_split_allocations_signed_accepts_deadline_window_boundary() {
+    let env = Env::default();
+    env.mock_all_auths();
+    set_time(&env, 10_000);
+
+    let harness = setup_split(&env, 2_500, 2_500, 2_500, 2_500);
+    let caller = Address::generate(&env);
+    let total: i128 = 99;
+    let deadline = env.ledger().timestamp() + MAX_DEADLINE_WINDOW_SECS;
+    let request_hash = quote_hash(&env, &harness.client.address, &caller, total, deadline);
+
+    let allocs = signed_allocations(
+        &env,
+        &harness.client.address,
+        &caller,
+        total,
+        deadline,
+        request_hash,
+    )
+    .expect("deadline exactly at max window must be accepted");
+
+    assert_canonical_order(&env, &allocs);
+    assert_conservation(&allocs, total);
+}
+
+#[test]
+fn test_get_split_allocations_signed_rejects_expired_deadline() {
+    let env = Env::default();
+    env.mock_all_auths();
+    set_time(&env, 10_000);
+
+    let harness = setup_split(&env, 4_000, 3_000, 2_000, 1_000);
+    let caller = Address::generate(&env);
+    let total: i128 = 100;
+    let deadline = env.ledger().timestamp();
+    let request_hash = quote_hash(&env, &harness.client.address, &caller, total, deadline);
+
+    let result = signed_allocations(
+        &env,
+        &harness.client.address,
+        &caller,
+        total,
+        deadline,
+        request_hash,
+    );
+
+    assert_eq!(result, Err(RemittanceSplitError::DeadlineExpired));
+}
+
+#[test]
+fn test_get_split_allocations_signed_rejects_deadline_beyond_window() {
+    let env = Env::default();
+    env.mock_all_auths();
+    set_time(&env, 10_000);
+
+    let harness = setup_split(&env, 4_000, 3_000, 2_000, 1_000);
+    let caller = Address::generate(&env);
+    let total: i128 = 100;
+    let deadline = env.ledger().timestamp() + MAX_DEADLINE_WINDOW_SECS + 1;
+    let request_hash = quote_hash(&env, &harness.client.address, &caller, total, deadline);
+
+    let result = signed_allocations(
+        &env,
+        &harness.client.address,
+        &caller,
+        total,
+        deadline,
+        request_hash,
+    );
+
+    assert_eq!(result, Err(RemittanceSplitError::InvalidDeadline));
+}
+
+#[test]
+fn test_get_split_allocations_signed_rejects_hash_mismatch() {
+    let env = Env::default();
+    env.mock_all_auths();
+    set_time(&env, 10_000);
+
+    let harness = setup_split(&env, 4_000, 3_000, 2_000, 1_000);
+    let caller = Address::generate(&env);
+    let total: i128 = 500;
+    let deadline = env.ledger().timestamp() + 600;
+    let hash_for_different_amount =
+        quote_hash(&env, &harness.client.address, &caller, total + 1, deadline);
+
+    let result = signed_allocations(
+        &env,
+        &harness.client.address,
+        &caller,
+        total,
+        deadline,
+        hash_for_different_amount,
+    );
+
+    assert_eq!(result, Err(RemittanceSplitError::RequestHashMismatch));
+}
+
+#[test]
+fn test_get_split_allocations_signed_rejects_zero_amount() {
+    let env = Env::default();
+    env.mock_all_auths();
+    set_time(&env, 10_000);
+
+    let harness = setup_split(&env, 4_000, 3_000, 2_000, 1_000);
+    let caller = Address::generate(&env);
+    let total: i128 = 0;
+    let deadline = env.ledger().timestamp() + 600;
+    let request_hash = quote_hash(&env, &harness.client.address, &caller, total, deadline);
+
+    let result = signed_allocations(
+        &env,
+        &harness.client.address,
+        &caller,
+        total,
+        deadline,
+        request_hash,
+    );
+
+    assert_eq!(result, Err(RemittanceSplitError::InvalidAmount));
 }
 
 /// Shape invariant: uninitialized contract uses the default [50,30,15,5] split,


### PR DESCRIPTION
## Summary

Closes #1011.

Adds an authenticated allocation-quote path for `remittance_split`:

- Adds `get_split_allocations_hash(caller, total_amount, deadline)` so callers can compute the exact quote hash off-chain.
- Adds `get_split_allocations_signed(caller, total_amount, deadline, request_hash)` to validate amount, deadline, hash binding, and caller authorization before returning allocations.
- Binds the quote hash to the shared signing domain, `alloc` functional tag, network id, current contract address, caller address, total amount, and deadline.
- Delegates the final allocation calculation to the existing `get_split_allocations` path so signed and unsigned quote semantics stay in lockstep.

## Security notes

- The signed quote path performs no token transfers and writes no contract state.
- The auth payload includes the caller, network, contract instance, amount, and deadline.
- The request hash uses stable XDR address bytes for the caller and contract address to avoid object-id instability across repeated computations.
- Deadline handling mirrors the public hashed distribution semantics: `deadline <= now` expires, `deadline > now + MAX_DEADLINE_WINDOW_SECS` is invalid, and the exact max-window boundary is accepted.

## Tests

- `cargo test -p remittance_split test_get_split_allocations_signed -- --nocapture`
- `cargo clippy -p remittance_split --all-targets` completed with existing warnings.
- `git diff --check`

Known baseline: the full `cargo test -p remittance_split -- --nocapture` suite is currently red on existing tests unrelated to this change. The failures include older tests still initializing splits with `50/30/15/5`-style values while `initialize_split` now validates basis points summing to `10_000`, plus an existing event-topic assertion. The focused tests added for this issue pass.

Bounty: GrantFox OSS campaign for issue #1011.