### PR TITLE
test(remitwise-common): add both-direction tests for validate_period …

### DIFF
--- a/remitwise-common/src/tests.rs
+++ b/remitwise-common/src/tests.rs
@@ -959,3 +959,139 @@ fn test_require_matching_ledger_far_after() {
     let result = require_matching_ledger(&env, 100);
     assert_eq!(result, Err(LedgerError::LedgerMismatch));
 }
+
+// ─── validate_period ─────────────────────────────────────────────────────────
+
+/// Happy path: start strictly before end returns Ok.
+#[test]
+fn validate_period_returns_ok_when_start_less_than_end() {
+    assert_eq!(validate_period(0, 1), Ok(()));
+    assert_eq!(validate_period(100, 200), Ok(()));
+    assert_eq!(validate_period(1_000_000, 9_999_999), Ok(()));
+}
+
+/// Happy path: start equal to end is a valid zero-length period and returns Ok.
+#[test]
+fn validate_period_returns_ok_when_start_equals_end() {
+    assert_eq!(validate_period(0, 0), Ok(()));
+    assert_eq!(validate_period(42, 42), Ok(()));
+    assert_eq!(validate_period(u64::MAX, u64::MAX), Ok(()));
+}
+
+/// Sad path: start strictly greater than end returns Err(InvalidPeriod).
+#[test]
+fn validate_period_returns_err_when_start_greater_than_end() {
+    assert_eq!(validate_period(1, 0), Err(TimeError::InvalidPeriod));
+    assert_eq!(validate_period(200, 100), Err(TimeError::InvalidPeriod));
+    assert_eq!(validate_period(9_999_999, 1_000_000), Err(TimeError::InvalidPeriod));
+}
+
+/// Sad path: one-apart near u64::MAX — start exactly one more than end.
+#[test]
+fn validate_period_returns_err_when_start_is_max_minus_zero_and_end_is_max_minus_one() {
+    assert_eq!(
+        validate_period(u64::MAX, u64::MAX - 1),
+        Err(TimeError::InvalidPeriod)
+    );
+}
+
+/// Happy path: large values still ordered correctly return Ok.
+#[test]
+fn validate_period_returns_ok_for_large_ordered_values() {
+    assert_eq!(validate_period(u64::MAX - 1, u64::MAX), Ok(()));
+    assert_eq!(validate_period(1_000_000_000_000, 9_999_999_999_999), Ok(()));
+}
+
+/// Edge: u64::MAX as start with u64::MAX as end is valid (equal).
+#[test]
+fn validate_period_returns_ok_for_u64_max_equal() {
+    assert_eq!(validate_period(u64::MAX, u64::MAX), Ok(()));
+}
+
+/// Edge: u64::MAX as start with any smaller end is invalid.
+#[test]
+fn validate_period_returns_err_when_start_is_u64_max_and_end_is_smaller() {
+    assert_eq!(validate_period(u64::MAX, 0), Err(TimeError::InvalidPeriod));
+    assert_eq!(
+        validate_period(u64::MAX, u64::MAX / 2),
+        Err(TimeError::InvalidPeriod)
+    );
+}
+
+proptest! {
+    /// Property: validate_period is consistent with `start <= end`.
+    /// This pins both directions: Ok for ordered, Err for reversed.
+    #[test]
+    fn proptest_validate_period_matches_ordering(start in any::<u64>(), end in any::<u64>()) {
+        let result = validate_period(start, end);
+        if start <= end {
+            prop_assert_eq!(result, Ok(()));
+        } else {
+            prop_assert_eq!(result, Err(TimeError::InvalidPeriod));
+        }
+    }
+}
+
+// ─── guard_bytes_len ──────────────────────────────────────────────────────────
+
+/// Happy path: empty Bytes (len == 0) is within budget.
+#[test]
+fn guard_bytes_len_returns_ok_for_empty_bytes() {
+    let env = Env::default();
+    let b = Bytes::new(&env);
+    assert_eq!(guard_bytes_len(&b), Ok(()));
+}
+
+/// Happy path: a short non-empty slice is within budget.
+#[test]
+fn guard_bytes_len_returns_ok_for_short_bytes() {
+    let env = Env::default();
+    let b = Bytes::from_slice(&env, &[1u8, 2, 3]);
+    assert_eq!(guard_bytes_len(&b), Ok(()));
+}
+
+/// Happy path: bytes at exactly MAX_BYTES_RETURN are allowed (boundary is inclusive).
+#[test]
+fn guard_bytes_len_returns_ok_when_len_equals_max_bytes_return() {
+    let env = Env::default();
+    let data = std::vec![0u8; MAX_BYTES_RETURN as usize];
+    let b = Bytes::from_slice(&env, &data);
+    assert_eq!(b.len(), MAX_BYTES_RETURN);
+    assert_eq!(guard_bytes_len(&b), Ok(()));
+}
+
+/// Sad path: one byte over the limit returns Err(ReturnTooLarge).
+#[test]
+fn guard_bytes_len_returns_err_when_len_is_one_over_max_bytes_return() {
+    let env = Env::default();
+    let data = std::vec![0u8; MAX_BYTES_RETURN as usize + 1];
+    let b = Bytes::from_slice(&env, &data);
+    assert_eq!(b.len(), MAX_BYTES_RETURN + 1);
+    assert_eq!(guard_bytes_len(&b), Err(BytesReturnError::ReturnTooLarge));
+}
+
+/// Sad path: significantly over the limit also returns Err(ReturnTooLarge).
+#[test]
+fn guard_bytes_len_returns_err_for_double_the_limit() {
+    let env = Env::default();
+    let data = std::vec![0u8; MAX_BYTES_RETURN as usize * 2];
+    let b = Bytes::from_slice(&env, &data);
+    assert_eq!(guard_bytes_len(&b), Err(BytesReturnError::ReturnTooLarge));
+}
+
+proptest! {
+    /// Property: guard_bytes_len is consistent with `len <= MAX_BYTES_RETURN`.
+    /// Generates lengths in 0..=MAX_BYTES_RETURN*2 to cover both sides of the boundary.
+    #[test]
+    fn proptest_guard_bytes_len_matches_limit(len in 0u32..=(MAX_BYTES_RETURN * 2)) {
+        let env = Env::default();
+        let data = std::vec![0u8; len as usize];
+        let b = Bytes::from_slice(&env, &data);
+        let result = guard_bytes_len(&b);
+        if len <= MAX_BYTES_RETURN {
+            prop_assert_eq!(result, Ok(()));
+        } else {
+            prop_assert_eq!(result, Err(BytesReturnError::ReturnTooLarge));
+        }
+    }
+}


### PR DESCRIPTION
PR Description
  
  Title: test(remitwise-common): add both-direction tests for validate_period and guard_bytes_len
  
  ───────────────────────────────────────────────────────────────────────────────────────────────
  
  Summary
  
  Adds unit and property-based tests for two shared utility functions in remitwise-common that
  previously had no test coverage. Both the happy path and the sad path are explicitly locked in,
  preventing silent regressions when the logic changes.
  
  Changes
  
  remitwise-common/src/tests.rs — 136 lines added, no production code changed.
  
  validate_period
  
  ┌──────┬───────────┐
  │ Test                                                │ Direction │
  ├─────────────────────────────────────────────────────┼───────────┤
  │ validate_period_returns_ok_when_start_less_than_end │ happy     │
  │ ss_than_end                              │                                               │
  ├──────────────────────────────────────────┼───────────────────────────────────────────────┤
  │ validate_period_returns_ok_when_start_eq │ happy (zero-length period, including u64::MAX │
  │ uals_end                                 │ == u64::MAX)                                  │
  ├──────────────────────────────────────────┼───────────────────────────────────────────────┤
  │ validate_period_returns_ok_for_large_ord │ happy                                         │
  │ ered_values                              │                                               │
  ├──────────────────────────────────────────┼───────────────────────────────────────────────┤
  │ validate_period_returns_ok_for_u64_max_e │ happy (edge)                                  │
  │ ual                                       │                                              │
  ├───────────────────────────────────────────┼──────────────────────────────────────────────┤
  │ validate_period_returns_err_when_start_gr │ sad                                          │
  ├────────────────────────────────────────────────────┼─────────────────────────────────────┤
  │ validate_period_returns_err_when_start_is_max_minu │ sad (edge)                          │
  │ s_zero_and_end_is_max_minus_one                    │                                     │
  ├────────────────────────────────────────────────────┼─────────────────────────────────────┤
  │ validate_period_returns_err_when_start_is_u64_max_ │ sad (edge)                          │
  │ and_end_is_smaller                                 │                                     │
  ├────────────────────────────────────────────────┼─────────────────────────────────────────┤
  │ proptest_validate_period_matches_ordering      │ property — pins the full start <= end ↔ │
  │                                                │ Ok contract over all u64 pairs          │
  └────────────────────────────────────────────────┴─────────────────────────────────────────┘
  
  guard_bytes_len
  
  ┌──────┬───────────┐
  │ Test                                       │ Direction │
  ├────────────────────────────────────────────┼───────────┤
  │ guard_bytes_len_returns_ok_for_empty_bytes │ happy     │
  ├────────────────────────────────────────────┼───────────┤
  │ guard_bytes_len_returns_ok_for_short_bytes                  │ happy     │
  ├─────────────────────────────────────────────────────────────┼─────────────────────────────┤
  │ guard_bytes_len_returns_ok_when_len_equals_max_bytes_return │ happy (boundary, inclusive) │
  ├─────────────────────────────────────────────────────────────┼─────────────────────────────┤
  │ guard_bytes_len_returns_err_when_len_is_one_over_max_bytes_ │ sad (boundary + 1)          │
  │ return                                                      │                             │
  ├─────────────────────────────────────────────────────────────┼─────────────────────────────┤
  │ guard_bytes_len_returns_err_for_double_the_limit            │ sad                         │
  │ one_over_max_bytes_return                │                                               │
  ├──────────────────────────────────────────┼───────────────────────────────────────────────┤
  │ guard_bytes_len_returns_err_for_double_t │ sad                                           │
  │ he_limit                                 │                                               │
  ├──────────────────────────────────────────┼───────────────────────────────────────────────┤
  │ proptest_guard_bytes_len_matches_limit   │ property — pins len <= MAX_BYTES_RETURN ↔ Ok  │
  │                                          │ across 0..=MAX_BYTES_RETURN*2                 │
  └──────────────────────────────────────────┴───────────────────────────────────────────────┘
  
  Testing
  
  cargo test -p remitwise-common
  
  All new tests are deterministic and run on every CI matrix entry as part of the existing
  remitwise-common test suite.
  
  Checklist
  
  - [x] Both directions covered (happy path and explicit sad path)
  - [x] Assertive test names (returns_ok_when_…, returns_err_when_…)
  - [x] #![no_std] discipline maintained — std::vec! only in #[cfg(test)] scope
  - [x] No production code modified
  - [x] Proptest property tests included for both functions
  - [x] No new dependencies introduced
  
  Closes #1099 