### PR TITLE
Add require_governance_ok helper for parameter changes

### DIFF
--- a/family_wallet/src/lib.rs
+++ b/family_wallet/src/lib.rs
@@ -584,15 +584,13 @@ impl FamilyWallet {
         caller: Address,
         member_address: Address,
         new_limit: i128,
-    ) -> bool {
+    ) -> Result<bool, Error> {
         caller.require_auth();
         Self::require_not_paused(&env);
 
-        if !Self::is_owner_or_admin(&env, &caller) {
-            panic!("Only Owner or Admin can update spending limits");
-        }
+        Self::require_governance_ok(&env, &caller)?;
         if new_limit < 0 {
-            panic!("InvalidSpendingLimit");
+            return Err(Error::InvalidSpendingLimit);
         }
 
         let mut members: Map<Address, FamilyMember> = env
@@ -603,8 +601,7 @@ impl FamilyWallet {
 
         let mut record = members
             .get(member_address.clone())
-            .ok_or(Error::MemberNotFound)
-            .unwrap_or_else(|_| panic!("MemberNotFound"));
+            .ok_or(Error::MemberNotFound)?;
 
         let old_limit = record.spending_limit;
         record.spending_limit = new_limit;
@@ -629,7 +626,7 @@ impl FamilyWallet {
             },
         );
 
-        true
+        Ok(true)
     }
 
     /// Check if `caller` is allowed to spend `amount`.
@@ -3063,6 +3060,27 @@ impl FamilyWallet {
         }
         if Self::role_has_expired(env, caller) {
             panic!("Role has expired");
+        }
+    }
+
+    /// Governance check helper for parameter changes.
+    ///
+    /// Returns a typed `Error::Unauthorized` instead of panicking when the caller
+    /// is not an Owner or Admin. This provides consistent error handling for
+    /// governance-level operations and enables proper error propagation to callers.
+    ///
+    /// # Arguments
+    /// * `env` - Soroban environment
+    /// * `caller` - Address attempting the governance operation
+    ///
+    /// # Returns
+    /// * `Ok(())` if caller is Owner or Admin
+    /// * `Err(Error::Unauthorized)` if caller lacks governance role
+    fn require_governance_ok(env: &Env, caller: &Address) -> Result<(), Error> {
+        if Self::is_owner_or_admin(env, caller) {
+            Ok(())
+        } else {
+            Err(Error::Unauthorized)
         }
     }
 

--- a/family_wallet/src/test.rs
+++ b/family_wallet/src/test.rs
@@ -6749,10 +6749,10 @@ fn test_auth_matrix_update_spending_limit_by_owner() {
 
     // Action: Owner updates member's spending limit
     let new_limit = 1000_0000000i128;
-    let result = client.update_spending_limit(&owner, &member, &new_limit);
+    let result = client.try_update_spending_limit(&owner, &member, &new_limit);
 
     // Assertion: Operation succeeds
-    assert!(result, "Owner must be able to update spending limits");
+    assert_eq!(result, Ok(true), "Owner must be able to update spending limits");
 
     // Verification: Spending limit was updated
     let member_data = client.get_family_member(&member);
@@ -6784,10 +6784,10 @@ fn test_auth_matrix_update_spending_limit_by_admin() {
 
     // Action: Admin updates member's spending limit
     let new_limit = 500_0000000i128;
-    let result = client.update_spending_limit(&admin, &member, &new_limit);
+    let result = client.try_update_spending_limit(&admin, &member, &new_limit);
 
     // Assertion: Operation succeeds
-    assert!(result, "Admin must be able to update spending limits");
+    assert_eq!(result, Ok(true), "Admin must be able to update spending limits");
 
     // Verification
     let member_data = client.get_family_member(&member);
@@ -6818,9 +6818,10 @@ fn test_auth_matrix_update_spending_limit_by_member_fails() {
     // Action: Member1 attempts to update Member2's spending limit (should fail)
     let result = client.try_update_spending_limit(&member1, &member2, &1000_0000000);
 
-    // Assertion: Operation fails
-    assert!(
-        result.is_err(),
+    // Assertion: Operation fails with typed error
+    assert_eq!(
+        result,
+        Err(Ok(Error::Unauthorized)),
         "Member must not be able to update spending limits"
     );
 }
@@ -6846,10 +6847,40 @@ fn test_auth_matrix_update_spending_limit_by_viewer_fails() {
     // Action: Viewer attempts to update spending limit (should fail)
     let result = client.try_update_spending_limit(&viewer, &member, &1000_0000000);
 
-    // Assertion: Operation fails
-    assert!(
-        result.is_err(),
+    // Assertion: Operation fails with typed error
+    assert_eq!(
+        result,
+        Err(Ok(Error::Unauthorized)),
         "Viewer must not be able to update spending limits"
+    );
+}
+
+#[test]
+fn test_require_governance_ok_returns_typed_error() {
+    // **Description**:
+    // Verifies that `require_governance_ok` helper returns a typed `Error::Unauthorized`
+    // instead of panicking when a non-admin attempts a parameter change.
+    //
+    // **Security Note**: This test ensures governance checks use typed errors for
+    // consistent error handling and proper audit trails.
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, FamilyWallet);
+    let client = FamilyWalletClient::new(&env, &contract_id);
+
+    // Setup
+    let owner = Address::generate(&env);
+    let member = Address::generate(&env);
+    client.init(&owner, &vec![&env, member.clone()]);
+
+    // Action: Member attempts to update spending limit (should fail with typed error)
+    let result = client.try_update_spending_limit(&member, &member, &1000_0000000);
+
+    // Assertion: Operation fails with specific typed error
+    assert_eq!(
+        result,
+        Err(Ok(Error::Unauthorized)),
+        "require_governance_ok must return typed Error::Unauthorized"
     );
 }
 
@@ -6940,8 +6971,9 @@ fn test_auth_matrix_comprehensive_role_isolation() {
 
         // Member cannot update spending limit
         let result_update = client.try_update_spending_limit(&member, &test_target, &1000_0000000);
-        assert!(
-            result_update.is_err(),
+        assert_eq!(
+            result_update,
+            Err(Ok(Error::Unauthorized)),
             "Member cannot update spending limit"
         );
     }
@@ -6954,8 +6986,9 @@ fn test_auth_matrix_comprehensive_role_isolation() {
 
         // Viewer cannot update spending limit
         let result_update = client.try_update_spending_limit(&viewer, &test_target, &1000_0000000);
-        assert!(
-            result_update.is_err(),
+        assert_eq!(
+            result_update,
+            Err(Ok(Error::Unauthorized)),
             "Viewer cannot update spending limit"
         );
     }

--- a/integration_tests/tests/orchestrated_multisig_flow.rs
+++ b/integration_tests/tests/orchestrated_multisig_flow.rs
@@ -61,7 +61,9 @@ fn test_orchestrated_multisig_flow() {
     );
 
     // Set low spending limit for user to force multisig/role change
-    family_wallet_client.update_spending_limit(&admin, &user, &100i128);
+    family_wallet_client
+        .try_update_spending_limit(&admin, &user, &100i128)
+        .unwrap();
 
     let mock_usdc = Address::generate(&env);
     remittance_client.initialize_split(


### PR DESCRIPTION
- Add require_governance_ok() helper that returns typed Error::Unauthorized
- Update update_spending_limit() to use helper and return Result<bool, Error>
- Add negative test test_require_governance_ok_returns_typed_error
- Update existing tests to expect typed errors instead of panics

This standardizes governance checks to use typed errors for consistent error handling and proper audit trails.
closes #1137 