### PR TITLE
fix: wire verify_no_dust into distribute_usdc transfer functions (#1113)

### DIFF
--- a/remittance_split/src/lib.rs
+++ b/remittance_split/src/lib.rs
@@ -9,7 +9,7 @@ mod test;
 mod tests_safe_math;
 
 use remitwise_common::{
-    clamp_limit, guard_bytes_len, verify_no_dust, DustError, EventCategory, EventPriority,
+    clamp_limit, guard_bytes_len, verify_no_dust, EventCategory, EventPriority,
     RemitwiseEvents, Timestamp, ToI128Checked, INSTANCE_BUMP_AMOUNT, INSTANCE_LIFETIME_THRESHOLD,
     PERSISTENT_BUMP_AMOUNT, PERSISTENT_LIFETIME_THRESHOLD, SNAPSHOT_KEY, SNAPSHOT_VERSION,
 };

--- a/remittance_split/src/lib.rs
+++ b/remittance_split/src/lib.rs
@@ -9,9 +9,9 @@ mod test;
 mod tests_safe_math;
 
 use remitwise_common::{
-    clamp_limit, guard_bytes_len, EventCategory, EventPriority, RemitwiseEvents, Timestamp,
-    ToI128Checked, INSTANCE_BUMP_AMOUNT, INSTANCE_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT,
-    PERSISTENT_LIFETIME_THRESHOLD, SNAPSHOT_KEY, SNAPSHOT_VERSION,
+    clamp_limit, guard_bytes_len, verify_no_dust, DustError, EventCategory, EventPriority,
+    RemitwiseEvents, Timestamp, ToI128Checked, INSTANCE_BUMP_AMOUNT, INSTANCE_LIFETIME_THRESHOLD,
+    PERSISTENT_BUMP_AMOUNT, PERSISTENT_LIFETIME_THRESHOLD, SNAPSHOT_KEY, SNAPSHOT_VERSION,
 };
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, symbol_short, token::TokenClient, vec,
@@ -1330,6 +1330,10 @@ impl RemittanceSplit {
             Self::append_audit(&env, symbol_short!("distrib"), &from, false);
             return Err(RemittanceSplitError::InvalidAmount);
         }
+        if verify_no_dust(total_amount).is_err() {
+            Self::append_audit(&env, symbol_short!("distrib"), &from, false);
+            return Err(RemittanceSplitError::InvalidAmount);
+        }
 
         // 7. No destination account may equal the sender (self-transfer guard).
         if accounts.spending == from
@@ -1431,6 +1435,10 @@ impl RemittanceSplit {
         Self::extend_instance_ttl(&env);
         // Validate amount
         if request.total_amount <= 0 {
+            Self::append_audit(&env, symbol_short!("distH"), &request.from, false);
+            return Err(RemittanceSplitError::InvalidAmount);
+        }
+        if verify_no_dust(request.total_amount).is_err() {
             Self::append_audit(&env, symbol_short!("distH"), &request.from, false);
             return Err(RemittanceSplitError::InvalidAmount);
         }


### PR DESCRIPTION
 Summary
Closes #1113

`verify_no_dust` already existed in `remitwise-common` (with `MIN_TRANSFER = 100`
and `DustError`) but was never called from any contract. This PR wires it into
the two USDC distribution entrypoints in `remittance_split`.

 Changes
- Imported `verify_no_dust, DustError` from `remitwise_common` in
  `remittance_split/src/lib.rs`
- Added a dust check on `total_amount` in `distribute_usdc`, immediately after
  the existing `total_amount <= 0` validation
- Added the same dust check on `request.total_amount` in
  `distribute_usdc_hashed`, immediately after its `total_amount <= 0` validation
- Both checks return `RemittanceSplitError::InvalidAmount` if the amount fails
  the dust threshold, consistent with the existing amount-validation error path

 Why
Amounts below `MIN_TRANSFER` can produce zero or near-zero per-category
allocations after the percentage split, wasting gas on no-op transfers and
letting dust-value distributions through unchecked. Rejecting them early,
alongside the existing `<= 0` check, closes that gap.

 Testing
- `cargo check -p remittance_split` passes
- Manually verified both dust checks are placed inside the function bodies
  (not in the parameter list) and execute right after their respective
  `total_amount <= 0` guards