### PR TITLE
Add a "no dead crates" workspace check

### DIFF
--- a/docs/ci-pipeline.md
+++ b/docs/ci-pipeline.md
@@ -57,6 +57,22 @@ done
 - A contract that fails to build is reported as size `0`. The workflow does not fail the PR on build errors in this job; use the main `ci.yml` build gate for that.
 - The comment is updated in-place on each push to the PR (identified by a hidden HTML marker), so the thread stays clean.
 
+## Workspace Invariants (`scripts/check_workspace_invariants.py`)
+
+Runs as the `workspace-invariants` job in `.github/workflows/ci.yml` (non-blocking: `continue-on-error: true`). It performs grep-based static checks across every workspace member:
+
+1. Every crate directory has a `README.md`.
+2. Every public entrypoint (`pub fn` inside `#[contractimpl]`) has a `///` doc comment.
+3. Every `#[contracterror]` variant has a `///` doc comment.
+4. No bare `todo!()` / `unimplemented!()` in production (non-test) source.
+5. **No dead crates**: every workspace member must be referenced as a `path` dependency by another crate (a `[dev-dependencies]` reference — i.e. used by another crate's tests — counts too), or have tests of its own (`tests/*.rs`, or a `#[test]`/`#[cfg(test)]` anywhere in the crate).
+
+Run it locally with:
+
+```bash
+python3 scripts/check_workspace_invariants.py
+```
+
 ## Soroban SDK Updates
 
 This pipeline acts as a regression gate for SDK upgrades. When bumping the SDK version (e.g., to `21.7.7` and beyond), the CI must pass before merging.

--- a/scripts/check_workspace_invariants.py
+++ b/scripts/check_workspace_invariants.py
@@ -2,12 +2,16 @@
 """Check workspace-level invariants via grep-based analysis.
 
 Issue #1095: Add a check-workspace-invariants CI job
+Issue #1102: Add a "no dead crates" workspace check
 
 Checks performed:
   1. Every workspace crate directory has a README.md
   2. Every public entrypoint (pub fn inside #[contractimpl]) has a doc comment (///)
   3. Every #[contracterror] variant has a doc comment (///)
   4. No bare `todo!()` or `unimplemented!()` in production (non-test) source files
+  5. Every workspace crate is referenced as a path dependency by another crate
+     (including as a dev-dependency, i.e. used by another crate's tests), or has
+     tests of its own
 
 Usage:
     python scripts/check_workspace_invariants.py
@@ -207,6 +211,70 @@ def check_no_todos(workspace_root: Path, members: List[str]) -> List[str]:
 
 
 # ---------------------------------------------------------------------------
+# Check 5: no dead crates — every crate is referenced by another crate
+# (as a [dependencies] or [dev-dependencies] path dependency) or has its own
+# tests.
+# ---------------------------------------------------------------------------
+
+def find_crate_path_refs(cargo_toml_text: str, members: List[str]) -> set:
+    """Return the subset of `members` referenced via `path = "..."` in a
+    Cargo.toml's dependency tables (any table — [dependencies],
+    [dev-dependencies], [patch.*], etc. — a reference anywhere is enough)."""
+    members_set = set(members)
+    refs = set()
+    for m in re.finditer(r'path\s*=\s*"([^"]+)"', cargo_toml_text):
+        raw = m.group(1)
+        if raw.endswith(".rs"):
+            # e.g. `path = "src/main.rs"` on a [[bin]] target, not a crate dep.
+            continue
+        name = raw.rstrip("/").split("/")[-1]
+        if name in members_set:
+            refs.add(name)
+    return refs
+
+
+def crate_has_own_tests(workspace_root: Path, member: str) -> bool:
+    crate_dir = workspace_root / member
+    tests_dir = crate_dir / "tests"
+    if tests_dir.is_dir() and any(tests_dir.rglob("*.rs")):
+        return True
+    for rs_file in crate_dir.rglob("*.rs"):
+        if "target" in rs_file.parts:
+            continue
+        content = rs_file.read_text(encoding="utf-8", errors="ignore")
+        if re.search(r"#\[test\]|#\[cfg\(test\)\]", content):
+            return True
+    return False
+
+
+def check_no_dead_crates(workspace_root: Path, members: List[str]) -> List[str]:
+    errors: List[str] = []
+
+    referenced: set = set()
+    cargo_files = [workspace_root / "Cargo.toml"] + [
+        workspace_root / member / "Cargo.toml" for member in members
+    ]
+    for cargo_file in cargo_files:
+        if not cargo_file.exists():
+            continue
+        referenced |= find_crate_path_refs(
+            cargo_file.read_text(encoding="utf-8"), members
+        )
+
+    for member in members:
+        if member in referenced:
+            continue
+        if crate_has_own_tests(workspace_root, member):
+            continue
+        errors.append(
+            f"Crate '{member}' is not referenced as a path dependency by any "
+            f"other workspace crate and has no tests of its own "
+            f"(no tests/*.rs, no #[test]/#[cfg(test)])"
+        )
+    return errors
+
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -255,6 +323,15 @@ def main() -> int:
             print(f"  FAIL: {e}")
     else:
         print("  PASS: no bare todo!()/unimplemented!() found")
+
+    print("\n=== Check 5: no dead crates ===")
+    errors = check_no_dead_crates(workspace_root, members)
+    all_errors.extend(errors)
+    if errors:
+        for e in errors:
+            print(f"  FAIL: {e}")
+    else:
+        print(f"  PASS: all {len(members)} crates are referenced or tested")
 
     print(f"\n{'='*60}")
     if all_errors:

--- a/tests/test_check_workspace_invariants.py
+++ b/tests/test_check_workspace_invariants.py
@@ -1,0 +1,71 @@
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.check_workspace_invariants import (  # noqa: E402
+    check_no_dead_crates,
+    read_workspace_members,
+)
+
+
+def _write_cargo_toml(crate_dir: Path, deps: dict | None = None, dev_deps: dict | None = None) -> None:
+    crate_dir.mkdir(parents=True, exist_ok=True)
+    lines = ["[package]", f'name = "{crate_dir.name}"', 'version = "0.1.0"', ""]
+    if deps:
+        lines.append("[dependencies]")
+        for name, rel_path in deps.items():
+            lines.append(f'{name} = {{ path = "{rel_path}" }}')
+        lines.append("")
+    if dev_deps:
+        lines.append("[dev-dependencies]")
+        for name, rel_path in dev_deps.items():
+            lines.append(f'{name} = {{ path = "{rel_path}" }}')
+        lines.append("")
+    (crate_dir / "Cargo.toml").write_text("\n".join(lines), encoding="utf-8")
+
+
+def test_flags_crate_with_no_references_and_no_tests(tmp_path):
+    members = ["used", "orphan", "tested_only"]
+    for name in members:
+        _write_cargo_toml(tmp_path / name)
+
+    # Root package depends on "used", mirroring how this repo's root
+    # Cargo.toml depends on most of the contract crates.
+    _write_cargo_toml(tmp_path, deps={"used": "./used"})
+
+    # "tested_only" is not referenced anywhere, but has its own tests.
+    tests_dir = tmp_path / "tested_only" / "tests"
+    tests_dir.mkdir(parents=True)
+    (tests_dir / "smoke.rs").write_text("#[test]\nfn it_works() {}\n", encoding="utf-8")
+
+    errors = check_no_dead_crates(tmp_path, members)
+
+    assert len(errors) == 1
+    assert "orphan" in errors[0]
+
+
+def test_dev_dependency_reference_counts_as_used(tmp_path):
+    members = ["lib_crate", "test_helpers"]
+    _write_cargo_toml(tmp_path / "lib_crate", dev_deps={"test_helpers": "../test_helpers"})
+    _write_cargo_toml(tmp_path / "test_helpers")
+    # Root depends on "lib_crate" directly; "test_helpers" is only ever
+    # reachable via lib_crate's [dev-dependencies], which must still count.
+    _write_cargo_toml(tmp_path, deps={"lib_crate": "./lib_crate"})
+
+    errors = check_no_dead_crates(tmp_path, members)
+
+    assert errors == []
+
+
+def test_no_false_positives_against_this_repo():
+    """Regression check against the real workspace: today, exactly one crate
+    ('cli') is neither depended on by another crate nor has its own tests.
+    If this starts failing because a *different* crate regresses, that's a
+    real bug this check is meant to catch."""
+    members = read_workspace_members(REPO_ROOT)
+    errors = check_no_dead_crates(REPO_ROOT, members)
+
+    assert len(errors) == 1
+    assert "'cli'" in errors[0]


### PR DESCRIPTION
## Summary
Adds a 5th check to `scripts/check_workspace_invariants.py` (the existing `workspace-invariants` CI job): every workspace member must either be referenced as a `path` dependency by another crate — a `[dev-dependencies]` reference counts too, i.e. being used by another crate's tests is sufficient — or have tests of its own.

## How it works
- Scans the root `Cargo.toml` and every member's `Cargo.toml` for `path = "..."` dependency references (any table, so `[dependencies]` and `[dev-dependencies]` both count).
- A crate is "alive" if it's referenced that way, or if it has its own `tests/*.rs` files or a `#[test]`/`#[cfg(test)]` anywhere in its source.
- Anything else is reported as a dead crate.

Verified against this repo's actual workspace (14 members): `cli` is currently the only crate that is neither depended on by another crate nor has its own tests, so it's the one flagged today. Everything else (including crates like `emergency_killswitch`, `scenarios`, and `integration_tests` that aren't path-dependencies of anything) passes because each has its own `tests/*.rs`.

## Test plan
- `tests/test_check_workspace_invariants.py` (new): two synthetic-fixture tests (an orphaned crate with no refs/tests is flagged; a dev-dependency-only reference correctly counts as "used") plus a regression test asserting the real workspace flags exactly `cli` today.
- No Rust source was touched, so `cargo build --target wasm32-unknown-unknown --release` / `cargo clippy` are unaffected by this change.
- Documented the new check in `docs/ci-pipeline.md`.

## Note
I didn't comment to claim this issue before opening the PR — happy to close/rework if a maintainer had already assigned it or wants a different approach.

Closes #1102