### PR TITLE
feat: reject rotate-admin proposal when new_admin == current admin

### DIFF
--- a/reporting/src/lib.rs
+++ b/reporting/src/lib.rs
@@ -259,6 +259,8 @@ pub enum ReportingError {
     InvalidPercentageSplit = 8,
     /// u64 to u32 overflow guard
     Overflow = 9,
+    /// Proposed new admin is the same as the current admin.
+    SameAdmin = 10,
 }
 
 #[contracttype]
@@ -686,6 +688,7 @@ impl ReportingContract {
     /// # Errors
     /// * `NotInitialized` - If contract has not been initialized
     /// * `Unauthorized` - If caller is not the current admin
+    /// * `SameAdmin` - If `new_admin` is the same as the current admin
     pub fn propose_new_admin(
         env: Env,
         caller: Address,
@@ -701,6 +704,10 @@ impl ReportingContract {
 
         if caller != admin {
             return Err(ReportingError::Unauthorized);
+        }
+
+        if new_admin == admin {
+            return Err(ReportingError::SameAdmin);
         }
 
         Self::extend_instance_ttl(&env);

--- a/reporting/src/tests_auth_acl.rs
+++ b/reporting/src/tests_auth_acl.rs
@@ -529,27 +529,29 @@ fn test_admin_rotation_accept_with_no_pending_proposal() {
     assert_eq!(client.get_admin(), Some(admin));
 }
 
-/// Edge case "proposing the current admin as the new admin": this is a safe
-/// no-op rotation. The admin proposes itself, accepts, remains admin, and the
-/// pending proposal is cleared (a second accept reports `NotAdminProposed`).
+/// Proposing the current admin as the new admin is rejected at the boundary
+/// with a structured `SameAdmin` error. The admin and pending-proposal state
+/// remain unchanged.
 #[test]
-fn test_admin_rotation_propose_current_admin_is_safe() {
+fn test_admin_rotation_reject_propose_current_admin() {
     let env = create_test_env();
     let (client, admin) = setup_reporting(&env);
 
-    client.propose_new_admin(&admin, &admin);
-    assert_eq!(client.try_accept_admin_rotation(&admin), Ok(Ok(())));
+    assert_eq!(
+        client.try_propose_new_admin(&admin, &admin),
+        Err(Ok(ReportingError::SameAdmin)),
+        "self-proposal must be rejected"
+    );
 
-    // Admin is still the same address...
+    // Admin is unchanged, no pending proposal exists.
     assert_eq!(client.get_admin(), Some(admin.clone()));
-    // ...and the pending slot was cleared by the successful accept.
     assert_eq!(
         client.try_accept_admin_rotation(&admin),
         Err(Ok(ReportingError::NotAdminProposed)),
-        "pending proposal must be cleared after acceptance"
+        "no pending proposal after rejected self-proposal"
     );
 
-    // The admin retains its privileges (self-rotation is a harmless no-op).
+    // The admin retains its privileges.
     let (a, b, c, d, e) = fresh_dependency_addresses(&env);
     assert_eq!(
         client.try_configure_addresses(&admin, &a, &b, &c, &d, &e),


### PR DESCRIPTION
## Summary

Reject `propose_new_admin` when `new_admin` is the same as the current admin, returning a structured `SameAdmin` error instead of silently accepting the no-op.

## Changes

- **`reporting/src/lib.rs`**: Added `SameAdmin = 10` variant to `ReportingError`. Added a guard in `propose_new_admin` that returns `Err(ReportingError::SameAdmin)` when `new_admin == admin`, before any state mutation.
- **`reporting/src/tests_auth_acl.rs`**: Replaced the old `test_admin_rotation_propose_current_admin_is_safe` (which treated self-proposal as a harmless no-op) with `test_admin_rotation_reject_propose_current_admin` (which asserts the structured rejection and verifies admin state is unchanged).

## Acceptance criteria

- [x] Self-proposal is rejected at the boundary with a typed error
- [x] Test covers the happy path (legitimate rotation still works) and the failure mode (self-proposal → `SameAdmin`)
- [x] Lint and tests pass (verified via `cargo test -p reporting` and `cargo clippy --workspace --all-targets -- -D warnings`)

Closes #1341 
