### PR TITLE
docs: add ZERO_AMOUNT_POLICY.md and link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ To run an example, use `cargo run --example <example_name>`:
 - [Authorization Matrix](docs/AUTHORIZATION_MATRIX.md) - Per-entrypoint caller authorization requirements for all contracts
 - [Pause Playbook](docs/PAUSE_PLAYBOOK.md) - Emergency pause mechanisms and recovery procedures for operators
 - [Committed Hashes](docs/COMMITTED_HASHES.md) - Request-hash coverage and verification guidance for downstream integrators
+- [Zero-Amount Policy](docs/ZERO_AMOUNT_POLICY.md) - Which entrypoints reject, accept, or normalize zero amounts; quick reference for integrators
 - [Family Wallet Design (as implemented)](docs/family-wallet-design.md)
 - [Reporting Admin Rotation](docs/reporting-admin-rotation.md) - Two-step upgrade-admin handoff procedure for reporting dependency configuration
 - [Event Indexing Guide](docs/INDEXING.md) - Mapping contract events to off-chain tables

--- a/docs/ZERO_AMOUNT_POLICY.md
+++ b/docs/ZERO_AMOUNT_POLICY.md
@@ -1,0 +1,47 @@
+# Zero-Amount Policy
+
+> **Audience:** downstream integrators — wallet UI, bot, or backend calling RemitWise contracts.
+> For the full per-entrypoint breakdown see [AMOUNT_INVARIANTS.md](AMOUNT_INVARIANTS.md).
+
+## TL;DR
+
+| Behavior | When | Example entrypoint |
+|---|---|---|
+| **Reject** | Most value-moving entrypoints | `create_bill`, `pay_bill`, `execute_remittance_flow` |
+| **Accept** | `savings_goals::add_to_goal` only | `add_to_goal(amount: 0)` succeeds as a no-op |
+| **Normalize** | Fan-out allocations; `spending_limit` sentinel | Zero leg skipped in `run_remittance_fan_out`; `spending_limit = 0` means unlimited |
+
+## Default Rule
+
+If an entrypoint moves or schedules value, treat `amount = 0` as **rejected** unless this document says otherwise.
+
+## Known Exceptions
+
+### `savings_goals::add_to_goal` — Accepts zero
+Calling `add_to_goal` with `amount = 0` succeeds and emits an event with `amount = 0`. It is a no-op that moves no funds. Guard against this if your intent is to skip zero contributions.
+
+```rust
+// This succeeds — no funds move, event is emitted
+client.add_to_goal(&user, &goal_id, &0i128);
+```
+
+### `orchestrator::run_remittance_fan_out` — Normalizes zero allocations
+The top-level `total_amount` must be `> 0`. After splitting, any leg with a zero allocation is silently skipped — the downstream contract is never called for that leg.
+
+```rust
+// Zero savings allocation → savings_goals::add_to_goal is never called
+// Zero bills allocation  → bill_payments::pay_bill is never called
+```
+
+### `family_wallet` spending limit — Zero means unlimited
+`spending_limit = 0` on a member record is a sentinel for "no cap", not "blocked". `check_spending_limit` always returns `true` when `spending_limit == 0`.
+
+## All Amounts Are i128 Stroops
+
+All `amount` parameters are `i128` stroops (1 XLM = 10,000,000 stroops). There is no shared amount type — each contract validates independently.
+
+## Related Docs
+
+- [AMOUNT_INVARIANTS.md](AMOUNT_INVARIANTS.md) — full per-entrypoint table
+- [Remittance Split Rounding & Dust Policy](remittance-split-rounding-policy.md)
+- [AUTHORIZATION_MATRIX.md](AUTHORIZATION_MATRIX.md)


### PR DESCRIPTION
## Summary
Adds `docs/ZERO_AMOUNT_POLICY.md` — a concise quick-reference for downstream integrators (wallet UI, bot, backend) on where the contracts reject, accept, or normalize zero amounts.

## Changes

### `docs/ZERO_AMOUNT_POLICY.md` (new)
- TL;DR table of the three behaviors (Reject / Accept / Normalize)
- Default rule: assume zero is rejected for any value-moving entrypoint
- Named exceptions with Rust code examples:
  - `savings_goals::add_to_goal` — accepts zero as a no-op
  - `orchestrator::run_remittance_fan_out` — normalizes zero allocations (skips the leg)
  - `family_wallet` spending limit — `spending_limit = 0` means unlimited
- Cross-links to `AMOUNT_INVARIANTS.md`, `remittance-split-rounding-policy.md`, `AUTHORIZATION_MATRIX.md`

### `README.md`
- Added link to `docs/ZERO_AMOUNT_POLICY.md` in the documentation section

## Notes
- No Rust source files modified
- No `#![no_std]` discipline violated — documentation only
- `cargo build` and `cargo test` unaffected

Closes #1175