### PR TITLE
test+docs: migration-completed helper, cross-contract epoch guard, observability model

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,8 @@ To run an example, use `cargo run --example <example_name>`:
 - [Security Review Summary](SECURITY_REVIEW_SUMMARY.md)
 - [Event Versioning ADR](docs/events-versioning.md) - Why contract events are versioned via a `_v2` suffix
 - [Event Versioning Discipline](docs/EVENT_VERSIONING.md) - Backward-compatibility rules, migration steps, and indexer guidelines for event schema changes
+- [Cross-Contract Epochs](docs/CROSS_CONTRACT_EPOCHS.md) - Actor-epoch semantics, the cross-contract coordination protocol, and the `EpochMismatch` guard
+- [Observability Model](docs/OBSERVABILITY_MODEL.md) - Per-contract event catalogue: what each contract emits and what off-chain consumers rely on
 
 ## Contracts
 

--- a/data_migration/src/lib.rs
+++ b/data_migration/src/lib.rs
@@ -4313,4 +4313,240 @@ mod tests {
         assert_eq!(first.payload, second.payload);
         assert_eq!(first.header.checksum, second.header.checksum);
     }
+
+    // =========================================================================
+    // Issue #1282 — Migration-completed helper: Completed / InProgress / None
+    //
+    // The `MigrationTracker::is_imported` helper is the canonical
+    // "migration-completed" predicate. It maps to three observable states:
+    //
+    // * **None** (tracker is fresh — no snapshots have ever been presented to
+    //   it): `is_imported` returns `false`; `mark_imported` transitions to
+    //   Completed on first call.
+    //
+    // * **InProgress** (a snapshot has been built and is about to be imported,
+    //   but `mark_imported` has not yet been called for it): `is_imported`
+    //   returns `false` even though the tracker has recorded *other* payloads.
+    //
+    // * **Completed** (the snapshot has been successfully fed through
+    //   `mark_imported` without error): `is_imported` returns `true`.
+    //
+    // Each test below is named assertively after the invariant it locks in, and
+    // is fully deterministic (no randomness, no external I/O).
+    // =========================================================================
+
+    /// A fresh `MigrationTracker` (None state) reports every snapshot as
+    /// not-imported because nothing has been recorded yet.
+    #[test]
+    fn migration_completed_none_state_reports_not_imported() {
+        let snapshot = ExportSnapshot::new(sample_remittance_payload(), ExportFormat::Json);
+        let tracker = MigrationTracker::new();
+
+        // A brand-new tracker has no history — any snapshot must read as
+        // not-yet-imported regardless of its payload type or checksum.
+        assert!(
+            !tracker.is_imported(&snapshot),
+            "a fresh tracker must return false for any snapshot"
+        );
+    }
+
+    /// A fresh tracker serialised via `Default` is semantically equivalent to
+    /// one produced by `new()`.
+    #[test]
+    fn migration_completed_default_tracker_equals_new() {
+        let snapshot = ExportSnapshot::new(sample_savings_payload(), ExportFormat::Json);
+        let tracker_new = MigrationTracker::new();
+        let tracker_default = MigrationTracker::default();
+
+        assert_eq!(
+            tracker_new.is_imported(&snapshot),
+            tracker_default.is_imported(&snapshot),
+            "MigrationTracker::new() and Default must agree on every query"
+        );
+    }
+
+    /// Once `mark_imported` succeeds the tracker transitions to the Completed
+    /// state and `is_imported` returns `true` for that exact snapshot.
+    #[test]
+    fn migration_completed_completed_state_returns_true_after_mark() {
+        let snapshot = ExportSnapshot::new(sample_remittance_payload(), ExportFormat::Json);
+        let mut tracker = MigrationTracker::new();
+
+        // Pre-condition: not yet completed.
+        assert!(!tracker.is_imported(&snapshot));
+
+        // Transition to Completed.
+        tracker.mark_imported(&snapshot, 1_000).unwrap();
+
+        // Post-condition: completed.
+        assert!(
+            tracker.is_imported(&snapshot),
+            "is_imported must return true after a successful mark_imported"
+        );
+    }
+
+    /// After a full tracked round-trip (`import_from_json`) the snapshot is in
+    /// Completed state — `is_imported` returns `true` for both the original
+    /// handle and the deserialized copy.
+    #[test]
+    fn migration_completed_completed_state_after_full_tracked_import() {
+        let snapshot = ExportSnapshot::new(sample_remittance_payload(), ExportFormat::Json);
+        let bytes = export_to_json(&snapshot).unwrap();
+        let mut tracker = MigrationTracker::new();
+
+        let loaded = import_from_json(&bytes, &mut tracker, 42_000).unwrap();
+
+        assert!(
+            tracker.is_imported(&snapshot),
+            "original snapshot handle must read as completed"
+        );
+        assert!(
+            tracker.is_imported(&loaded),
+            "deserialized snapshot must read as completed (identity is checksum+version)"
+        );
+    }
+
+    /// The InProgress state: a snapshot exists in memory and is about to be
+    /// imported, but the tracker has not yet recorded it.  `is_imported` must
+    /// return `false` even when the tracker already holds entries for *other*
+    /// payloads — completion is per-identity, not global.
+    #[test]
+    fn migration_completed_in_progress_state_returns_false_before_mark() {
+        let done_snapshot = ExportSnapshot::new(sample_remittance_payload(), ExportFormat::Json);
+        let pending_snapshot = ExportSnapshot::new(sample_savings_payload(), ExportFormat::Json);
+        let mut tracker = MigrationTracker::new();
+
+        // Complete the first migration.
+        tracker.mark_imported(&done_snapshot, 1_000).unwrap();
+        assert!(tracker.is_imported(&done_snapshot), "first must be completed");
+
+        // The second snapshot is in-progress (built, not yet marked).
+        assert!(
+            !tracker.is_imported(&pending_snapshot),
+            "second snapshot must still be in-progress (not completed) \
+             even though the tracker has entries for another payload"
+        );
+    }
+
+    /// The InProgress → Completed transition is atomic from the caller's
+    /// perspective: `mark_imported` either succeeds (→ Completed) or returns
+    /// `DuplicateImport` (snapshot was already Completed).
+    #[test]
+    fn migration_completed_in_progress_transitions_to_completed_on_mark() {
+        let snapshot = ExportSnapshot::new(sample_generic_payload(), ExportFormat::Json);
+        let mut tracker = MigrationTracker::new();
+
+        // InProgress: present but not yet marked.
+        assert!(!tracker.is_imported(&snapshot));
+
+        // Transition: InProgress → Completed.
+        let mark_result = tracker.mark_imported(&snapshot, 2_000);
+        assert!(
+            mark_result.is_ok(),
+            "first mark_imported must succeed (InProgress → Completed)"
+        );
+        assert!(tracker.is_imported(&snapshot));
+
+        // A second mark must be rejected — already Completed.
+        let dup_result = tracker.mark_imported(&snapshot, 3_000);
+        assert_eq!(
+            dup_result.unwrap_err(),
+            MigrationError::DuplicateImport,
+            "second mark_imported must return DuplicateImport (already Completed)"
+        );
+    }
+
+    /// Completed → InProgress rollback via `unmark_imported_by_identity` is the
+    /// mechanism that lets an operator retry a failed migration.  After unmarking,
+    /// `is_imported` must return `false` and `mark_imported` must succeed again.
+    #[test]
+    fn migration_completed_unmark_reverts_completed_to_in_progress() {
+        let snapshot = ExportSnapshot::new(sample_remittance_payload(), ExportFormat::Json);
+        let mut tracker = MigrationTracker::new();
+
+        // Reach Completed state.
+        tracker.mark_imported(&snapshot, 5_000).unwrap();
+        assert!(tracker.is_imported(&snapshot));
+
+        // Rollback to InProgress via unmark.
+        tracker.unmark_imported_by_identity(
+            &snapshot.header.checksum,
+            snapshot.header.version,
+        );
+        assert!(
+            !tracker.is_imported(&snapshot),
+            "unmark must revert to InProgress (is_imported returns false)"
+        );
+
+        // Re-marking must succeed (confirming the rollback is clean).
+        tracker.mark_imported(&snapshot, 6_000).unwrap();
+        assert!(tracker.is_imported(&snapshot));
+    }
+
+    /// `unmark_imported_by_identity` on a snapshot that was never marked is a
+    /// no-op: the tracker stays in None/InProgress state without panicking.
+    #[test]
+    fn migration_completed_unmark_nonexistent_identity_is_no_op() {
+        let snapshot = ExportSnapshot::new(sample_savings_payload(), ExportFormat::Json);
+        let mut tracker = MigrationTracker::new();
+
+        // Tracker is in None state; snapshot was never marked.
+        assert!(!tracker.is_imported(&snapshot));
+
+        // Unmark a non-existent identity — must not panic.
+        tracker.unmark_imported_by_identity(
+            &snapshot.header.checksum,
+            snapshot.header.version,
+        );
+
+        // Still in None/InProgress state.
+        assert!(!tracker.is_imported(&snapshot));
+    }
+
+    /// Multiple independent snapshots each have their own Completed state;
+    /// completing one does not affect the others.
+    #[test]
+    fn migration_completed_each_snapshot_has_independent_completion_state() {
+        let s1 = ExportSnapshot::new(sample_remittance_payload(), ExportFormat::Json);
+        let s2 = ExportSnapshot::new(sample_savings_payload(), ExportFormat::Json);
+        let s3 = ExportSnapshot::new(sample_generic_payload(), ExportFormat::Json);
+        let mut tracker = MigrationTracker::new();
+
+        // None state for all three.
+        assert!(!tracker.is_imported(&s1));
+        assert!(!tracker.is_imported(&s2));
+        assert!(!tracker.is_imported(&s3));
+
+        // Complete s1 only.
+        tracker.mark_imported(&s1, 1_000).unwrap();
+
+        assert!(tracker.is_imported(&s1), "s1 must be Completed");
+        assert!(!tracker.is_imported(&s2), "s2 must remain InProgress/None");
+        assert!(!tracker.is_imported(&s3), "s3 must remain InProgress/None");
+
+        // Complete s3; s2 stays pending.
+        tracker.mark_imported(&s3, 2_000).unwrap();
+        assert!(tracker.is_imported(&s1));
+        assert!(!tracker.is_imported(&s2));
+        assert!(tracker.is_imported(&s3));
+    }
+
+    /// Binary-format imports also reach Completed state and are recognised by
+    /// `is_imported`, confirming the helper is format-agnostic (identity is
+    /// derived from checksum + version, not from the encoded bytes).
+    #[test]
+    fn migration_completed_binary_import_sets_completed_state() {
+        let snapshot = ExportSnapshot::new(sample_remittance_payload(), ExportFormat::Binary);
+        let bytes = export_to_binary(&snapshot).unwrap();
+        let mut tracker = MigrationTracker::new();
+
+        assert!(!tracker.is_imported(&snapshot));
+
+        import_from_binary(&bytes, &mut tracker, 7_000).unwrap();
+
+        assert!(
+            tracker.is_imported(&snapshot),
+            "binary-format import must also reach Completed state"
+        );
+    }
 }

--- a/docs/CROSS_CONTRACT_EPOCHS.md
+++ b/docs/CROSS_CONTRACT_EPOCHS.md
@@ -1,0 +1,194 @@
+# Cross-Contract Epochs
+
+**Audience:** Contributors and downstream integrators building services that call
+`execute_remittance_flow_signed` or coordinate with the orchestrator contract.
+
+---
+
+## What an epoch is
+
+The orchestrator contract keeps a single `u64` counter in instance storage
+under the key `ACT_EPOCH` (symbol `"ACT_EPOCH"`).  That counter is called the
+**actor epoch**.  Every signed request to `execute_remittance_flow_signed` must
+carry the current epoch value; if it does not match exactly, the call is
+rejected with `OrchestratorError::EpochMismatch`.
+
+```
+┌─────────────────────────────────┐
+│  Orchestrator contract          │
+│  instance storage               │
+│                                 │
+│  ACT_EPOCH  →  u64 (e.g. 3)   │
+└─────────────────────────────────┘
+```
+
+The epoch starts at 0 after `init` and is monotonically incremented by the
+owner via `bump_actor_epoch`.  There is no automatic rollover and the value
+never resets except through a re-deploy.
+
+---
+
+## Why epochs exist
+
+The primary threat is **stale token replay**: an attacker who obtains a signed
+request (e.g. from a compromised relayer or a leaked API key) should not be
+able to replay it after the signing service is rotated.
+
+Bumping the epoch atomically invalidates every token signed under the previous
+value without requiring individual per-actor revocation lists.
+
+---
+
+## Coordination protocol
+
+### Producing a signed request (caller side)
+
+```
+1. Read the current epoch:
+       epoch = orchestrator.get_actor_epoch_public()
+
+2. Build the request hash (binds operation, nonce, amount, deadline, routing):
+       hash = compute_request_hash("flow", nonce, amount, deadline,
+                                   goal_id, bill_id, policy_id)
+
+3. Submit:
+       orchestrator.execute_remittance_flow_signed(
+           executor, amount, nonce, deadline, hash,
+           actor_epoch = epoch   ← must match on-chain value exactly
+       )
+```
+
+`get_actor_epoch_public` is a read-only view — it costs no auth and has no
+side effects.  Call it immediately before building each signed request so the
+embedded epoch is never stale.
+
+### What the guard checks (contract side)
+
+```rust
+// orchestrator/src/lib.rs — verify_matching_epoch (private helper)
+fn verify_matching_epoch(env: &Env, actor_epoch: u64) -> Result<(), OrchestratorError> {
+    let current_epoch = Self::get_actor_epoch(env);    // reads ACT_EPOCH
+    if actor_epoch != current_epoch {
+        return Err(OrchestratorError::EpochMismatch);  // strict equality
+    }
+    Ok(())
+}
+```
+
+The check is **strict equality**: there is no tolerance window, no off-by-one
+leniency, no grace period for "immediately prior" tokens.  The same
+`EpochMismatch` error is returned whether the supplied value is one behind,
+one ahead, or `u64::MAX` away from the current epoch.
+
+---
+
+## Epoch tiers
+
+| Tier | Definition | Guard outcome |
+|---|---|---|
+| **Same** | `actor_epoch == current_epoch` | ✅ Accepted |
+| **Off-by-one (prior)** | `actor_epoch == current_epoch - 1` | ❌ `EpochMismatch` |
+| **Off-by-one (future)** | `actor_epoch == current_epoch + 1` | ❌ `EpochMismatch` |
+| **Ancient** | `actor_epoch << current_epoch` (e.g. 0 after 10 bumps) | ❌ `EpochMismatch` |
+
+---
+
+## Bumping the epoch
+
+Only the contract owner may call `bump_actor_epoch`.  The call increments the
+counter by exactly 1 and emits:
+
+```
+topic: ("orch", "epoch_bump")
+data:  (old_epoch: u64, new_epoch: u64)
+```
+
+**Effect on callers:** every cached epoch value is immediately stale.  All
+in-flight requests that have not yet been submitted will fail with
+`EpochMismatch`.  Callers must call `get_actor_epoch_public()` again before
+retrying.
+
+### When to bump
+
+- After rotating a signing service or API key
+- After detecting a suspicious pattern of requests from an old token
+- As part of a scheduled key rotation cadence
+
+There is no cost to bump frequently; the only consequence is that callers
+holding pre-computed tokens must refresh them.
+
+---
+
+## Worked example
+
+```text
+Time  On-chain epoch  Event
+────  ─────────────  ─────────────────────────────────────────
+ 0    0              init() — epoch initialised to 0
+ 1    0              Caller queries get_actor_epoch_public() → 0
+ 2    0              Caller submits with actor_epoch=0 → ✅ accepted
+ 3    1              Owner calls bump_actor_epoch() → epoch = 1
+ 4    1              Caller submits with actor_epoch=0 → ❌ EpochMismatch
+ 5    1              Caller queries get_actor_epoch_public() → 1
+ 6    1              Caller submits with actor_epoch=1 → ✅ accepted
+```
+
+---
+
+## Relationship to nonce and deadline
+
+The epoch guard fires **before** the nonce and deadline checks:
+
+```
+1. executor.require_auth()
+2. Validate initialization
+3. Check amount > 0
+4. Reentrancy guard
+5. ← verify_matching_epoch (epoch check)
+6. Validate nonce + deadline + request hash
+7. Execute downstream cross-contract calls
+```
+
+A request that arrives with the correct epoch but a consumed nonce still fails
+(at step 6).  A request with a wrong epoch never reaches step 6.  This
+ordering means epoch mismatches are surfaced early and are easily distinguished
+from nonce-replay errors in indexer logs.
+
+---
+
+## Error reference
+
+| Error | Discriminant | When raised |
+|---|---|---|
+| `EpochMismatch` | 15 | `actor_epoch != current_epoch` in `verify_matching_epoch` |
+
+The error discriminant is stable: it is tested in the compatibility-guard suite
+and must not be renumbered.
+
+---
+
+## Testing
+
+Cross-contract epoch guard behaviour is covered in two test files:
+
+| File | What it covers |
+|---|---|
+| `orchestrator/tests/dispute_epoch_guard.rs` | Intra-contract same / prior / ancient / future / sweep |
+| `orchestrator/tests/cross_contract_epoch_guard.rs` | Cross-contract same / off-by-one / ancient / sweep + bump-transition |
+
+Run with:
+
+```bash
+cargo test -p orchestrator
+```
+
+---
+
+## See also
+
+- [docs/OBSERVABILITY_MODEL.md](OBSERVABILITY_MODEL.md) — `epoch_bump` event
+  schema and off-chain consumption guidelines
+- [orchestrator/src/lib.rs](../orchestrator/src/lib.rs) — `verify_matching_epoch`,
+  `bump_actor_epoch`, `get_actor_epoch_public`
+- [docs/AUDIT_TRAIL.md](AUDIT_TRAIL.md) — How to reconstruct historical state
+  from events alone

--- a/docs/OBSERVABILITY_MODEL.md
+++ b/docs/OBSERVABILITY_MODEL.md
@@ -1,0 +1,343 @@
+# Observability Model
+
+**Audience:** Downstream integrators — indexers, analytics pipelines, and
+monitoring services that consume on-chain events from Remitwise contracts.
+
+This document describes **what each contract emits**, the topic/payload schema
+for every event, and what off-chain consumers must rely on to reconstruct
+contract state without re-reading on-chain storage.
+
+---
+
+## How events are published
+
+All Remitwise contracts use Soroban's `env.events().publish()` mechanism.
+There are two emission styles in use:
+
+**Style 1 — categorised (via `RemitwiseEvents::emit`):**
+
+```rust
+// topic: (String("Remitwise"), EventCategory, EventPriority, Symbol)
+// data:  an arbitrary serialisable value
+RemitwiseEvents::emit(&env, EventCategory::Transaction, EventPriority::High,
+                       symbol_short!("flow"), (executor, amount));
+```
+
+**Style 2 — raw two-element topic:**
+
+```rust
+// topic: (Symbol, Symbol)
+// data:  tuple
+env.events().publish((symbol_short!("orch"), symbol_short!("epch_bump")),
+                     (old_epoch, new_epoch));
+```
+
+Both styles are permanently on-chain and queryable through any Soroban RPC
+node.  The topic structure is the stable public API; never rely on topic
+ordinality alone — always match on symbol content.
+
+---
+
+## Orchestrator contract
+
+### `flow` — remittance flow started
+
+| Field | Value |
+|---|---|
+| Topic style | Categorised |
+| Category | `Transaction` |
+| Priority | `High` |
+| Symbol | `"flow"` |
+| Data | `(executor: Address, amount: i128)` |
+
+Emitted at the start of `execute_remittance_flow` and
+`execute_remittance_flow_signed` **after** all input validation passes (auth,
+amount > 0, reentrancy guard, epoch check, nonce/hash check).
+
+> Off-chain: a `flow` event with no subsequent `flow_ok` or `flow_fail` in the
+> same transaction indicates a crash-abort — flag for investigation.
+
+---
+
+### `flow_ok` — flow completed successfully
+
+| Field | Value |
+|---|---|
+| Topic style | Categorised |
+| Category | `Transaction` |
+| Priority | `High` |
+| Symbol | `"flow_ok"` |
+| Data | `(executor: Address, amount: i128)` |
+
+Emitted when all downstream cross-contract calls succeed.
+
+---
+
+### `flow_fail` — flow failed
+
+| Field | Value |
+|---|---|
+| Topic style | Categorised |
+| Category | `Transaction` |
+| Priority | `High` |
+| Symbol | `"flow_fail"` |
+| Data | `(executor: Address, error_code: u32)` |
+
+The `amount` is **intentionally omitted** to avoid leaking sensitive financial
+information in failure paths.  Map `error_code` to `OrchestratorError` using
+the discriminant table:
+
+| Code | Variant | Meaning |
+|---|---|---|
+| 1 | `Unauthorized` | Caller not authorised |
+| 2 | `InvalidAmount` | Amount ≤ 0 |
+| 3 | `Overflow` | Arithmetic overflow |
+| 4 | `CrossContractCallFailed` | Downstream contract returned an error |
+| 5 | `NonceAlreadyUsed` | Nonce was already consumed |
+| 6 | `InvalidNonce` | Nonce or hash validation failed |
+| 7 | `DeadlineExpired` | Deadline timestamp has passed |
+| 8 | `ExecutionLocked` | Reentrancy guard active |
+| 9 | `InvalidDependency` | Required contract dependency missing |
+| 10 | `DuplicateDependency` | Dependency registered twice |
+| 15 | `EpochMismatch` | Supplied actor_epoch ≠ current epoch |
+
+---
+
+### `init_ok` — orchestrator initialised
+
+| Field | Value |
+|---|---|
+| Topic style | Categorised |
+| Category | `System` |
+| Priority | `High` |
+| Symbol | `"init_ok"` |
+| Data | `caller: Address` |
+
+One-time event on successful `init`.
+
+---
+
+### `upgraded` — contract version changed
+
+| Field | Value |
+|---|---|
+| Topic style | Raw two-element |
+| Topic | `("orch", "upgraded")` |
+| Data | `(previous_version: u32, new_version: u32)` |
+
+Emitted by `set_version`.  Indexers should watch for this event to
+invalidate any cached schema assumptions derived from `get_version`.
+
+---
+
+### `epch_bump` — actor epoch bumped
+
+| Field | Value |
+|---|---|
+| Topic style | Raw two-element |
+| Topic | `("orch", "epch_bump")` |
+| Data | `(old_epoch: u64, new_epoch: u64)` |
+
+Emitted by `bump_actor_epoch`.  Off-chain signers and relayers **must**
+refresh their cached epoch after seeing this event — all tokens signed under
+`old_epoch` are immediately invalid.
+
+See [CROSS_CONTRACT_EPOCHS.md](CROSS_CONTRACT_EPOCHS.md) for the full epoch
+coordination protocol.
+
+---
+
+### `clm_rwd` — rewards claimed
+
+| Field | Value |
+|---|---|
+| Topic style | Raw two-element |
+| Topic | `("orch", "clm_rwd")` |
+| Data | `(caller: Address, amount: u64)` |
+
+---
+
+### `snap_pre` / `snap_rst` — upgrade snapshot lifecycle
+
+| Symbol | Trigger | Data |
+|---|---|---|
+| `"snap_pre"` | `pre_upgrade` called | `snapshot_version: u32` |
+| `"snap_rst"` | `restore_from_snapshot` called | `snapshot_version: u32` |
+
+These are operational events for the upgrade runbook; see
+[docs/UPGRADE_RUNBOOK.md](UPGRADE_RUNBOOK.md).
+
+---
+
+## Remittance Split contract
+
+### `init` — split configured
+
+| Field | Value |
+|---|---|
+| Symbol | `"init"` |
+| Data | split configuration struct |
+
+### `calc` — split calculated
+
+| Field | Value |
+|---|---|
+| Symbol | `"calc"` |
+| Data | `(total, spending, savings, bills, insurance): (i128, i128, i128, i128, i128)` |
+
+Emitted by `calculate_split` with the four resulting allocations.
+
+---
+
+## Savings Goals contract
+
+| Symbol | Trigger | Key data |
+|---|---|---|
+| `"create"` / `"created"` | `create_goal` | `(goal_id, owner, name, target_amount, target_date)` |
+| `"add"` / `"funds_add"` | `add_to_goal` | `(goal_id, amount, new_total)` |
+| `"completed"` | Goal target reached | `(goal_id, name, final_amount)` |
+| `"archive"` | `archive_completed_goals` | `(owner, count)` |
+| `"import"` | Data migration import | `(format, record_count)` |
+| `"lock"` | Goal locked | `(goal_id, locked_until)` |
+
+---
+
+## Bill Payments contract
+
+| Symbol | Trigger | Key data |
+|---|---|---|
+| `"created"` | `create_bill` | `(bill_id, owner, name, amount, due_date, recurring)` |
+| `"paid"` | `pay_bill` | `(bill_id, owner, amount, paid_at)` |
+| `"sched_crt"` | `create_bill_schedule` | `(schedule_id, owner)` |
+| `"sched_exe"` | `execute_due_bill_schedules` | `schedule_id` |
+| `"sched_mod"` | `modify_bill_schedule` | `schedule_id` |
+| `"sched_ccl"` | `cancel_bill_schedule` | `schedule_id` |
+
+---
+
+## Insurance contract
+
+| Symbol | Trigger | Key data |
+|---|---|---|
+| `"created"` | `create_policy` | `(policy_id, name, coverage_type, monthly_premium, coverage_amount)` |
+| `"prem_pay"` / `"paid"` | `pay_premium` | `(policy_id, amount, next_payment_date)` |
+| `"deactive"` | `deactivate_policy` | `(policy_id, name)` |
+| `"react"` | `reactivate_policy` | `(policy_id)` |
+| `"sched_crt"` | Schedule created | `(schedule_id, owner)` |
+| `"sched_exe"` | Schedule executed | `schedule_id` |
+
+---
+
+## Family Wallet contract
+
+| Symbol | Trigger | Key data |
+|---|---|---|
+| `"added"` / member events | `add_member` | `(wallet_id, member, role)` |
+| `"updated"` / limit events | `update_spending_limit` | `(member, limit)` |
+| `"emerg/*"` | Emergency mode / transfers | mode and transfer details |
+| `"wallet/*"` | Multisig proposals / withdrawals | proposal id, amount |
+
+---
+
+## Reporting contract
+
+| Symbol | Trigger | Key data |
+|---|---|---|
+| `"report"` | `get_remittance_summary` (write path) | `(owner, data_availability)` |
+
+The `data_availability` value maps to `DataAvailability::Complete`,
+`Partial`, or `Missing` — consumers should surface `Partial` and `Missing`
+states to users rather than treating them as errors.
+
+---
+
+## Event lifecycle: successful remittance flow
+
+The canonical cross-contract event sequence for a single remittance:
+
+```
+ Contract             Event         Meaning
+ ─────────────────────────────────────────────────────────────
+ orchestrator    →    flow          flow started (validated)
+ remittance_split→    calc          allocation calculated
+ savings_goals   →    add           savings slice deposited
+ bill_payments   →    paid          bills slice applied
+ insurance       →    prem_pay      insurance slice applied
+ orchestrator    →    flow_ok       all cross-contract calls succeeded
+```
+
+An indexer that wants to detect partial failures should check whether a
+`flow` event is followed by `flow_ok` or `flow_fail` **in the same
+ledger** — Soroban guarantees atomicity within a single transaction.
+
+---
+
+## Off-chain consumption guidelines
+
+### Guaranteed invariants
+
+1. `flow_ok` is only emitted when all downstream calls succeeded — it is safe
+   to use as a settlement trigger.
+2. `flow_fail` carries an `error_code` instead of an `amount` — do not infer
+   financial amounts from failure events.
+3. Every `epch_bump` event makes all previously-signed tokens invalid — cache
+   the epoch and refresh on every `epch_bump`.
+4. `upgraded` events may change storage layout; re-read contract state after
+   observing one.
+
+### Event ordering
+
+Events within a single Soroban transaction are ordered by emission order.
+Cross-transaction ordering is determined by ledger sequence number.  Do not
+assume events from different contracts in different transactions are ordered
+relative to each other unless they share a ledger close.
+
+### What is NOT emitted
+
+The following state changes do **not** produce events and must be polled via
+view functions if off-chain visibility is needed:
+
+- TTL extension operations (`extend_ttl`, `bump_instance_ttl`)
+- Internal nonce increments
+- Storage key writes that are not part of a user-visible action
+
+---
+
+## Querying events
+
+```bash
+# Fetch events for the orchestrator contract from the RPC
+curl -X POST https://soroban-testnet.stellar.org \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "getEvents",
+    "params": {
+      "startLedger": "1000",
+      "filters": [{
+        "type": "contract",
+        "contractIds": ["<ORCHESTRATOR_CONTRACT_ID>"],
+        "topics": [["*", "*", "*", "AAAADQAAAARmbG93"]]
+      }],
+      "pagination": { "limit": 100 }
+    }
+  }'
+```
+
+Topic values are base64-encoded XDR `ScVal`s.  Use the Soroban SDK or the
+[indexer](../indexer/README.md) to decode them into typed structs.
+
+---
+
+## See also
+
+- [docs/CROSS_CONTRACT_EPOCHS.md](CROSS_CONTRACT_EPOCHS.md) — epoch coordination
+  and the `epch_bump` event
+- [docs/EVENTS.md](EVENTS.md) — complete event schema with full payload
+  definitions for all contracts
+- [docs/AUDIT_TRAIL.md](AUDIT_TRAIL.md) — how to reconstruct historical state
+  from events alone
+- [docs/EVENT_VERSIONING.md](EVENT_VERSIONING.md) — backward-compatibility
+  rules and `_v2` suffix discipline
+- [indexer/README.md](../indexer/README.md) — off-chain event indexing service

--- a/orchestrator/tests/cross_contract_epoch_guard.rs
+++ b/orchestrator/tests/cross_contract_epoch_guard.rs
@@ -1,0 +1,461 @@
+// =========================================================================
+// Issue #1286 — Cross-contract epoch guard boundary tests
+//
+// The `Orchestrator` publishes an actor-epoch value via `get_actor_epoch_public`
+// and mutates it via `bump_actor_epoch`.  Downstream callers (other contracts,
+// off-chain signers, or relayer services) embed the epoch in every signed
+// request.  The guard `verify_matching_epoch` enforces strict equality between
+// the embedded value and the on-chain epoch.
+//
+// The cross-contract dimension: an *external* actor reads the current epoch
+// from Contract A (the orchestrator), embeds it in a signed message, and then
+// that message is replayed against the same contract after the epoch has
+// changed.  Three tiers need to be locked in:
+//
+// * **Same** — actor_epoch == current epoch → accepted.
+// * **Off-by-one** — actor_epoch == current ± 1 → rejected with EpochMismatch.
+// * **Ancient** — actor_epoch is far behind the current epoch (e.g. 0 after
+//   many bumps) → rejected with the same EpochMismatch error.
+//
+// These tests are hosted in the integration-test crate
+// (`orchestrator/tests/`) so they compile independently of the in-`src/`
+// suite and exercise the public contract API exactly as an external caller
+// would.
+// =========================================================================
+
+use soroban_sdk::{
+    contract, contractimpl, symbol_short, testutils::Address as _, Address, Env, Vec,
+};
+
+use orchestrator::{Orchestrator, OrchestratorClient, OrchestratorError};
+
+// ---------------------------------------------------------------------------
+// Minimal mock downstream contract — mirrors the one in dispute_epoch_guard.rs.
+// All methods succeed unconditionally; we only care about the epoch guard.
+// ---------------------------------------------------------------------------
+#[contract]
+struct MockDownstream;
+
+#[contractimpl]
+impl MockDownstream {
+    pub fn check_spending_limit(_env: Env, _user: Address, _amount: i128) -> bool {
+        true
+    }
+    pub fn calculate_split(env: Env, _total_amount: i128) -> Vec<i128> {
+        soroban_sdk::vec![&env, 2500i128, 2500i128, 2500i128, 2500i128]
+    }
+    pub fn add_to_goal(_env: Env, _caller: Address, _goal_id: u32, _amount: i128) {}
+    pub fn pay_bill(_env: Env, _caller: Address, _bill_id: u32, _amount: i128) {}
+    pub fn pay_premium(_env: Env, _caller: Address, _policy_id: u32, _amount: i128) {}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Replicate `Orchestrator::compute_request_hash` (private) with the
+/// default routing IDs that `Orchestrator::init` writes
+/// (`goal_id = 1, bill_id = 1, policy_id = 1`).
+///
+/// If those defaults ever drift in `init`, update this replica in lockstep.
+fn build_request_hash(nonce: u64, amount: i128, deadline: u64) -> u64 {
+    let op_bits: u64 = symbol_short!("flow").to_val().get_payload();
+    let amt_lo = amount as u64;
+    let amt_hi = (amount >> 64) as u64;
+    op_bits
+        .wrapping_add(nonce)
+        .wrapping_add(amt_lo)
+        .wrapping_add(amt_hi)
+        .wrapping_add(deadline)
+        .wrapping_add(1u64) // goal_id
+        .wrapping_add(1u64) // bill_id
+        .wrapping_add(1u64) // policy_id
+        .wrapping_mul(1_000_000_007)
+}
+
+/// Boot a fresh orchestrator with five MockDownstream contracts and return
+/// `(owner, client, executor)`.  Mirrors the pattern in `dispute_epoch_guard.rs`
+/// so both test files exercise exactly the same setup path.
+fn boot(env: &Env) -> (Address, OrchestratorClient<'_>, Address) {
+    let owner = Address::generate(env);
+    let orch_id = env.register_contract(None, Orchestrator);
+    let client = OrchestratorClient::new(env, &orch_id);
+
+    let fw = env.register_contract(None, MockDownstream);
+    let rs = env.register_contract(None, MockDownstream);
+    let sg = env.register_contract(None, MockDownstream);
+    let bp = env.register_contract(None, MockDownstream);
+    let ins = env.register_contract(None, MockDownstream);
+
+    client.init(&owner, &fw, &rs, &sg, &bp, &ins);
+
+    let executor = Address::generate(env);
+    (owner, client, executor)
+}
+
+// ---------------------------------------------------------------------------
+// Same tier — the cross-contract call uses the epoch it just queried
+// ---------------------------------------------------------------------------
+
+/// An external actor queries `get_actor_epoch_public` and immediately embeds
+/// the returned value in a signed request.  The call must succeed: querying
+/// then using the same epoch value is the canonical cross-contract pattern.
+#[test]
+fn cross_contract_same_epoch_is_accepted() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.budget().reset_unlimited();
+    let (owner, client, executor) = boot(&env);
+
+    // Simulate several epoch bumps (as another contract might trigger).
+    for _ in 0..3u32 {
+        client.bump_actor_epoch(&owner);
+    }
+
+    // External actor reads the epoch — this is the cross-contract read.
+    let queried_epoch = client.get_actor_epoch_public();
+    assert_eq!(queried_epoch, 3, "epoch must reflect all bumps");
+
+    let amount = 500i128;
+    let nonce = 0u64;
+    let deadline = env.ledger().timestamp() + 500;
+    let hash = build_request_hash(nonce, amount, deadline);
+
+    // Cross-contract call: embed the queried epoch in the signed request.
+    let result = client.try_execute_remittance_flow_signed(
+        &executor,
+        &amount,
+        &nonce,
+        &deadline,
+        &hash,
+        &queried_epoch,
+    );
+    assert_eq!(
+        result,
+        Ok(Ok(true)),
+        "request with the epoch obtained from get_actor_epoch_public must be accepted"
+    );
+}
+
+/// Same-epoch acceptance holds at the initial epoch (0) before any bumps —
+/// the epoch guard must not treat zero as a special-cased "unset" value.
+#[test]
+fn cross_contract_same_epoch_accepted_at_zero_before_any_bump() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.budget().reset_unlimited();
+    let (_owner, client, executor) = boot(&env);
+
+    let epoch_zero = client.get_actor_epoch_public();
+    assert_eq!(epoch_zero, 0);
+
+    let amount = 100i128;
+    let nonce = 0u64;
+    let deadline = env.ledger().timestamp() + 500;
+    let hash = build_request_hash(nonce, amount, deadline);
+
+    let result = client.try_execute_remittance_flow_signed(
+        &executor,
+        &amount,
+        &nonce,
+        &deadline,
+        &hash,
+        &epoch_zero,
+    );
+    assert_eq!(
+        result,
+        Ok(Ok(true)),
+        "epoch 0 must be accepted when no bumps have occurred"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Off-by-one tier — the external actor's cached epoch is stale by exactly one
+// ---------------------------------------------------------------------------
+
+/// An external actor caches the epoch, then the owner bumps once before the
+/// signed request arrives.  The cached (now prior) value must be rejected with
+/// `EpochMismatch`.  This is the exact cross-contract replay scenario the guard
+/// is designed to prevent.
+#[test]
+fn cross_contract_off_by_one_below_current_is_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.budget().reset_unlimited();
+    let (owner, client, executor) = boot(&env);
+
+    for _ in 0..3u32 {
+        client.bump_actor_epoch(&owner);
+    }
+
+    // External actor reads and caches the current epoch (3).
+    let cached_epoch = client.get_actor_epoch_public();
+    assert_eq!(cached_epoch, 3);
+
+    // Owner bumps the epoch — the cached value is now stale (off by one).
+    client.bump_actor_epoch(&owner);
+    let current = client.get_actor_epoch_public();
+    assert_eq!(current, 4);
+
+    let deadline = env.ledger().timestamp() + 500;
+    let hash = build_request_hash(0, 500, deadline);
+
+    let result = client.try_execute_remittance_flow_signed(
+        &executor,
+        &500i128,
+        &0u64,
+        &deadline,
+        &hash,
+        &cached_epoch, // stale: current - 1
+    );
+    assert_eq!(
+        result,
+        Err(Ok(OrchestratorError::EpochMismatch)),
+        "off-by-one (current - 1 = {cached_epoch}) must be rejected; there is no off-by-one tolerance"
+    );
+}
+
+/// An external actor somehow has an epoch that is one *ahead* of the current
+/// on-chain value (e.g. constructed a future epoch from a side channel).
+/// The guard must reject it with the same `EpochMismatch`.
+#[test]
+fn cross_contract_off_by_one_above_current_is_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.budget().reset_unlimited();
+    let (owner, client, executor) = boot(&env);
+
+    for _ in 0..3u32 {
+        client.bump_actor_epoch(&owner);
+    }
+    let current = client.get_actor_epoch_public();
+    assert_eq!(current, 3);
+
+    let future_epoch = current + 1; // one ahead of on-chain value
+    let deadline = env.ledger().timestamp() + 500;
+    let hash = build_request_hash(0, 500, deadline);
+
+    let result = client.try_execute_remittance_flow_signed(
+        &executor,
+        &500i128,
+        &0u64,
+        &deadline,
+        &hash,
+        &future_epoch,
+    );
+    assert_eq!(
+        result,
+        Err(Ok(OrchestratorError::EpochMismatch)),
+        "off-by-one above current ({future_epoch}) must also be rejected"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Ancient tier — the external actor's cached epoch is many bumps behind
+// ---------------------------------------------------------------------------
+
+/// An actor that signed a token when the epoch was 0 and tries to replay it
+/// after the epoch has advanced to a large value must be rejected.  Models the
+/// real-world scenario of a long-dormant relayer re-submitting an old request.
+#[test]
+fn cross_contract_ancient_epoch_zero_rejected_after_many_bumps() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.budget().reset_unlimited();
+    let (owner, client, executor) = boot(&env);
+
+    // Many bumps — simulates a contract that has been live for a long time.
+    for _ in 0..10u32 {
+        client.bump_actor_epoch(&owner);
+    }
+    let current = client.get_actor_epoch_public();
+    assert_eq!(current, 10);
+
+    let ancient_epoch = 0u64;
+    let deadline = env.ledger().timestamp() + 500;
+    let hash = build_request_hash(0, 200, deadline);
+
+    let result = client.try_execute_remittance_flow_signed(
+        &executor,
+        &200i128,
+        &0u64,
+        &deadline,
+        &hash,
+        &ancient_epoch,
+    );
+    assert_eq!(
+        result,
+        Err(Ok(OrchestratorError::EpochMismatch)),
+        "ancient epoch 0 must be rejected when current epoch is {current}"
+    );
+}
+
+/// A moderately stale epoch (5 bumps behind) is rejected with the same error
+/// as an epoch that is 0.  There is no grace window for "recently stale"
+/// cross-contract tokens.
+#[test]
+fn cross_contract_moderately_stale_epoch_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.budget().reset_unlimited();
+    let (owner, client, executor) = boot(&env);
+
+    for _ in 0..10u32 {
+        client.bump_actor_epoch(&owner);
+    }
+    let current = client.get_actor_epoch_public();
+
+    // 5 bumps behind the current epoch.
+    let stale_epoch = current - 5;
+    let deadline = env.ledger().timestamp() + 500;
+    let hash = build_request_hash(0, 300, deadline);
+
+    let result = client.try_execute_remittance_flow_signed(
+        &executor,
+        &300i128,
+        &0u64,
+        &deadline,
+        &hash,
+        &stale_epoch,
+    );
+    assert_eq!(
+        result,
+        Err(Ok(OrchestratorError::EpochMismatch)),
+        "stale epoch {stale_epoch} (current - 5, current = {current}) must be rejected"
+    );
+}
+
+/// `u64::MAX` as a cross-contract epoch value is rejected.  This pins the
+/// absence of any overflow / wraparound behaviour in the guard.
+#[test]
+fn cross_contract_u64_max_epoch_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.budget().reset_unlimited();
+    let (owner, client, executor) = boot(&env);
+
+    for _ in 0..3u32 {
+        client.bump_actor_epoch(&owner);
+    }
+    let current = client.get_actor_epoch_public();
+    assert_ne!(current, u64::MAX);
+
+    let deadline = env.ledger().timestamp() + 500;
+    let hash = build_request_hash(0, 100, deadline);
+
+    let result = client.try_execute_remittance_flow_signed(
+        &executor,
+        &100i128,
+        &0u64,
+        &deadline,
+        &hash,
+        &u64::MAX,
+    );
+    assert_eq!(
+        result,
+        Err(Ok(OrchestratorError::EpochMismatch)),
+        "u64::MAX must be rejected; guard must not wrap around"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Sweep — every non-matching value produces the same typed error
+// ---------------------------------------------------------------------------
+
+/// Exhaustive sweep over representative epoch values (prior trough, immediate
+/// future, extreme values including `u64::MAX`).  Every value except `current`
+/// must produce `EpochMismatch`.  Pins uniform error semantics across the full
+/// cross-contract call surface.
+#[test]
+fn cross_contract_non_matching_epochs_all_produce_epoch_mismatch() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.budget().reset_unlimited();
+    let (owner, client, executor) = boot(&env);
+
+    for _ in 0..5u32 {
+        client.bump_actor_epoch(&owner);
+    }
+    let current = client.get_actor_epoch_public();
+    assert_eq!(current, 5);
+
+    let amount = 400i128;
+    let deadline = env.ledger().timestamp() + 500;
+    let hash = build_request_hash(0, amount, deadline);
+
+    // A representative set: prior-trough (0..=4), immediate-future (6),
+    // mid-range (50, 1000), and the maximum u64 value.
+    for bad_epoch in [0u64, 1, 2, 3, 4, 6, 50, 1000, u64::MAX] {
+        let result = client.try_execute_remittance_flow_signed(
+            &executor,
+            &amount,
+            &0u64,
+            &deadline,
+            &hash,
+            &bad_epoch,
+        );
+        assert_eq!(
+            result,
+            Err(Ok(OrchestratorError::EpochMismatch)),
+            "epoch {bad_epoch} (current = {current}) must produce EpochMismatch"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Transition correctness — bump changes what is accepted
+// ---------------------------------------------------------------------------
+
+/// After the owner bumps the epoch the previously-accepted value is no longer
+/// valid and the new value becomes the only accepted one.  Models the lifecycle
+/// of a cross-contract client that must refresh its cached epoch after each bump.
+#[test]
+fn cross_contract_bump_makes_old_epoch_stale_and_new_epoch_valid() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.budget().reset_unlimited();
+    let (owner, client, executor) = boot(&env);
+
+    // Initial accepted epoch.
+    let initial_epoch = client.get_actor_epoch_public();
+    assert_eq!(initial_epoch, 0);
+
+    // Bump: old value must now be rejected, new value must be accepted.
+    let new_epoch = client.bump_actor_epoch(&owner);
+    assert_eq!(new_epoch, 1);
+
+    let amount = 200i128;
+    let nonce = 0u64;
+    let deadline = env.ledger().timestamp() + 500;
+    let hash_new = build_request_hash(nonce, amount, deadline);
+
+    // Old (stale) epoch rejected.
+    let stale_result = client.try_execute_remittance_flow_signed(
+        &executor,
+        &amount,
+        &nonce,
+        &deadline,
+        &hash_new,
+        &initial_epoch,
+    );
+    assert_eq!(
+        stale_result,
+        Err(Ok(OrchestratorError::EpochMismatch)),
+        "initial epoch {initial_epoch} must be stale after bump to {new_epoch}"
+    );
+
+    // New epoch accepted.
+    let fresh_result = client.try_execute_remittance_flow_signed(
+        &executor,
+        &amount,
+        &nonce,
+        &deadline,
+        &hash_new,
+        &new_epoch,
+    );
+    assert_eq!(
+        fresh_result,
+        Ok(Ok(true)),
+        "new epoch {new_epoch} must be accepted immediately after bump"
+    );
+}


### PR DESCRIPTION
Closes #1282
Closes #1286
Closes #1287
Closes #1288

---

## What changed

### #1282 — Tests for the migration-completed helper

**File:** `data_migration/src/lib.rs`

Added 10 unit tests inside the existing `mod tests` block that lock in the three observable states of `MigrationTracker::is_imported` — the canonical migration-completed predicate:

| State | Meaning | `is_imported` returns |
|---|---|---|
| **None** | Fresh tracker, nothing recorded | `false` |
| **InProgress** | Snapshot built, `mark_imported` not yet called | `false` |
| **Completed** | `mark_imported` succeeded | `true` |

Tests added:
- `migration_completed_none_state_reports_not_imported`
- `migration_completed_default_tracker_equals_new`
- `migration_completed_completed_state_returns_true_after_mark`
- `migration_completed_completed_state_after_full_tracked_import`
- `migration_completed_in_progress_state_returns_false_before_mark`
- `migration_completed_in_progress_transitions_to_completed_on_mark`
- `migration_completed_unmark_reverts_completed_to_in_progress`
- `migration_completed_unmark_nonexistent_identity_is_no_op`
- `migration_completed_each_snapshot_has_independent_completion_state`
- `migration_completed_binary_import_sets_completed_state`

All tests are deterministic (no randomness, no I/O) and use only the existing helper functions already present in the test module.

---

### #1286 — Tests for the cross-contract epoch guard

**File:** `orchestrator/tests/cross_contract_epoch_guard.rs` (new)

Added 9 integration tests that exercise `verify_matching_epoch` from the perspective of an external caller — the cross-contract scenario where an actor reads the epoch from Contract A, embeds it in a signed message, and replays it after the epoch has changed.

| Tier | Tests |
|---|---|
| **Same** | `cross_contract_same_epoch_is_accepted`, `cross_contract_same_epoch_accepted_at_zero_before_any_bump` |
| **Off-by-one** | `cross_contract_off_by_one_below_current_is_rejected`, `cross_contract_off_by_one_above_current_is_rejected` |
| **Ancient** | `cross_contract_ancient_epoch_zero_rejected_after_many_bumps`, `cross_contract_moderately_stale_epoch_rejected` |
| **Boundary / sweep** | `cross_contract_u64_max_epoch_rejected`, `cross_contract_non_matching_epochs_all_produce_epoch_mismatch`, `cross_contract_bump_makes_old_epoch_stale_and_new_epoch_valid` |

The file follows the same structure as the existing `orchestrator/tests/dispute_epoch_guard.rs` (same `boot` pattern, same request-hash replica, same mock downstream contract shape).

---

### #1287 — `docs/CROSS_CONTRACT_EPOCHS.md` (new)

Contributor-facing reference for the actor-epoch coordination protocol. Covers:

- What the epoch counter is and where it lives in storage (`ACT_EPOCH`)
- Why epochs exist (stale token replay mitigation)
- The read → embed → submit coordination pattern with real call signatures
- `verify_matching_epoch` source excerpt explaining the strict-equality contract
- Tier table: Same / Off-by-one / Ancient / Future
- When and why to call `bump_actor_epoch`
- Worked timeline showing the full lifecycle
- Where the epoch check sits in the 8-step validation pipeline
- `EpochMismatch` error discriminant (15) with stability note
- Pointers to both epoch guard test files

---

### #1288 — `docs/OBSERVABILITY_MODEL.md` (new)

Integrator-facing event catalogue for all Remitwise contracts. Covers:

- The two event emission styles used across the codebase
- Full topic/payload specs for every orchestrator event: `flow`, `flow_ok`, `flow_fail`, `init_ok`, `upgraded`, `epch_bump`, `clm_rwd`, `snap_pre`, `snap_rst`
- `OrchestratorError` discriminant table (codes 1–15) for decoding `flow_fail` payloads
- Per-contract event summary tables for remittance_split, savings_goals, bill_payments, insurance, family_wallet, reporting
- Canonical cross-contract event sequence for a successful remittance flow
- Off-chain consumption invariants (settlement trigger, epoch refresh on `epch_bump`, schema invalidation on `upgraded`, privacy in `flow_fail`)
- What is NOT emitted (TTL bumps, nonce increments)
- Example `getEvents` RPC query

---

## Testing

```bash
# Run new migration-completed tests
cargo test -p data_migration -- migration_completed

# Run new cross-contract epoch guard tests
cargo test -p orchestrator

# Full workspace lint
cargo clippy --workspace --all-targets -- -D warnings
```

## Checklist

- [x] Tests cover happy path and explicit sad paths for each boundary
- [x] Test names are assertive, not interrogative
- [x] Tests are fully deterministic — no external I/O or randomness
- [x] No `std::` calls introduced; no new dependencies added
- [x] New test file follows existing patterns in `orchestrator/tests/`
- [x] Both docs linked from `README.md`
- [x] PR description references all four closing issues