### PR TITLE
test: add require_matching_ledger boundary condition tests

### DIFF
--- a/remitwise-common/src/tests.rs
+++ b/remitwise-common/src/tests.rs
@@ -912,3 +912,50 @@ fn test_require_matching_ledger_far_after() {
     let result = require_matching_ledger(&env, 100);
     assert_eq!(result, Err(LedgerError::LedgerMismatch));
 }
+
+// ─── require_matching_ledger ───────────────────────────────────────────────────
+
+/// Calling with the current ledger sequence returns Ok(()).
+#[test]
+fn test_require_matching_ledger_same_ledger() {
+    let env = Env::default();
+    set_ledger(&env, 42);
+    let result = require_matching_ledger(&env, 42);
+    assert_eq!(result, Ok(()));
+}
+
+/// Calling with one less than the current ledger returns Err(LedgerMismatch).
+#[test]
+fn test_require_matching_ledger_one_before() {
+    let env = Env::default();
+    set_ledger(&env, 42);
+    let result = require_matching_ledger(&env, 41);
+    assert_eq!(result, Err(LedgerError::LedgerMismatch));
+}
+
+/// Calling with one more than the current ledger returns Err(LedgerMismatch).
+#[test]
+fn test_require_matching_ledger_one_after() {
+    let env = Env::default();
+    set_ledger(&env, 42);
+    let result = require_matching_ledger(&env, 43);
+    assert_eq!(result, Err(LedgerError::LedgerMismatch));
+}
+
+/// Calling with a far-earlier ledger also returns Err(LedgerMismatch).
+#[test]
+fn test_require_matching_ledger_far_before() {
+    let env = Env::default();
+    set_ledger(&env, 100);
+    let result = require_matching_ledger(&env, 1);
+    assert_eq!(result, Err(LedgerError::LedgerMismatch));
+}
+
+/// Calling with a far-later ledger also returns Err(LedgerMismatch).
+#[test]
+fn test_require_matching_ledger_far_after() {
+    let env = Env::default();
+    set_ledger(&env, 1);
+    let result = require_matching_ledger(&env, 100);
+    assert_eq!(result, Err(LedgerError::LedgerMismatch));
+}


### PR DESCRIPTION
## Summary

Adds `require_matching_ledger` function and tests for its three boundary conditions: **same ledger**, **one before**, **one after**.

## Changes

- **`remitwise-common/src/lib.rs`**: Added `LedgerError` enum (`LedgerMismatch`) and `require_matching_ledger(env, expected)` utility that returns `Ok(())` when `expected == env.ledger().sequence()` and `Err(LedgerMismatch)` otherwise.

- **`remitwise-common/src/tests.rs`**: Added five tests:
  - `test_require_matching_ledger_same_ledger` — happy path
  - `test_require_matching_ledger_one_before` — boundary: current - 1
  - `test_require_matching_ledger_one_after` — boundary: current + 1
  - `test_require_matching_ledger_far_before` — general sad path
  - `test_require_matching_ledger_far_after` — general sad path

  Added a `set_ledger` helper (mirroring `testutils::set_ledger_time`) to set the ledger sequence in tests.

## Why

The schedule executor uses `last_executed` / `next_due` for idempotency, but there is no ledger-sequence-based replay protection helper. This function fills that gap and the tests lock the boundary conditions (exact match vs ±1) in place.

Closes #1130