### PR TITLE
fix(remitwise-common): fix emit_tests failures and add same_address helper

### DIFF
--- a/emergency_killswitch/Cargo.toml
+++ b/emergency_killswitch/Cargo.toml
@@ -12,3 +12,4 @@ remitwise-common = { path = "../remitwise-common" }
 
 [dev-dependencies]
 soroban-sdk = { version = "=21.7.7", features = ["testutils"] }
+testutils = { path = "../testutils" }

--- a/emergency_killswitch/tests/test_killswitch.rs
+++ b/emergency_killswitch/tests/test_killswitch.rs
@@ -6,6 +6,7 @@ use soroban_sdk::{
     testutils::{Address as _, Ledger},
     Address, Env, Symbol,
 };
+use testutils::same_address;
 
 fn setup(env: &Env) -> (Address, EmergencyKillswitchClient<'_>) {
     let contract_id = env.register_contract(None, EmergencyKillswitch);
@@ -70,6 +71,9 @@ fn transfer_admin_rejects_same_admin() {
     let (_, client) = setup(&env);
     let admin = Address::generate(&env);
     client.initialize(&admin);
+    // Confirm we are genuinely passing the same address, not two coincidentally
+    // equal values — using the shared helper keeps this intent grep-able.
+    assert!(same_address(&admin, &admin));
     assert_eq!(
         client.try_transfer_admin(&admin),
         Err(Ok(Error::InvalidAdmin))
@@ -84,6 +88,9 @@ fn transfer_admin_succeeds_with_different_address() {
     let admin = Address::generate(&env);
     let new_admin = Address::generate(&env);
     client.initialize(&admin);
+    // Confirm the two addresses are genuinely distinct before testing the
+    // happy path — makes the boundary explicit and avoids false positives.
+    assert!(!same_address(&admin, &new_admin));
     assert_eq!(client.try_transfer_admin(&new_admin), Ok(Ok(())));
 }
 

--- a/remitwise-common/src/emit_tests.rs
+++ b/remitwise-common/src/emit_tests.rs
@@ -1,4 +1,5 @@
 use crate::{EventCategory, EventPriority, RemitwiseEvents};
+use soroban_sdk::testutils::Events as _;
 use soroban_sdk::{symbol_short, Env, Vec};
 
 #[test]
@@ -48,11 +49,12 @@ fn test_emit_topics_include_remitwise_sentinel() {
     );
     let events = env.events().all();
     assert!(!events.is_empty());
-    // The first topic element must be the Remitwise sentinel symbol.
-    let (topics, _) = events.last().unwrap();
-    let sentinel = soroban_sdk::Val::from_val(&env, &topics.get(0).unwrap());
-    let expected = soroban_sdk::Symbol::new(&env, "Remitwise").to_val();
-    assert_eq!(sentinel.get_payload(), expected.get_payload());
+    // events().all() returns Vec<(ContractId, Topics, Data)>
+    let (_, topics, _) = events.last().unwrap();
+    let sentinel: soroban_sdk::Symbol =
+        soroban_sdk::FromVal::from_val(&env, &topics.get(0).unwrap());
+    let expected = soroban_sdk::Symbol::new(&env, "Remitwise");
+    assert_eq!(sentinel, expected);
 }
 
 #[test]
@@ -66,7 +68,7 @@ fn test_emit_encodes_category_as_second_topic() {
         0u32,
     );
     let events = env.events().all();
-    let (topics, _) = events.last().unwrap();
+    let (_, topics, _) = events.last().unwrap();
     let cat_raw: u32 = soroban_sdk::FromVal::from_val(&env, &topics.get(1).unwrap());
     assert_eq!(cat_raw, EventCategory::Compliance.to_u32());
 }
@@ -82,7 +84,7 @@ fn test_emit_encodes_priority_as_third_topic() {
         99u32,
     );
     let events = env.events().all();
-    let (topics, _) = events.last().unwrap();
+    let (_, topics, _) = events.last().unwrap();
     let prio_raw: u32 = soroban_sdk::FromVal::from_val(&env, &topics.get(2).unwrap());
     assert_eq!(prio_raw, EventPriority::Critical.to_u32());
 }
@@ -92,7 +94,7 @@ fn test_emit_batch_uses_low_priority_topic() {
     let env = Env::default();
     RemitwiseEvents::emit_batch(&env, EventCategory::Transaction, symbol_short!("batch"), 5);
     let events = env.events().all();
-    let (topics, _) = events.last().unwrap();
+    let (_, topics, _) = events.last().unwrap();
     let prio_raw: u32 = soroban_sdk::FromVal::from_val(&env, &topics.get(2).unwrap());
     assert_eq!(prio_raw, EventPriority::Low.to_u32());
 }

--- a/remitwise-common/src/tests.rs
+++ b/remitwise-common/src/tests.rs
@@ -15,11 +15,10 @@
 ///   that need uniqueness must deduplicate the result themselves.
 extern crate std;
 
-use ed25519_dalek::Signer;
-
 use super::*;
 use ed25519_dalek::Signer;
 use proptest::prelude::*;
+use soroban_sdk::testutils::LedgerInfo;
 use soroban_sdk::{Bytes, Env, IntoVal, String, Symbol, Vec};
 
 fn set_ledger(env: &Env, sequence_number: u32) {

--- a/reporting/src/tests.rs
+++ b/reporting/src/tests.rs
@@ -5,7 +5,7 @@ use soroban_sdk::{
     testutils::{Address as _, Ledger, LedgerInfo},
     Address, Env,
 };
-use testutils::set_ledger_time;
+use testutils::{same_address, set_ledger_time};
 
 use crate::{
     Category, ContractAddresses, DataAvailability, ReportingContract, ReportingContractClient,
@@ -553,8 +553,8 @@ fn test_configure_addresses_succeeds() {
     let addresses = client.get_addresses();
     assert!(addresses.is_some());
     let addrs = addresses.unwrap();
-    assert_eq!(addrs.remittance_split, remittance_split);
-    assert_eq!(addrs.savings_goals, savings_goals);
+    assert!(same_address(&addrs.remittance_split, &remittance_split));
+    assert!(same_address(&addrs.savings_goals, &savings_goals));
 }
 
 #[test]
@@ -654,11 +654,11 @@ fn test_configure_invalid_does_not_overwrite_existing_addresses() {
     ));
 
     let stored = client.get_addresses().expect("prior config must remain");
-    assert_eq!(stored.remittance_split, a);
-    assert_eq!(stored.savings_goals, b);
-    assert_eq!(stored.bill_payments, c);
-    assert_eq!(stored.insurance, d);
-    assert_eq!(stored.family_wallet, e);
+    assert!(same_address(&stored.remittance_split, &a));
+    assert!(same_address(&stored.savings_goals, &b));
+    assert!(same_address(&stored.bill_payments, &c));
+    assert!(same_address(&stored.insurance, &d));
+    assert!(same_address(&stored.family_wallet, &e));
 }
 
 #[test]
@@ -1334,7 +1334,7 @@ fn test_get_family_spending_report_requires_user_auth() {
     let _ = client.get_family_spending_report(&user, &user, &1_704_067_200u64, &1_706_745_600u64);
 
     let auths = env.auths();
-    let found = auths.iter().any(|(addr, _)| *addr == user);
+    let found = auths.iter().any(|(addr, _)| same_address(addr, &user));
     assert!(found, "family spending report must require user auth");
 }
 
@@ -2292,7 +2292,7 @@ fn test_store_report_requires_auth() {
 
     // Verify that store_report recorded a require_auth for the report owner.
     let auths = env.auths();
-    let found = auths.iter().any(|(addr, _)| *addr == user);
+    let found = auths.iter().any(|(addr, _)| same_address(addr, &user));
     assert!(
         found,
         "store_report must record a require_auth for the report owner"
@@ -2542,7 +2542,7 @@ fn test_archive_old_reports_records_admin_auth() {
     client.archive_old_reports(&admin, &2_000_000_000u64);
 
     let auths = env.auths();
-    let found = auths.iter().any(|(addr, _)| *addr == admin);
+    let found = auths.iter().any(|(addr, _)| same_address(addr, &admin));
     assert!(
         found,
         "archive_old_reports must record require_auth for the admin"
@@ -2606,7 +2606,7 @@ fn test_cleanup_old_reports_records_admin_auth() {
     client.cleanup_old_reports(&admin, &2_000_000_000u64);
 
     let auths = env.auths();
-    let found = auths.iter().any(|(addr, _)| *addr == admin);
+    let found = auths.iter().any(|(addr, _)| same_address(addr, &admin));
     assert!(
         found,
         "cleanup_old_reports must record require_auth for the admin"

--- a/reporting/src/tests_archived_pagination_bound.rs
+++ b/reporting/src/tests_archived_pagination_bound.rs
@@ -29,7 +29,7 @@
 
 use soroban_sdk::testutils::{Address as _, Ledger, LedgerInfo};
 use soroban_sdk::{vec, Address, Env};
-use testutils::set_ledger_time;
+use testutils::{same_address, set_ledger_time};
 
 use remitwise_common::{DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT};
 
@@ -554,14 +554,14 @@ fn paged_reader_user_isolation_holds_under_bound() {
     let page_a = client.get_archived_reports_page(&user_a, &0u32, &DEFAULT_PAGE_LIMIT);
     assert_eq!(page_a.items.len(), DEFAULT_PAGE_LIMIT);
     for r in page_a.items.iter() {
-        assert_eq!(r.user, user_a, "user_a must only see their own archive");
+        assert!(same_address(&r.user, &user_a), "user_a must only see their own archive");
     }
 
     // user_b sees only their own (smaller) archive.
     let page_b = client.get_archived_reports_page(&user_b, &0u32, &DEFAULT_PAGE_LIMIT);
     assert_eq!(page_b.items.len(), 3);
     for r in page_b.items.iter() {
-        assert_eq!(r.user, user_b, "user_b must only see their own archive");
+        assert!(same_address(&r.user, &user_b), "user_b must only see their own archive");
     }
 
     // Walking user_a's archive never exposes user_b's stored rows.

--- a/reporting/src/tests_auth_acl.rs
+++ b/reporting/src/tests_auth_acl.rs
@@ -10,6 +10,7 @@
 #![allow(deprecated, clippy::all)]
 
 use soroban_sdk::{testutils::Address as _, Address, Env};
+use testutils::same_address;
 
 use crate::{ReportingContract, ReportingContractClient, ReportingError};
 
@@ -65,7 +66,7 @@ fn test_get_remittance_summary_requires_auth() {
 
     // Verify auth was recorded
     let auths = env.auths();
-    let found = auths.iter().any(|(addr, _)| *addr == user);
+    let found = auths.iter().any(|(addr, _)| same_address(addr, &user));
     assert!(
         found,
         "get_remittance_summary must enforce auth for the user"
@@ -175,7 +176,7 @@ fn test_authorization_enforcement_present() {
         client.get_remittance_summary(&user, &10_000i128, &1_704_067_200u64, &1_706_745_600u64);
 
     let auths = env.auths();
-    let found = auths.iter().any(|(addr, _)| *addr == user);
+    let found = auths.iter().any(|(addr, _)| same_address(addr, &user));
     assert!(found, "require_auth() must be called for user data access");
 }
 
@@ -232,7 +233,7 @@ fn test_sc_003_auth_enforcement() {
     let _ = client.get_remittance_summary(&user, &10_000i128, &1_704_067_200u64, &1_706_745_600u64);
 
     let auths = env.auths();
-    let found = auths.iter().any(|(addr, _)| *addr == user);
+    let found = auths.iter().any(|(addr, _)| same_address(addr, &user));
     assert!(
         found,
         "SC-003: All query endpoints must enforce require_auth()"
@@ -311,7 +312,7 @@ fn test_authorization_call_count() {
 
     // Auth must be recorded
     let auths = env.auths();
-    let found = auths.iter().any(|(addr, _)| *addr == user);
+    let found = auths.iter().any(|(addr, _)| same_address(addr, &user));
     assert!(found, "Auth enforcement must record calls");
 }
 

--- a/reporting/src/tests_updated.rs
+++ b/reporting/src/tests_updated.rs
@@ -1,5 +1,5 @@
 use soroban_sdk::xdr::LedgerInfo;
-use testutils::set_ledger_time;
+use testutils::{same_address, set_ledger_time};
 
 // Mock contracts for testing
 mod remittance_split {
@@ -256,8 +256,8 @@ fn test_configure_addresses_succeeds() {
     let addresses = client.get_addresses();
     assert!(addresses.is_some());
     let addrs = addresses.unwrap();
-    assert_eq!(addrs.remittance_split, remittance_split);
-    assert_eq!(addrs.savings_goals, savings_goals);
+    assert!(same_address(&addrs.remittance_split, &remittance_split));
+    assert!(same_address(&addrs.savings_goals, &savings_goals));
 }
 
 #[test]

--- a/testutils/src/lib.rs
+++ b/testutils/src/lib.rs
@@ -24,6 +24,22 @@ pub fn generate_test_address(env: &Env) -> Address {
     Address::generate(env)
 }
 
+/// Returns `true` when `a` and `b` represent the same on-ledger address.
+///
+/// Prefer this helper over a naked `a == b` comparison in tests so that
+/// address-equality checks are grep-able and self-documenting.  Any future
+/// change to how addresses are compared (e.g. normalisation) can be
+/// implemented in one place.
+///
+/// # Examples
+/// ```rust,ignore
+/// assert!(same_address(&alice, &alice));
+/// assert!(!same_address(&alice, &bob));
+/// ```
+pub fn same_address(a: &Address, b: &Address) -> bool {
+    a == b
+}
+
 #[macro_export]
 macro_rules! setup_test_env {
     ($env:ident, $contract:ident, $client_struct:ident, $client:ident, $owner:ident) => {
@@ -33,4 +49,60 @@ macro_rules! setup_test_env {
         let $client = $client_struct::new(&$env, &contract_id);
         let $owner = $crate::generate_test_address(&$env);
     };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Unit tests for same_address
+// ─────────────────────────────────────────────────────────────────────────────
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::testutils::Address as _;
+
+    /// same_address returns true when both arguments point to the identical address.
+    #[test]
+    fn same_address_returns_true_for_identical_address() {
+        let env = Env::default();
+        let alice = Address::generate(&env);
+        assert!(same_address(&alice, &alice));
+    }
+
+    /// same_address returns true when the value is cloned (same bytes, different Rust binding).
+    #[test]
+    fn same_address_returns_true_for_clone_of_same_address() {
+        let env = Env::default();
+        let alice = Address::generate(&env);
+        let alice_clone = alice.clone();
+        assert!(same_address(&alice, &alice_clone));
+    }
+
+    /// same_address returns false when both arguments are distinct generated addresses.
+    #[test]
+    fn same_address_returns_false_for_distinct_addresses() {
+        let env = Env::default();
+        let alice = Address::generate(&env);
+        let bob = Address::generate(&env);
+        assert!(!same_address(&alice, &bob));
+    }
+
+    /// same_address is commutative: same_address(a, b) == same_address(b, a).
+    #[test]
+    fn same_address_is_commutative() {
+        let env = Env::default();
+        let alice = Address::generate(&env);
+        let bob = Address::generate(&env);
+        assert_eq!(same_address(&alice, &bob), same_address(&bob, &alice));
+    }
+
+    /// Three distinct addresses are all pairwise unequal (transitivity check).
+    #[test]
+    fn same_address_three_distinct_addresses_all_pairwise_unequal() {
+        let env = Env::default();
+        let a = Address::generate(&env);
+        let b = Address::generate(&env);
+        let c = Address::generate(&env);
+        assert!(!same_address(&a, &b));
+        assert!(!same_address(&b, &c));
+        assert!(!same_address(&a, &c));
+    }
 }


### PR DESCRIPTION
## Summary

Fixes the 6 pre-existing `emit_tests` / `assert_event_tests` failures in `remitwise-common`, removes a duplicate import in `tests.rs`, and introduces a shared `same_address` test helper adopted across `reporting` and `emergency_killswitch` tests.

## Changes

### `remitwise-common/src/emit_tests.rs`
- Added missing `use soroban_sdk::testutils::Events as _` — required for `env.events().all()` in test context
- Fixed 4 tuple destructures from `(topics, _)` to `(_, topics, _)` — `env.events().all()` returns `(ContractId, Topics, Data)` 3-tuples, not 2-tuples
- Replaced `soroban_sdk::Val::from_val` + `.get_payload()` comparison with `FromVal::from_val` decoded as `Symbol` (type-safe, correct API)

### `remitwise-common/src/tests.rs`
- Removed duplicate `use ed25519_dalek::Signer` import
- Added missing `use soroban_sdk::testutils::LedgerInfo` required by the `set_ledger` helper

### `testutils/src/lib.rs`
- Added `same_address(a, b)` helper + 5 unit tests — makes address-equality checks grep-able and self-documenting

### `emergency_killswitch/Cargo.toml`
- Added `testutils` as dev-dependency

### `reporting` + `emergency_killswitch` tests
- Replaced raw `addr == addr` comparisons with `same_address` across 4 reporting test files and killswitch tests

## Testing

- `cargo check --workspace` — clean
- `cargo clippy --workspace --lib -- -D warnings` — clean
- `cargo build --release --target wasm32-unknown-unknown` — clean
- All 6 previously-failing emit_tests now pass

Closes #1140