### PR TITLE
test: cover issue 1024

### DIFF
--- a/insurance/src/test.rs
+++ b/insurance/src/test.rs
@@ -324,6 +324,105 @@ mod tests {
         );
     }
 
+    /// create_policy with an empty name returns InvalidName.
+    #[test]
+    fn test_create_policy_empty_name() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let c = setup(&env);
+        let caller = Address::generate(&env);
+        assert_eq!(
+            c.try_create_policy(
+                &caller,
+                &String::from_str(&env, ""),
+                &CoverageType::Health,
+                &5_000_000i128,
+                &50_000_000i128,
+            )
+            .unwrap_err()
+            .unwrap(),
+            InsuranceError::InvalidName,
+        );
+    }
+
+    /// create_policy with a name longer than MAX_NAME_LEN (64) returns InvalidName.
+    #[test]
+    fn test_create_policy_name_too_long() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let c = setup(&env);
+        let caller = Address::generate(&env);
+        // 65 characters (MAX_NAME_LEN is 64)
+        let long_name = String::from_str(
+            &env,
+            "12345678901234567890123456789012345678901234567890123456789012345",
+        );
+        assert_eq!(
+            c.try_create_policy(
+                &caller,
+                &long_name,
+                &CoverageType::Health,
+                &5_000_000i128,
+                &50_000_000i128,
+            )
+            .unwrap_err()
+            .unwrap(),
+            InsuranceError::InvalidName,
+        );
+    }
+
+    /// pay_premium on an inactive policy returns PolicyInactive.
+    #[test]
+    fn test_pay_premium_inactive_policy() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (c, _contract_owner) = setup_with_owner(&env);
+        let policy_owner = Address::generate(&env);
+        let pid = c.create_policy(
+            &policy_owner,
+            &n(&env, "P"),
+            &CoverageType::Health,
+            &5_000_000i128,
+            &50_000_000i128,
+        );
+
+        // Deactivate the policy
+        c.deactivate_policy(&policy_owner, &pid);
+
+        // Attempt to pay premium on inactive policy
+        assert_eq!(
+            c.try_pay_premium(&policy_owner, &pid)
+                .unwrap_err()
+                .unwrap(),
+            InsuranceError::PolicyInactive,
+        );
+    }
+
+    /// pay_premium by a non-owner returns Unauthorized.
+    #[test]
+    fn test_pay_premium_unauthorized() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let c = setup(&env);
+        let policy_owner = Address::generate(&env);
+        let other_user = Address::generate(&env);
+        let pid = c.create_policy(
+            &policy_owner,
+            &n(&env, "P"),
+            &CoverageType::Health,
+            &5_000_000i128,
+            &50_000_000i128,
+        );
+
+        // Attempt to pay premium by a different user
+        assert_eq!(
+            c.try_pay_premium(&other_user, &pid)
+                .unwrap_err()
+                .unwrap(),
+            InsuranceError::Unauthorized,
+        );
+    }
+
     // ── Helper: initialise contract with a known owner ────────────────────────
 
     fn setup_with_owner(env: &Env) -> (InsuranceClient<'_>, Address) {

--- a/insurance/tests/stress_tests.rs
+++ b/insurance/tests/stress_tests.rs
@@ -122,7 +122,7 @@ fn stress_200_policies_single_user() {
     // full the caller receives a non-zero cursor that produces a trailing empty page,
     // so the round-trip count is pages = ceil(200/50) + 1 trailing = 5.
     assert!(
-        pages >= 4 && pages <= 5,
+        (4..=5).contains(&pages),
         "Expected 4-5 pages for 200 policies at limit 50, got {}",
         pages
     );


### PR DESCRIPTION
Closes #1024

Summary:
- Add focused regression coverage for `create_policy` returning `InsuranceError::InvalidName` on empty and overlong names.
- Add focused regression coverage for `pay_premium` returning `InsuranceError::PolicyInactive` and `InsuranceError::Unauthorized`.
- Clean up an existing clippy `manual_range_contains` warning in `insurance/tests/stress_tests.rs`.

Verification:
- `~/.cargo/bin/cargo test -p insurance --lib` passed in the private build evidence.
- `~/.cargo/bin/cargo clippy -p insurance --all-targets -- -D warnings` passed in the private build evidence.
- `git diff --check` passed.
- Clean-clone `git apply --check --unidiff-zero` passed against `main`.

Note:
- The recorded private-build evidence notes that the full `cargo test -p insurance` suite has existing unrelated stress-test failures, so I kept verification scoped to the passing lib tests and clippy run.
