### PR TITLE
feat(common): add require_positive_settlement_amount helper (#1153)

### DIFF
--- a/remitwise-common/src/lib.rs
+++ b/remitwise-common/src/lib.rs
@@ -148,6 +148,94 @@ pub fn guard_bytes_len(bytes: &Bytes) -> Result<(), BytesReturnError> {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Settlement amount validation
+// ---------------------------------------------------------------------------
+
+/// Error returned when a settlement-moving amount is not strictly positive.
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum SettlementAmountError {
+    /// `amount <= 0`. Every settlement (a value transfer that finalizes an
+    /// obligation — a bill payment, premium payment, goal contribution,
+    /// remittance disbursement, etc.) must be strictly positive by policy.
+    NonPositiveAmount = 1,
+}
+
+/// Guards that a settlement amount is strictly positive (`> 0`).
+///
+/// This is a defence-in-depth check meant to be called at the top of any
+/// entry point that finalizes a value transfer ("settles" an obligation),
+/// in addition to — not instead of — each contract's own existing
+/// validation. Individual contracts have historically implemented this
+/// bound inconsistently (some guard `amount <= 0`, at least one guard only
+/// `amount < 0`, silently letting a zero-amount settlement through as a
+/// successful no-op). A shared, single-purpose helper removes the chance
+/// of a future entry point picking the wrong comparison operator.
+///
+/// # Threat model
+/// A settlement of `0` that is accepted rather than rejected lets a caller
+/// trigger the full side effects of a "successful" settlement — state
+/// mutation, an emitted settlement event, consumption of a rate-limit
+/// budget, or satisfying a downstream "was this settled?" check in an
+/// orchestrating contract — without moving any value. That gap is useful
+/// to an attacker who wants to grief accounting/audit trails, force
+/// extra event-indexer/off-chain load, or manufacture a "paid" state to
+/// unblock a workflow gate that only checks for success, not amount.
+/// Negative amounts are equally invalid and are rejected by the same
+/// check, since a "negative settlement" has no valid real-world meaning
+/// and would invert the direction of a transfer if it reached arithmetic.
+///
+/// # Cost
+/// A single `i128` comparison; negligible relative to any settlement
+/// entry point's existing storage reads/writes.
+///
+/// # Errors
+/// Returns [`SettlementAmountError::NonPositiveAmount`] if `amount <= 0`.
+pub fn require_positive_settlement_amount(amount: i128) -> Result<(), SettlementAmountError> {
+    if amount <= 0 {
+        Err(SettlementAmountError::NonPositiveAmount)
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod settlement_amount_tests {
+    use super::*;
+
+    #[test]
+    fn rejects_zero() {
+        assert_eq!(
+            require_positive_settlement_amount(0),
+            Err(SettlementAmountError::NonPositiveAmount)
+        );
+    }
+
+    #[test]
+    fn rejects_negative() {
+        assert_eq!(
+            require_positive_settlement_amount(-1),
+            Err(SettlementAmountError::NonPositiveAmount)
+        );
+        assert_eq!(
+            require_positive_settlement_amount(i128::MIN),
+            Err(SettlementAmountError::NonPositiveAmount)
+        );
+    }
+
+    #[test]
+    fn accepts_smallest_positive_amount() {
+        assert_eq!(require_positive_settlement_amount(1), Ok(()));
+    }
+
+    #[test]
+    fn accepts_large_positive_amount() {
+        assert_eq!(require_positive_settlement_amount(i128::MAX), Ok(()));
+    }
+}
+
 /// Pre-upgrade snapshot version
 pub const SNAPSHOT_VERSION: u32 = 1;
 


### PR DESCRIPTION
## Summary
Adds `require_positive_settlement_amount(amount: i128) -> Result<(), SettlementAmountError>`
to `remitwise-common`, plus its typed `SettlementAmountError::NonPositiveAmount`
error, as a defence-in-depth guard for entry points that finalize a value
transfer ("settle" an obligation).

## Threat being mitigated
Several contracts in this workspace already validate amounts at their own
entry points, but the bound has been applied inconsistently: most guard
`amount <= 0`, but `savings_goals::add_to_goal` only guards `amount < 0`,
which means a caller can submit a settlement of exactly `0` and have it
succeed as a no-op rather than be rejected. A zero-amount settlement that
is accepted rather than rejected gives an attacker the full side effects of
a "successful" settlement — state mutation, an emitted event, consumption
of rate-limit budget, or satisfying a downstream "was this settled?" check
in an orchestrating contract — without moving any value. That's useful for
griefing accounting/audit trails, generating indexer/off-chain load, or
manufacturing a "paid" state to slip past a workflow gate that only checks
for call success, not amount. This is raised as a baseline hardening item,
not in response to a known exploit.

## Design
- Added to `remitwise-common` (the shared `#![no_std]` crate every contract
  already depends on) rather than duplicated per-contract, following the
  existing pattern of `guard_bytes_len` / `validate_period` in the same file.
- Returns a typed `#[contracterror]` (`SettlementAmountError::NonPositiveAmount`)
  rather than panicking, consistent with the rest of the crate.
- This PR only adds the helper + tests, per the issue's scope. Wiring it into
  existing entry points (including fixing the `add_to_goal` inconsistency) is
  left as a follow-up to avoid an unrelated multi-file refactor in this PR.

## Cost
Single `i128` comparison — negligible relative to any settlement entry
point's existing storage reads/writes; not a hot-path concern.

## Testing
- `settlement_amount_tests::rejects_zero` / `rejects_negative` — negative
  tests that did not exist before this change (nothing to guard against);
  they pass now that the helper exists.
- `settlement_amount_tests::accepts_smallest_positive_amount` /
  `accepts_large_positive_amount` — positive-path coverage at the boundary
  and at `i128::MAX`.
- `cargo test -p remitwise-common --lib settlement_amount_tests`
- `cargo build --target wasm32-unknown-unknown --release`
- `cargo clippy --workspace --all-targets -- -D warnings`

Closes #1153