### PR TITLE
fix(remitwise-common): reject verifier keys registered on a different…

### DIFF
--- a/remitwise-common/src/lib.rs
+++ b/remitwise-common/src/lib.rs
@@ -961,25 +961,36 @@ pub enum SignatureError {
     VerificationFailed = 3,
     /// The verifier public key has not been registered for attestation verification.
     UnregisteredVerifier = 4,
+    /// The verifier public key was registered under a different Stellar network
+    /// (e.g. Testnet) than the one this contract instance is currently running on.
+    VerifierNetworkMismatch = 5,
 }
 
 /// Storage key for the set of registered verifier public keys.
 const REGISTERED_VERIFIERS_KEY: Symbol = symbol_short!("REGVER");
 
 /// Registers a verifier public key so its attestations may be consumed.
+///
+/// The public key is bound to `env.ledger().network_id()` (the SHA-256 hash of
+/// the network passphrase) at registration time. This prevents a verifier key
+/// that was only ever intended to be trusted on one Stellar network (for
+/// example a "test signer" key provisioned for Testnet QA) from silently
+/// becoming trusted on another network (for example Public/Mainnet) if the
+/// underlying storage entry is ever copied or replayed across deployments —
+/// see [`require_registered_verifier`].
 pub fn register_verifier(env: &Env, public_key: &[u8]) -> Result<(), SignatureError> {
     let pk_arr: [u8; 32] = public_key
         .try_into()
         .map_err(|_| SignatureError::InvalidPublicKeyLength)?;
     let key = BytesN::<32>::from_array(env, &pk_arr);
 
-    let mut registered_verifiers: Map<BytesN<32>, bool> = env
+    let mut registered_verifiers: Map<BytesN<32>, BytesN<32>> = env
         .storage()
         .instance()
         .get(&REGISTERED_VERIFIERS_KEY)
         .unwrap_or_else(|| Map::new(env));
 
-    registered_verifiers.set(key, true);
+    registered_verifiers.set(key, env.ledger().network_id());
     env.storage()
         .instance()
         .set(&REGISTERED_VERIFIERS_KEY, &registered_verifiers);
@@ -987,24 +998,32 @@ pub fn register_verifier(env: &Env, public_key: &[u8]) -> Result<(), SignatureEr
     Ok(())
 }
 
-/// Requires the supplied verifier public key to be registered before an external
-/// attestation can be consumed.
+/// Requires the supplied verifier public key to be registered, and registered
+/// under the network this contract instance is currently executing on, before
+/// an external attestation can be consumed.
+///
+/// # Errors
+/// * [`SignatureError::UnregisteredVerifier`] if the key was never registered.
+/// * [`SignatureError::VerifierNetworkMismatch`] if the key was registered
+///   under a different network than the current one (see [`register_verifier`]).
 pub fn require_registered_verifier(env: &Env, public_key: &[u8]) -> Result<(), SignatureError> {
     let pk_arr: [u8; 32] = public_key
         .try_into()
         .map_err(|_| SignatureError::InvalidPublicKeyLength)?;
     let key = BytesN::<32>::from_array(env, &pk_arr);
 
-    let registered_verifiers: Map<BytesN<32>, bool> = env
+    let registered_verifiers: Map<BytesN<32>, BytesN<32>> = env
         .storage()
         .instance()
         .get(&REGISTERED_VERIFIERS_KEY)
         .unwrap_or_else(|| Map::new(env));
 
-    if registered_verifiers.get(key).unwrap_or(false) {
-        Ok(())
-    } else {
-        Err(SignatureError::UnregisteredVerifier)
+    match registered_verifiers.get(key) {
+        Some(registered_network_id) if registered_network_id == env.ledger().network_id() => {
+            Ok(())
+        }
+        Some(_) => Err(SignatureError::VerifierNetworkMismatch),
+        None => Err(SignatureError::UnregisteredVerifier),
     }
 }
 

--- a/remitwise-common/src/tests.rs
+++ b/remitwise-common/src/tests.rs
@@ -19,7 +19,8 @@ use super::*;
 use crate::distribute_pro_rata;
 use ed25519_dalek::Signer;
 use proptest::prelude::*;
-use soroban_sdk::{Bytes, Env, IntoVal, String, Symbol, Vec};
+use soroban_sdk::testutils::{Ledger, LedgerInfo};
+use soroban_sdk::{contract, contractimpl, Bytes, Env, IntoVal, String, Symbol, Vec};
 
 fn set_ledger(env: &Env, sequence_number: u32) {
     let proto = env.ledger().protocol_version();
@@ -28,6 +29,24 @@ fn set_ledger(env: &Env, sequence_number: u32) {
         sequence_number,
         timestamp: 1_700_000_000,
         network_id: [0; 32],
+        base_reserve: 10,
+        min_temp_entry_ttl: 1,
+        min_persistent_entry_ttl: 1,
+        max_entry_ttl: 3_000_000,
+    });
+}
+
+/// Sets only `network_id` on the ledger, preserving the rest of its current
+/// state. Used to simulate the same contract instance storage being read
+/// under a different Stellar network.
+fn set_network(env: &Env, network_id: [u8; 32]) {
+    let proto = env.ledger().protocol_version();
+    let sequence_number = env.ledger().sequence();
+    env.ledger().set(LedgerInfo {
+        protocol_version: proto,
+        sequence_number,
+        timestamp: 1_700_000_000,
+        network_id,
         base_reserve: 10,
         min_temp_entry_ttl: 1,
         min_persistent_entry_ttl: 1,
@@ -669,9 +688,21 @@ fn test_timestamp_seconds_until_u64_max_boundary() {
 
 // ─── verify_signature tests ──────────────────────────────────────────────────
 
+// `register_verifier`/`require_registered_verifier` read and write instance
+// storage, which the Soroban host only allows inside a contract's execution
+// context. Tests exercising them run their storage-touching calls inside
+// `env.as_contract(&contract_id, || { .. })` against this no-op contract,
+// mirroring the pattern already used in `orchestrator/src/test.rs`.
+#[contract]
+struct VerifierTestContract;
+
+#[contractimpl]
+impl VerifierTestContract {}
+
 #[test]
 fn test_verify_signature_valid() {
     let env = Env::default();
+    let contract_id = env.register_contract(None, VerifierTestContract);
     let domain = b"test-domain";
     let message = b"hello world";
 
@@ -684,15 +715,18 @@ fn test_verify_signature_valid() {
     prefixed.extend_from_slice(message);
     let signature = sk.sign(&prefixed).to_bytes();
 
-    register_verifier(&env, &pk).unwrap();
+    env.as_contract(&contract_id, || {
+        register_verifier(&env, &pk).unwrap();
 
-    let result = verify_signature(&env, domain, message, &signature, &pk);
-    assert_eq!(result, Ok(()));
+        let result = verify_signature(&env, domain, message, &signature, &pk);
+        assert_eq!(result, Ok(()));
+    });
 }
 
 #[test]
 fn test_verify_signature_rejects_unregistered_verifier() {
     let env = Env::default();
+    let contract_id = env.register_contract(None, VerifierTestContract);
     let domain = b"test-domain";
     let message = b"hello world";
 
@@ -703,14 +737,17 @@ fn test_verify_signature_rejects_unregistered_verifier() {
     prefixed.extend_from_slice(message);
     let signature = sk.sign(&prefixed).to_bytes();
 
-    let result = verify_signature(&env, domain, message, &signature, &pk);
-    assert_eq!(result, Err(SignatureError::UnregisteredVerifier));
+    env.as_contract(&contract_id, || {
+        let result = verify_signature(&env, domain, message, &signature, &pk);
+        assert_eq!(result, Err(SignatureError::UnregisteredVerifier));
+    });
 }
 
 #[test]
 #[should_panic]
 fn test_verify_signature_invalid_signature() {
     let env = Env::default();
+    let contract_id = env.register_contract(None, VerifierTestContract);
     let domain = b"test-domain";
     let message = b"hello world";
 
@@ -718,14 +755,17 @@ fn test_verify_signature_invalid_signature() {
     let pk = sk.verifying_key().to_bytes();
     let invalid_signature = [0u8; 64];
 
-    register_verifier(&env, &pk).unwrap();
+    env.as_contract(&contract_id, || {
+        register_verifier(&env, &pk).unwrap();
 
-    let _ = verify_signature(&env, domain, message, &invalid_signature, &pk);
+        let _ = verify_signature(&env, domain, message, &invalid_signature, &pk);
+    });
 }
 
 #[test]
 fn test_verify_signature_invalid_signature_length() {
     let env = Env::default();
+    let contract_id = env.register_contract(None, VerifierTestContract);
     let domain = b"test-domain";
     let message = b"hello world";
 
@@ -733,10 +773,12 @@ fn test_verify_signature_invalid_signature_length() {
     let pk = sk.verifying_key().to_bytes();
     let short_signature = [0u8; 32];
 
-    register_verifier(&env, &pk).unwrap();
+    env.as_contract(&contract_id, || {
+        register_verifier(&env, &pk).unwrap();
 
-    let result = verify_signature(&env, domain, message, &short_signature, &pk);
-    assert_eq!(result, Err(SignatureError::InvalidSignatureLength));
+        let result = verify_signature(&env, domain, message, &short_signature, &pk);
+        assert_eq!(result, Err(SignatureError::InvalidSignatureLength));
+    });
 }
 
 #[test]
@@ -748,6 +790,8 @@ fn test_verify_signature_invalid_public_key_length() {
     let short_pk = [0u8; 16];
     let signature = [0u8; 64];
 
+    // Invalid key length is rejected before any storage access, so this
+    // does not need a contract context.
     let result = verify_signature(&env, domain, message, &signature, &short_pk);
     assert_eq!(result, Err(SignatureError::InvalidPublicKeyLength));
 }
@@ -756,6 +800,7 @@ fn test_verify_signature_invalid_public_key_length() {
 #[should_panic]
 fn test_verify_signature_wrong_domain() {
     let env = Env::default();
+    let contract_id = env.register_contract(None, VerifierTestContract);
     let domain1 = b"domain1";
     let domain2 = b"domain2";
     let message = b"hello world";
@@ -768,14 +813,63 @@ fn test_verify_signature_wrong_domain() {
     prefixed.extend_from_slice(message);
     let signature = sk.sign(&prefixed).to_bytes();
 
-    register_verifier(&env, &pk).unwrap();
+    env.as_contract(&contract_id, || {
+        register_verifier(&env, &pk).unwrap();
 
-    let _ = verify_signature(&env, domain2, message, &signature, &pk);
+        let _ = verify_signature(&env, domain2, message, &signature, &pk);
+    });
+}
+
+/// Regression test for the "test signer on prod" gap: a verifier public key
+/// registered while the contract instance observed one network (e.g. Testnet)
+/// must NOT be accepted once the same storage is read under a different
+/// network (e.g. Public/Mainnet), even though the key itself is unchanged.
+///
+/// This simulates a verifier registry entry that ended up on the wrong
+/// deployment (e.g. via a copy-pasted `REMITWISE_ACTIVE_VERIFIERS` config, or
+/// a snapshot import) by registering under one `network_id` and then mutating
+/// the ledger's `network_id` before verifying, all against the same
+/// underlying instance storage.
+///
+/// Before the fix: `require_registered_verifier` only tracked `bool`
+/// membership, so this passed regardless of network. This test fails against
+/// that behavior and passes once registration is bound to `network_id`.
+#[test]
+fn test_verify_signature_rejects_verifier_from_different_network() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, VerifierTestContract);
+    let domain = b"test-domain";
+    let message = b"hello world";
+
+    let sk = ed25519_dalek::SigningKey::generate(&mut rand::rngs::OsRng);
+    let pk = sk.verifying_key().to_bytes();
+
+    let mut prefixed = std::vec::Vec::new();
+    prefixed.extend_from_slice(domain);
+    prefixed.extend_from_slice(message);
+    let signature = sk.sign(&prefixed).to_bytes();
+
+    env.as_contract(&contract_id, || {
+        // Register the verifier while the contract instance observes "testnet".
+        set_network(&env, [7u8; 32]);
+        register_verifier(&env, &pk).unwrap();
+
+        // Same storage, but the instance is now running on a different
+        // network ("mainnet") — the registration above must no longer be
+        // honored.
+        set_network(&env, [9u8; 32]);
+        let result = require_registered_verifier(&env, &pk);
+        assert_eq!(result, Err(SignatureError::VerifierNetworkMismatch));
+
+        let result = verify_signature(&env, domain, message, &signature, &pk);
+        assert_eq!(result, Err(SignatureError::VerifierNetworkMismatch));
+    });
 }
 
 #[test]
 fn test_verify_slash_signature_valid() {
     let env = Env::default();
+    let contract_id = env.register_contract(None, VerifierTestContract);
     let message = b"slash payload";
 
     let sk = ed25519_dalek::SigningKey::generate(&mut rand::rngs::OsRng);
@@ -786,11 +880,13 @@ fn test_verify_slash_signature_valid() {
     prefixed.extend_from_slice(message);
     let signature = sk.sign(&prefixed).to_bytes();
 
-    register_verifier(&env, &pk).unwrap();
+    env.as_contract(&contract_id, || {
+        register_verifier(&env, &pk).unwrap();
 
-    // Verify the slash signature
-    let result = verify_slash_signature(&env, message, Some(&signature), &pk);
-    assert_eq!(result, Ok(()));
+        // Verify the slash signature
+        let result = verify_slash_signature(&env, message, Some(&signature), &pk);
+        assert_eq!(result, Ok(()));
+    });
 }
 
 #[test]
@@ -799,7 +895,8 @@ fn test_verify_slash_signature_optional_none() {
     let message = b"slash payload";
     let pk = [0u8; 32];
 
-    // Verify when signature is None (should succeed as it's optional)
+    // Optional-signature short-circuit never touches storage, so this does
+    // not need a contract context.
     let result = verify_slash_signature(&env, message, None, &pk);
     assert_eq!(result, Ok(()));
 }
@@ -808,17 +905,20 @@ fn test_verify_slash_signature_optional_none() {
 #[should_panic]
 fn test_verify_slash_signature_invalid() {
     let env = Env::default();
+    let contract_id = env.register_contract(None, VerifierTestContract);
     let message = b"slash payload";
 
     let sk = ed25519_dalek::SigningKey::generate(&mut rand::rngs::OsRng);
     let pk = sk.verifying_key().to_bytes();
     let invalid_signature = [0u8; 64]; // Invalid
 
-    register_verifier(&env, &pk).unwrap();
+    env.as_contract(&contract_id, || {
+        register_verifier(&env, &pk).unwrap();
 
-    // Verify the invalid slash signature
-    let result = verify_slash_signature(&env, message, Some(&invalid_signature), &pk);
-    assert_eq!(result, Err(SlashError::InvalidSignature));
+        // Verify the invalid slash signature
+        let result = verify_slash_signature(&env, message, Some(&invalid_signature), &pk);
+        assert_eq!(result, Err(SlashError::InvalidSignature));
+    });
 }
 
 // ─── distribute_pro_rata tests (#1085) ───────────────────────────────────────


### PR DESCRIPTION
closed #1149 

Bind register_verifier/require_registered_verifier to env.ledger().network_id() so a signer key registered while the contract instance observed one Stellar network (e.g. Testnet) is rejected with the typed
SignatureError::VerifierNetworkMismatch if presented under a different network (e.g. Public/Mainnet), instead of silently verifying. Mirrors the network_id/contract_addr domain-binding pattern already used by remittance_split::SplitAuthPayload.

Adds a regression test that fails against the prior bool-only registry and passes once registration is bound to network_id, plus env.as_contract() wrapping for the existing verify_signature/verify_slash_signature test suite (required for these storage-touching calls to run under soroban-sdk 21.7.7's test harness; previously several of these tests were passing vacuously via #[should_panic] without exercising the intended assertion).