### PR TITLE
test: add 3 clamp_limit pagination tests per contract

### DIFF
--- a/bill_payments/src/test.rs
+++ b/bill_payments/src/test.rs
@@ -3540,4 +3540,140 @@ mod testsuit {
             assert_eq!(cached_total, actual_total, "Cached unpaid total must match actual sum of unpaid bills");
         }
     }
+
+    // ── clamp_limit pagination tests for get_unpaid_bills ─────────────────────
+    //
+    // Three cases lock the pagination-limit normalisation contract used by
+    // `get_unpaid_bills` via `remitwise_common::clamp_limit`:
+    //   1. `limit == 0`  → treated as DEFAULT_PAGE_LIMIT (20)
+    //   2. `limit > MAX_PAGE_LIMIT` → clamped to MAX_PAGE_LIMIT (50)
+    //   3. `1 <= limit <= MAX_PAGE_LIMIT` → passes through unchanged
+
+    /// A zero limit must be normalised to DEFAULT_PAGE_LIMIT (20).
+    ///
+    /// Seed 25 unpaid bills so the page is visibly bounded by the default
+    /// rather than by the actual record count.
+    #[test]
+    fn get_unpaid_bills_zero_limit_returns_default_page_limit() {
+        use remitwise_common::{DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT};
+
+        let env = Env::default();
+        let contract_id = env.register_contract(None, BillPayments);
+        let client = BillPaymentsClient::new(&env, &contract_id);
+        let owner = <soroban_sdk::Address as AddressTrait>::generate(&env);
+        env.mock_all_auths();
+
+        let total: u32 = DEFAULT_PAGE_LIMIT + 5;
+        for i in 0..total {
+            client.create_bill(
+                &owner,
+                &String::from_str(&env, &format!("Bill{}", i)),
+                &100i128,
+                &2_000_000_000u64,
+                &false,
+                &0,
+                &None,
+                &String::from_str(&env, "XLM"),
+                &None,
+            );
+        }
+
+        let page = client.get_unpaid_bills(&owner, &0, &0);
+        assert_eq!(
+            page.items.len(),
+            DEFAULT_PAGE_LIMIT,
+            "limit=0 must be normalised to DEFAULT_PAGE_LIMIT={DEFAULT_PAGE_LIMIT}, \
+             not return all {total} records"
+        );
+        assert_eq!(page.count, DEFAULT_PAGE_LIMIT);
+        assert!(
+            page.next_cursor > 0,
+            "next_cursor must be non-zero when more pages remain"
+        );
+        let _ = MAX_PAGE_LIMIT; // keep import used
+    }
+
+    /// An oversized limit must be clamped to MAX_PAGE_LIMIT (50).
+    ///
+    /// Seed 55 unpaid bills so the page is visibly bounded by the maximum
+    /// rather than by the actual record count.
+    #[test]
+    fn get_unpaid_bills_oversized_limit_clamped_to_max_page_limit() {
+        use remitwise_common::MAX_PAGE_LIMIT;
+
+        let env = Env::default();
+        let contract_id = env.register_contract(None, BillPayments);
+        let client = BillPaymentsClient::new(&env, &contract_id);
+        let owner = <soroban_sdk::Address as AddressTrait>::generate(&env);
+        env.mock_all_auths();
+
+        let total: u32 = MAX_PAGE_LIMIT + 5;
+        for i in 0..total {
+            client.create_bill(
+                &owner,
+                &String::from_str(&env, &format!("Bill{}", i)),
+                &100i128,
+                &2_000_000_000u64,
+                &false,
+                &0,
+                &None,
+                &String::from_str(&env, "XLM"),
+                &None,
+            );
+        }
+
+        let page = client.get_unpaid_bills(&owner, &0, &u32::MAX);
+        assert_eq!(
+            page.items.len(),
+            MAX_PAGE_LIMIT,
+            "limit=u32::MAX must be clamped to MAX_PAGE_LIMIT={MAX_PAGE_LIMIT}"
+        );
+        assert_eq!(page.count, MAX_PAGE_LIMIT);
+        assert!(
+            page.next_cursor > 0,
+            "next_cursor must be non-zero when more pages remain"
+        );
+    }
+
+    /// A limit within [1, MAX_PAGE_LIMIT] must pass through unchanged.
+    #[test]
+    fn get_unpaid_bills_in_range_limit_passes_through_unchanged() {
+        use remitwise_common::MAX_PAGE_LIMIT;
+
+        let env = Env::default();
+        let contract_id = env.register_contract(None, BillPayments);
+        let client = BillPaymentsClient::new(&env, &contract_id);
+        let owner = <soroban_sdk::Address as AddressTrait>::generate(&env);
+        env.mock_all_auths();
+
+        let requested_limit: u32 = 7;
+        assert!(requested_limit >= 1 && requested_limit <= MAX_PAGE_LIMIT);
+
+        let total: u32 = requested_limit + 3;
+        for i in 0..total {
+            client.create_bill(
+                &owner,
+                &String::from_str(&env, &format!("Bill{}", i)),
+                &100i128,
+                &2_000_000_000u64,
+                &false,
+                &0,
+                &None,
+                &String::from_str(&env, "XLM"),
+                &None,
+            );
+        }
+
+        let page = client.get_unpaid_bills(&owner, &0, &requested_limit);
+        assert_eq!(
+            page.items.len(),
+            requested_limit,
+            "in-range limit={requested_limit} must be returned unmodified"
+        );
+        assert_eq!(page.count, requested_limit);
+        assert!(
+            page.next_cursor > 0,
+            "next_cursor must be non-zero when more pages remain"
+        );
+    }
 }

--- a/insurance/src/test.rs
+++ b/insurance/src/test.rs
@@ -1014,4 +1014,134 @@ mod tests {
         let err = c.try_batch_pay_premiums(&owner, &ids).unwrap_err().unwrap();
         assert_eq!(err, InsuranceError::PolicyNotFound);
     }
+
+    // ── clamp_limit pagination tests for get_deactivated_policies ─────────────
+    //
+    // Three cases lock the pagination-limit normalisation contract used by
+    // `get_deactivated_policies`:
+    //   1. `limit == 0`  → treated as DEFAULT_PAGE_LIMIT (20)
+    //   2. `limit > MAX_PAGE_LIMIT` → clamped to MAX_PAGE_LIMIT (50)
+    //   3. `1 <= limit <= MAX_PAGE_LIMIT` → passes through unchanged
+
+    /// A zero limit must be normalised to DEFAULT_PAGE_LIMIT (20).
+    ///
+    /// Seed 25 deactivated policies so the page is visibly bounded by the
+    /// default rather than by the actual record count.
+    #[test]
+    fn get_deactivated_policies_zero_limit_returns_default_page_limit() {
+        use remitwise_common::{DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT};
+
+        let env = Env::default();
+        env.mock_all_auths();
+        let (c, _contract_owner) = setup_with_owner(&env);
+        let owner = Address::generate(&env);
+
+        // Create and deactivate 25 policies (> DEFAULT_PAGE_LIMIT=20).
+        let total: u32 = DEFAULT_PAGE_LIMIT + 5;
+        for i in 0..total {
+            let name = String::from_str(&env, &format!("P{}", i));
+            let id = c.create_policy(
+                &owner,
+                &name,
+                &CoverageType::Health,
+                &5_000_000i128,
+                &50_000_000i128,
+            );
+            c.deactivate_policy(&owner, &id);
+        }
+
+        let page = c.get_deactivated_policies(&owner, &0, &0);
+        assert_eq!(
+            page.items.len(),
+            DEFAULT_PAGE_LIMIT,
+            "limit=0 must be normalised to DEFAULT_PAGE_LIMIT={DEFAULT_PAGE_LIMIT}, \
+             not return all {total} records"
+        );
+        assert_eq!(page.count, DEFAULT_PAGE_LIMIT);
+        // More pages exist because total > DEFAULT_PAGE_LIMIT.
+        assert!(
+            page.next_cursor > 0,
+            "next_cursor must be non-zero when more pages remain"
+        );
+        let _ = MAX_PAGE_LIMIT; // keep import used
+    }
+
+    /// An oversized limit must be clamped to MAX_PAGE_LIMIT (50).
+    ///
+    /// Seed 55 deactivated policies so the page is visibly bounded by the
+    /// maximum rather than by the actual record count.
+    #[test]
+    fn get_deactivated_policies_oversized_limit_clamped_to_max_page_limit() {
+        use remitwise_common::MAX_PAGE_LIMIT;
+
+        let env = Env::default();
+        env.mock_all_auths();
+        let (c, _contract_owner) = setup_with_owner(&env);
+        let owner = Address::generate(&env);
+
+        let total: u32 = MAX_PAGE_LIMIT + 5;
+        for i in 0..total {
+            let name = String::from_str(&env, &format!("P{}", i));
+            let id = c.create_policy(
+                &owner,
+                &name,
+                &CoverageType::Health,
+                &5_000_000i128,
+                &50_000_000i128,
+            );
+            c.deactivate_policy(&owner, &id);
+        }
+
+        let page = c.get_deactivated_policies(&owner, &0, &u32::MAX);
+        assert_eq!(
+            page.items.len(),
+            MAX_PAGE_LIMIT,
+            "limit=u32::MAX must be clamped to MAX_PAGE_LIMIT={MAX_PAGE_LIMIT}"
+        );
+        assert_eq!(page.count, MAX_PAGE_LIMIT);
+        assert!(
+            page.next_cursor > 0,
+            "next_cursor must be non-zero when more pages remain"
+        );
+    }
+
+    /// A limit within [1, MAX_PAGE_LIMIT] must pass through unchanged.
+    #[test]
+    fn get_deactivated_policies_in_range_limit_passes_through_unchanged() {
+        use remitwise_common::MAX_PAGE_LIMIT;
+
+        let env = Env::default();
+        env.mock_all_auths();
+        let (c, _contract_owner) = setup_with_owner(&env);
+        let owner = Address::generate(&env);
+
+        let requested_limit: u32 = 7;
+        assert!(requested_limit >= 1 && requested_limit <= MAX_PAGE_LIMIT);
+
+        // Seed more records than the requested limit.
+        let total: u32 = requested_limit + 3;
+        for i in 0..total {
+            let name = String::from_str(&env, &format!("P{}", i));
+            let id = c.create_policy(
+                &owner,
+                &name,
+                &CoverageType::Health,
+                &5_000_000i128,
+                &50_000_000i128,
+            );
+            c.deactivate_policy(&owner, &id);
+        }
+
+        let page = c.get_deactivated_policies(&owner, &0, &requested_limit);
+        assert_eq!(
+            page.items.len(),
+            requested_limit,
+            "in-range limit={requested_limit} must be returned unmodified"
+        );
+        assert_eq!(page.count, requested_limit);
+        assert!(
+            page.next_cursor > 0,
+            "next_cursor must be non-zero when more pages remain"
+        );
+    }
 }

--- a/remittance_split/src/test.rs
+++ b/remittance_split/src/test.rs
@@ -2466,3 +2466,114 @@ fn test_initialize_split_percentages_invalid_sum() {
         Err(Ok(RemittanceSplitError::PercentagesDoNotSumTo100))
     );
 }
+
+// ── clamp_limit pagination tests for get_audit_log ───────────────────────────
+//
+// Three cases lock the pagination-limit normalisation contract used by
+// `get_audit_log` via `remitwise_common::clamp_limit`:
+//   1. `limit == 0`  → treated as DEFAULT_PAGE_LIMIT (20)
+//   2. `limit > MAX_PAGE_LIMIT` → clamped to MAX_PAGE_LIMIT (50)
+//   3. `1 <= limit <= MAX_PAGE_LIMIT` → passes through unchanged
+//
+// Each call to `initialize_split` writes one audit entry, so re-initialising
+// via separate contract instances gives us the exact count we need.
+
+/// A zero limit must be normalised to DEFAULT_PAGE_LIMIT (20).
+///
+/// Seed 25 audit entries (> DEFAULT_PAGE_LIMIT) so the page is visibly
+/// bounded by the default rather than by the record count.
+#[test]
+fn get_audit_log_zero_limit_returns_default_page_limit() {
+    use remitwise_common::{DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT};
+
+    let env = Env::default();
+    // Seed 25 entries: each call to setup_split / initialize_split appends one
+    // audit entry.  We create a fresh contract per call so entries accumulate.
+    let total: u32 = DEFAULT_PAGE_LIMIT + 5;
+    // Use a single contract instance and reinitialise via update_split_config,
+    // which also appends an audit entry each time.
+    let harness = setup_split(&env, 50, 30, 15, 5);
+    let client = &harness.client;
+    let owner = &harness.owner;
+
+    // update_split_config appends an audit entry on every call.
+    for _ in 1..total {
+        client.update_split_config(owner, &50, &30, &15, &5);
+    }
+
+    let page = client.get_audit_log(&0, &0);
+    assert_eq!(
+        page.items.len(),
+        DEFAULT_PAGE_LIMIT,
+        "limit=0 must be normalised to DEFAULT_PAGE_LIMIT={DEFAULT_PAGE_LIMIT}, \
+         not return all {total} records"
+    );
+    assert_eq!(page.count, DEFAULT_PAGE_LIMIT);
+    assert!(
+        page.next_cursor > 0,
+        "next_cursor must be non-zero when more pages remain"
+    );
+    let _ = MAX_PAGE_LIMIT; // keep import used
+}
+
+/// An oversized limit must be clamped to MAX_PAGE_LIMIT (50).
+///
+/// Seed 55 audit entries (> MAX_PAGE_LIMIT) so the page is visibly bounded
+/// by the maximum rather than by the record count.
+#[test]
+fn get_audit_log_oversized_limit_clamped_to_max_page_limit() {
+    use remitwise_common::MAX_PAGE_LIMIT;
+
+    let env = Env::default();
+    let total: u32 = MAX_PAGE_LIMIT + 5;
+    let harness = setup_split(&env, 50, 30, 15, 5);
+    let client = &harness.client;
+    let owner = &harness.owner;
+
+    for _ in 1..total {
+        client.update_split_config(owner, &50, &30, &15, &5);
+    }
+
+    let page = client.get_audit_log(&0, &u32::MAX);
+    assert_eq!(
+        page.items.len(),
+        MAX_PAGE_LIMIT,
+        "limit=u32::MAX must be clamped to MAX_PAGE_LIMIT={MAX_PAGE_LIMIT}"
+    );
+    assert_eq!(page.count, MAX_PAGE_LIMIT);
+    assert!(
+        page.next_cursor > 0,
+        "next_cursor must be non-zero when more pages remain"
+    );
+}
+
+/// A limit within [1, MAX_PAGE_LIMIT] must pass through unchanged.
+#[test]
+fn get_audit_log_in_range_limit_passes_through_unchanged() {
+    use remitwise_common::MAX_PAGE_LIMIT;
+
+    let env = Env::default();
+    let requested_limit: u32 = 7;
+    assert!(requested_limit >= 1 && requested_limit <= MAX_PAGE_LIMIT);
+
+    let total: u32 = requested_limit + 3;
+    let harness = setup_split(&env, 50, 30, 15, 5);
+    let client = &harness.client;
+    let owner = &harness.owner;
+
+    for _ in 1..total {
+        client.update_split_config(owner, &50, &30, &15, &5);
+    }
+
+    let page = client.get_audit_log(&0, &requested_limit);
+    assert_eq!(
+        page.items.len(),
+        requested_limit,
+        "in-range limit={requested_limit} must be returned unmodified"
+    );
+    assert_eq!(page.count, requested_limit);
+    assert!(
+        page.next_cursor > 0,
+        "next_cursor must be non-zero when more pages remain"
+    );
+}


### PR DESCRIPTION
Add three unit tests to each of the three contracts that import clamp_limit from remitwise-common, locking the pagination-limit normalisation behaviour at the contract call-site.

Contracts covered:
- insurance/src/test.rs       → get_deactivated_policies
- bill_payments/src/test.rs   → get_unpaid_bills
- remittance_split/src/test.rs → get_audit_log

Each set covers:
1. limit=0 → normalised to DEFAULT_PAGE_LIMIT (20)
2. limit=u32::MAX → clamped to MAX_PAGE_LIMIT (50)
3. in-range limit (7) → passes through unchanged

Closes #1144