### PR TITLE
feat(remitwise-common): add Rate::from_percent shared constructor

### DIFF
--- a/remitwise-common/src/emit_tests.rs
+++ b/remitwise-common/src/emit_tests.rs
@@ -1,18 +1,35 @@
 use crate::{EventCategory, EventPriority, RemitwiseEvents};
-use soroban_sdk::{symbol_short, testutils::Events as _, Env, FromVal, Vec};
+use soroban_sdk::{contract, contractimpl, symbol_short, testutils::Events as _, Env, FromVal, Vec};
+
+// Events published outside a contract context are dropped by the host
+// (soroban-sdk 21), so tests publish through a minimal registered contract.
+#[contract]
+struct DummyContract;
+
+#[contractimpl]
+impl DummyContract {
+    pub fn noop(_env: Env) {}
+}
+
+fn in_contract_context(env: &Env, f: impl FnOnce()) {
+    let id = env.register_contract(None, DummyContract);
+    env.as_contract(&id, f);
+}
 
 #[test]
 fn test_compact_event_passes() {
     let env = Env::default();
     // A small payload
     let data = 42u32;
-    RemitwiseEvents::emit(
-        &env,
-        EventCategory::Transaction,
-        EventPriority::High,
-        symbol_short!("test"),
-        data,
-    );
+    in_contract_context(&env, || {
+        RemitwiseEvents::emit(
+            &env,
+            EventCategory::Transaction,
+            EventPriority::High,
+            symbol_short!("test"),
+            data,
+        );
+    });
 }
 
 #[test]
@@ -24,13 +41,15 @@ fn test_oversized_event_flagged() {
     for i in 0..100 {
         large_data.push_back(i);
     }
-    RemitwiseEvents::emit(
-        &env,
-        EventCategory::Transaction,
-        EventPriority::High,
-        symbol_short!("test"),
-        large_data,
-    );
+    in_contract_context(&env, || {
+        RemitwiseEvents::emit(
+            &env,
+            EventCategory::Transaction,
+            EventPriority::High,
+            symbol_short!("test"),
+            large_data,
+        );
+    });
 }
 
 // ============================================================================
@@ -41,17 +60,19 @@ fn test_oversized_event_flagged() {
 #[test]
 fn test_emit_topics_include_remitwise_sentinel() {
     let env = Env::default();
-    RemitwiseEvents::emit(
-        &env,
-        EventCategory::Transaction,
-        EventPriority::High,
-        symbol_short!("tx"),
-        1u32,
-    );
+    in_contract_context(&env, || {
+        RemitwiseEvents::emit(
+            &env,
+            EventCategory::Transaction,
+            EventPriority::High,
+            symbol_short!("tx"),
+            1u32,
+        );
+    });
     let events = env.events().all();
     assert!(!events.is_empty());
     // The first topic element must be the Remitwise sentinel symbol.
-    let (topics, _) = events.last().unwrap();
+    let (_, topics, _) = events.last().unwrap();
     let sentinel = soroban_sdk::Val::from_val(&env, &topics.get(0).unwrap());
     let expected = soroban_sdk::Symbol::new(&env, "Remitwise").to_val();
     assert_eq!(sentinel.get_payload(), expected.get_payload());
@@ -60,60 +81,66 @@ fn test_emit_topics_include_remitwise_sentinel() {
 #[test]
 fn test_emit_encodes_category_as_second_topic() {
     let env = Env::default();
-    RemitwiseEvents::emit(
-        &env,
-        EventCategory::Compliance,
-        EventPriority::Low,
-        symbol_short!("kyc"),
-        0u32,
-    );
+    in_contract_context(&env, || {
+        RemitwiseEvents::emit(
+            &env,
+            EventCategory::Access,
+            EventPriority::Low,
+            symbol_short!("kyc"),
+            0u32,
+        );
+    });
     let events = env.events().all();
-    let (topics, _) = events.last().unwrap();
+    let (_, topics, _) = events.last().unwrap();
     let cat_raw: u32 = soroban_sdk::FromVal::from_val(&env, &topics.get(1).unwrap());
-    assert_eq!(cat_raw, EventCategory::Compliance.to_u32());
+    assert_eq!(cat_raw, EventCategory::Access.to_u32());
 }
 
 #[test]
 fn test_emit_encodes_priority_as_third_topic() {
     let env = Env::default();
-    RemitwiseEvents::emit(
-        &env,
-        EventCategory::System,
-        EventPriority::Critical,
-        symbol_short!("alert"),
-        99u32,
-    );
+    in_contract_context(&env, || {
+        RemitwiseEvents::emit(
+            &env,
+            EventCategory::System,
+            EventPriority::Medium,
+            symbol_short!("alert"),
+            99u32,
+        );
+    });
     let events = env.events().all();
-    let (topics, _) = events.last().unwrap();
+    let (_, topics, _) = events.last().unwrap();
     let prio_raw: u32 = soroban_sdk::FromVal::from_val(&env, &topics.get(2).unwrap());
-    assert_eq!(prio_raw, EventPriority::Critical.to_u32());
+    assert_eq!(prio_raw, EventPriority::Medium.to_u32());
 }
 
 #[test]
 fn test_emit_batch_uses_low_priority_topic() {
     let env = Env::default();
-    RemitwiseEvents::emit_batch(
-        &env,
-        EventCategory::Transaction,
-        symbol_short!("batch"),
-        5,
-    );
+    in_contract_context(&env, || {
+        RemitwiseEvents::emit_batch(
+            &env,
+            EventCategory::Transaction,
+            symbol_short!("batch"),
+            5,
+        );
+    });
     let events = env.events().all();
-    let (topics, _) = events.last().unwrap();
+    let (_, topics, _) = events.last().unwrap();
     let prio_raw: u32 = soroban_sdk::FromVal::from_val(&env, &topics.get(2).unwrap());
     assert_eq!(prio_raw, EventPriority::Low.to_u32());
 }
 
 #[test]
 fn test_emit_all_categories_are_distinct() {
-    assert_ne!(EventCategory::Transaction.to_u32(), EventCategory::Compliance.to_u32());
-    assert_ne!(EventCategory::Compliance.to_u32(), EventCategory::System.to_u32());
+    assert_ne!(EventCategory::Transaction.to_u32(), EventCategory::Access.to_u32());
+    assert_ne!(EventCategory::Access.to_u32(), EventCategory::System.to_u32());
     assert_ne!(EventCategory::Transaction.to_u32(), EventCategory::System.to_u32());
 }
 
 #[test]
 fn test_emit_all_priorities_are_distinct() {
     assert_ne!(EventPriority::Low.to_u32(), EventPriority::High.to_u32());
-    assert_ne!(EventPriority::High.to_u32(), EventPriority::Critical.to_u32());
-    assert_ne!(EventPriority::Low.to_u32(), EventPriority::Critical.to_u32());
+    assert_ne!(EventPriority::High.to_u32(), EventPriority::Medium.to_u32());
+    assert_ne!(EventPriority::Low.to_u32(), EventPriority::Medium.to_u32());
 }

--- a/remitwise-common/src/emit_tests.rs
+++ b/remitwise-common/src/emit_tests.rs
@@ -1,5 +1,7 @@
 use crate::{EventCategory, EventPriority, RemitwiseEvents};
-use soroban_sdk::{contract, contractimpl, symbol_short, testutils::Events as _, Env, FromVal, Vec};
+use soroban_sdk::{
+    contract, contractimpl, symbol_short, testutils::Events as _, Env, FromVal, Vec,
+};
 
 // Events published outside a contract context are dropped by the host
 // (soroban-sdk 21), so tests publish through a minimal registered contract.
@@ -118,12 +120,7 @@ fn test_emit_encodes_priority_as_third_topic() {
 fn test_emit_batch_uses_low_priority_topic() {
     let env = Env::default();
     in_contract_context(&env, || {
-        RemitwiseEvents::emit_batch(
-            &env,
-            EventCategory::Transaction,
-            symbol_short!("batch"),
-            5,
-        );
+        RemitwiseEvents::emit_batch(&env, EventCategory::Transaction, symbol_short!("batch"), 5);
     });
     let events = env.events().all();
     let (_, topics, _) = events.last().unwrap();
@@ -133,9 +130,18 @@ fn test_emit_batch_uses_low_priority_topic() {
 
 #[test]
 fn test_emit_all_categories_are_distinct() {
-    assert_ne!(EventCategory::Transaction.to_u32(), EventCategory::Access.to_u32());
-    assert_ne!(EventCategory::Access.to_u32(), EventCategory::System.to_u32());
-    assert_ne!(EventCategory::Transaction.to_u32(), EventCategory::System.to_u32());
+    assert_ne!(
+        EventCategory::Transaction.to_u32(),
+        EventCategory::Access.to_u32()
+    );
+    assert_ne!(
+        EventCategory::Access.to_u32(),
+        EventCategory::System.to_u32()
+    );
+    assert_ne!(
+        EventCategory::Transaction.to_u32(),
+        EventCategory::System.to_u32()
+    );
 }
 
 #[test]

--- a/remitwise-common/src/lib.rs
+++ b/remitwise-common/src/lib.rs
@@ -567,6 +567,7 @@ impl RemitwiseEvents {
 
         #[cfg(test)]
         {
+            use soroban_sdk::xdr::ToXdr as _;
             use soroban_sdk::TryFromVal;
             let val = data.into_val(env);
             if let Ok(sc_val) = soroban_sdk::xdr::ScVal::try_from_val(env, &val) {
@@ -626,7 +627,8 @@ impl RemitwiseEvents {
         T: soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val>,
         F: FnOnce(&T) -> bool,
     {
-        use soroban_sdk::TryFromVal;
+        use soroban_sdk::testutils::Events as _;
+        use soroban_sdk::{IntoVal, TryFromVal};
 
         let all = env.events().all();
         let (_cid, topics, data) = all.last().expect("expected at least one emitted event");
@@ -638,24 +640,34 @@ impl RemitwiseEvents {
             4,
             "expected a 4-element Remitwise event topic tuple"
         );
+        let expected_marker: soroban_sdk::Val = symbol_short!("Remitwise").into_val(env);
         assert_eq!(
-            topics.get(0).unwrap(),
-            symbol_short!("Remitwise").into_val(env),
+            topics.get(0).unwrap().get_payload(),
+            expected_marker.get_payload(),
             "first topic must be the Remitwise marker"
         );
         assert_eq!(
-            topics.get(1).unwrap(),
-            expected_category.to_u32().into_val(env),
+            topics.get(1).unwrap().get_payload(),
+            IntoVal::<soroban_sdk::Env, soroban_sdk::Val>::into_val(
+                &expected_category.to_u32(),
+                env,
+            )
+            .get_payload(),
             "event category mismatch"
         );
         assert_eq!(
-            topics.get(2).unwrap(),
-            expected_priority.to_u32().into_val(env),
+            topics.get(2).unwrap().get_payload(),
+            IntoVal::<soroban_sdk::Env, soroban_sdk::Val>::into_val(
+                &expected_priority.to_u32(),
+                env,
+            )
+            .get_payload(),
             "event priority mismatch"
         );
         assert_eq!(
-            topics.get(3).unwrap(),
-            expected_action.into_val(env),
+            topics.get(3).unwrap().get_payload(),
+            IntoVal::<soroban_sdk::Env, soroban_sdk::Val>::into_val(&expected_action, env)
+                .get_payload(),
             "event action mismatch"
         );
 
@@ -675,19 +687,33 @@ impl RemitwiseEvents {
 #[cfg(test)]
 mod assert_event_tests {
     use super::{EventCategory, EventPriority, RemitwiseEvents};
+    use soroban_sdk::{contract, contractimpl, Env};
+
+    // Events published outside a contract context are dropped by the host
+    // (soroban-sdk 21), so tests emit through a minimal registered contract.
+    #[contract]
+    struct DummyContract;
+
+    #[contractimpl]
+    impl DummyContract {
+        pub fn noop(_env: Env) {}
+    }
 
     #[test]
     fn assert_last_event_matches_emitted_topic_and_data() {
         let env = soroban_sdk::Env::default();
         let action = soroban_sdk::Symbol::new(&env, "test_act");
 
-        RemitwiseEvents::emit(
-            &env,
-            EventCategory::Access,
-            EventPriority::High,
-            action,
-            (1u32, 2u32),
-        );
+        let id = env.register_contract(None, DummyContract);
+        env.as_contract(&id, || {
+            RemitwiseEvents::emit(
+                &env,
+                EventCategory::Access,
+                EventPriority::High,
+                action.clone(),
+                (1u32, 2u32),
+            );
+        });
 
         RemitwiseEvents::assert_last_event::<(u32, u32), _>(
             &env,
@@ -702,13 +728,16 @@ mod assert_event_tests {
     #[should_panic(expected = "event action mismatch")]
     fn assert_last_event_panics_on_action_mismatch() {
         let env = soroban_sdk::Env::default();
-        RemitwiseEvents::emit(
-            &env,
-            EventCategory::Access,
-            EventPriority::High,
-            soroban_sdk::Symbol::new(&env, "one"),
-            1u32,
-        );
+        let id = env.register_contract(None, DummyContract);
+        env.as_contract(&id, || {
+            RemitwiseEvents::emit(
+                &env,
+                EventCategory::Access,
+                EventPriority::High,
+                soroban_sdk::Symbol::new(&env, "one"),
+                1u32,
+            );
+        });
         RemitwiseEvents::assert_last_event::<u32, _>(
             &env,
             EventCategory::Access,

--- a/remitwise-common/src/lib.rs
+++ b/remitwise-common/src/lib.rs
@@ -287,6 +287,50 @@ impl ToI128Checked for i32 {
     }
 }
 
+/// Basis points in 100% (1 bps = 0.01%).
+pub const BPS_IN_FULL: u32 = 10_000;
+
+/// Error returned when constructing a [`Rate`] from an out-of-range input.
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum RateError {
+    /// The input represents more than 100% ([`BPS_IN_FULL`] basis points).
+    AboveMax = 1,
+}
+
+/// A proportion stored as basis points (1 bps = 0.01%).
+///
+/// Callers currently pass percentages around as bare `u32`s, some in whole
+/// percent (0-100, e.g. the remittance split fields) and some already in basis
+/// points (0-10_000, e.g. the data-migration split validation). `Rate` keeps
+/// the two representations from mixing by making the conversion explicit and
+/// range-checked at the boundary.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub struct Rate {
+    bps: u32,
+}
+
+impl Rate {
+    /// Builds a rate from hundredths of a percent: `1` is 0.01% (1 bps) and
+    /// `10_000` is 100%. Inputs above 100% are rejected.
+    ///
+    /// # Errors
+    /// Returns [`RateError::AboveMax`] when `percent_x100 > BPS_IN_FULL`.
+    pub fn from_percent(percent_x100: u32) -> Result<Self, RateError> {
+        if percent_x100 > BPS_IN_FULL {
+            return Err(RateError::AboveMax);
+        }
+        Ok(Self { bps: percent_x100 })
+    }
+
+    /// The rate in basis points (0-10_000).
+    pub fn bps(self) -> u32 {
+        self.bps
+    }
+}
+
 /// Error related to time and periods.
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -628,7 +672,7 @@ impl RemitwiseEvents {
         F: FnOnce(&T) -> bool,
     {
         use soroban_sdk::testutils::Events as _;
-        use soroban_sdk::{IntoVal, TryFromVal};
+        use soroban_sdk::IntoVal;
 
         let all = env.events().all();
         let (_cid, topics, data) = all.last().expect("expected at least one emitted event");
@@ -674,8 +718,7 @@ impl RemitwiseEvents {
         let payload: T = T::try_from_val(env, &data).expect("failed to decode event data");
         assert!(
             data_pred(&payload),
-            "event data predicate failed for action {:?}",
-            expected_action
+            "event data predicate failed for action {expected_action:?}"
         );
     }
 }
@@ -951,9 +994,7 @@ mod encoding_stability_tests {
             }
         }
 
-        for v in [PolicyMode::Strict] {
-            cover_all_variants(v);
-        }
+        cover_all_variants(PolicyMode::Strict);
 
         let vec = Vec::from_array(&env, [PolicyMode::Strict]);
         let mut out = Vec::<PolicyMode>::new(&env);

--- a/remitwise-common/src/tests.rs
+++ b/remitwise-common/src/tests.rs
@@ -16,8 +16,9 @@
 extern crate std;
 
 use super::*;
+use ed25519_dalek::Signer as _;
 use proptest::prelude::*;
-use soroban_sdk::{Bytes, Env, String, Vec};
+use soroban_sdk::{Env, String, Vec};
 
 // helper: build a single-element tag Vec
 fn single(env: &Env, tag: &str) -> Vec<String> {
@@ -534,13 +535,14 @@ fn test_verify_slash_signature_valid() {
     let message = b"slash payload";
 
     // Generate a keypair
-    let (sk, pk) = soroban_sdk::testutils::ed25519::generate(&env);
+    let sk = ed25519_dalek::SigningKey::generate(&mut rand::rngs::OsRng);
+    let pk = sk.verifying_key().to_bytes();
 
     // Sign the prefixed message
     let mut prefixed = std::vec::Vec::new();
     prefixed.extend_from_slice(b"slash-auth");
     prefixed.extend_from_slice(message);
-    let signature = soroban_sdk::testutils::ed25519::sign(&env, &sk, &prefixed);
+    let signature = sk.sign(&prefixed).to_bytes();
 
     // Verify the slash signature
     let result = verify_slash_signature(&env, message, Some(&signature), &pk);
@@ -559,17 +561,20 @@ fn test_verify_slash_signature_optional_none() {
 }
 
 #[test]
+#[should_panic]
 fn test_verify_slash_signature_invalid() {
     let env = Env::default();
     let message = b"slash payload";
 
     // Generate a keypair
-    let (_, pk) = soroban_sdk::testutils::ed25519::generate(&env);
+    let pk = ed25519_dalek::SigningKey::generate(&mut rand::rngs::OsRng)
+        .verifying_key()
+        .to_bytes();
     let invalid_signature = [0u8; 64]; // Invalid
 
-    // Verify the invalid slash signature
-    let result = verify_slash_signature(&env, message, Some(&invalid_signature), &pk);
-    assert_eq!(result, Err(SlashError::InvalidSignature));
+    // A well-formed but cryptographically invalid signature escalates to a
+    // host panic inside ed25519_verify, same as verify_signature.
+    let _ = verify_slash_signature(&env, message, Some(&invalid_signature), &pk);
 }
 
 // ============================================================================

--- a/remitwise-common/src/tests.rs
+++ b/remitwise-common/src/tests.rs
@@ -584,7 +584,8 @@ fn test_verify_slash_signature_invalid() {
 #[test]
 fn test_canonicalize_tags_checked_returns_ok_for_valid_tags() {
     let env = Env::default();
-    let tags = soroban_sdk::vec![&env,
+    let tags = soroban_sdk::vec![
+        &env,
         soroban_sdk::String::from_str(&env, "payments"),
         soroban_sdk::String::from_str(&env, "SAVINGS"),
     ];
@@ -592,7 +593,10 @@ fn test_canonicalize_tags_checked_returns_ok_for_valid_tags() {
     assert!(result.is_ok());
     let out = result.unwrap();
     assert_eq!(out.len(), 2);
-    assert_eq!(out.get(1).unwrap(), soroban_sdk::String::from_str(&env, "savings"));
+    assert_eq!(
+        out.get(1).unwrap(),
+        soroban_sdk::String::from_str(&env, "savings")
+    );
 }
 
 #[test]
@@ -636,5 +640,49 @@ fn test_canonicalize_tags_checked_does_not_panic_on_injected_special_chars() {
     let tags = soroban_sdk::vec![&env, soroban_sdk::String::from_str(&env, "=formula")];
     let result = canonicalize_tags_checked(&env, &tags);
     // '=' is not in [a-z0-9-_], so it must return InvalidChar.
-    assert!(matches!(result, Err(crate::TagError::InvalidChar { position: 0 })));
+    assert!(matches!(
+        result,
+        Err(crate::TagError::InvalidChar { position: 0 })
+    ));
+}
+
+// ─── Rate::from_percent boundary tests (#1186) ───────────────────────────────
+
+#[test]
+fn rate_from_percent_accepts_zero() {
+    let rate = Rate::from_percent(0).unwrap();
+    assert_eq!(rate.bps(), 0);
+}
+
+#[test]
+fn rate_from_percent_accepts_one_hundredth_of_a_percent() {
+    // 0.01% is the smallest representable rate: 1 unit in, 1 bps out.
+    let rate = Rate::from_percent(1).unwrap();
+    assert_eq!(rate.bps(), 1);
+}
+
+#[test]
+fn rate_from_percent_accepts_exactly_one_hundred_percent() {
+    let rate = Rate::from_percent(BPS_IN_FULL).unwrap();
+    assert_eq!(rate.bps(), 10_000);
+}
+
+#[test]
+fn rate_from_percent_rejects_above_one_hundred_percent() {
+    // 100.01% is the first invalid input.
+    assert_eq!(Rate::from_percent(10_001), Err(RateError::AboveMax));
+    assert_eq!(Rate::from_percent(u32::MAX), Err(RateError::AboveMax));
+}
+
+proptest! {
+    #[test]
+    fn rate_from_percent_round_trips_any_valid_input(p in 0u32..=BPS_IN_FULL) {
+        let rate = Rate::from_percent(p).unwrap();
+        prop_assert_eq!(rate.bps(), p);
+    }
+
+    #[test]
+    fn rate_from_percent_rejects_any_input_above_full(p in (BPS_IN_FULL + 1)..=u32::MAX) {
+        prop_assert_eq!(Rate::from_percent(p), Err(RateError::AboveMax));
+    }
 }


### PR DESCRIPTION
Closes #1185
Closes #1186

Percentages move between contracts as bare `u32` in two different units: whole percent (0-100) on the remittance split fields, basis points (0-10_000) in the data-migration split validation. `Rate` stores basis points and makes the conversion explicit: `Rate::from_percent(p)` takes hundredths of a percent (1 = 0.01% = 1 bps, 10_000 = 100%) and rejects anything above 100% with `RateError::AboveMax`. Landed in remitwise-common next to the other shared types, with the bound named once as `BPS_IN_FULL`.

The boundary tests pin the four cases from #1186 (0%, 0.01%, 100%, 100.01%) plus proptest sweeps of the full valid and invalid input ranges.

One thing to flag: `cargo test -p remitwise-common` did not compile on main before this change (the suite referenced enum variants and `testutils::ed25519` helpers that don't exist on soroban-sdk 21.7.7, and the lockfile pulled ed25519-dalek 3.0.0 which env-host 21.2.1 can't build against). The first commit repairs that so the acceptance criteria are actually checkable: events tests now publish through a registered contract context (the host drops top-level publishes), `assert_last_event` compares `Val` payloads, and the invalid-signature tests expect the host panic that `ed25519_verify` produces.

Verified locally on rustc 1.88.0:
- `cargo test -p remitwise-common`: 75 passed, 0 failed
- `cargo clippy -p remitwise-common --all-targets -- -D warnings`: clean
- `cargo build -p remitwise-common --target wasm32-unknown-unknown --release`: ok
- `cargo fmt --check`: clean

Workspace-wide clippy still fails in `data_migration` (34 errors, present on unmodified main); left alone to keep this diff focused.