### PR TITLE
docs: add KILL_SWITCH_EPOCHS.md and link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ To run an example, use `cargo run --example <example_name>`:
 - [Audit Trail](docs/AUDIT_TRAIL.md) - How to reconstruct historical state from events alone
 - [Settler Whitelist](docs/SETTLER_WHITELIST.md) - Operator guide: how settlers are added, rotated, and revoked
 - [Killswitch Trust Model](docs/killswitch-trust-model.md) - Who can trigger, who can clear, what state is preserved in the emergency killswitch
+- [Killswitch Epochs](docs/KILL_SWITCH_EPOCHS.md) - Defining emergency epochs and incident lifecycles
 - [Tagging Feature](TAGGING_FEATURE.md) - Tag-based organization system
 - [Threat Model](THREAT_MODEL.md) - Security analysis and mitigations
 - [Entrypoint Threat Breakdown](docs/THREAT_MODEL.md) - STRIDE-style threat analysis per contract entrypoint (contributor-focused)

--- a/docs/KILL_SWITCH_EPOCHS.md
+++ b/docs/KILL_SWITCH_EPOCHS.md
@@ -1,0 +1,35 @@
+# Emergency Killswitch: Epochs and Incident Lifecycles
+
+## Overview
+An "emergency epoch" refers to the period during which the `emergency_killswitch` contract is in an active pause state. This lifecycle is strictly managed to ensure controlled incident resolution and prevent erratic system behavior.
+
+## Lifecycle of an Emergency Epoch
+
+1. **Epoch Start (Incident)**: The pause admin triggers `pause()`. All guarded operations across modules cease immediately.
+2. **Cooling Period (Resolution)**: Once the incident is mitigated, the admin schedules an unpause (`schedule_unpause(timestamp)`) to provide a window for final verification.
+3. **Epoch End (Resolution)**:
+   - **Normal**: `unpause()` is called by the admin once the ledger timestamp exceeds the scheduled unpause time.
+   - **Emergency**: `clear_emergency_state()` is called to lift the pause immediately, bypassing the timelock.
+
+## Example: Managing an Emergency Epoch
+
+```rust
+// 1. Epoch Start: Incident detected
+killswitch.pause();
+assert!(killswitch.is_paused());
+
+// 2. Cooling Period: Schedule unpause for 24 hours later
+let now = env.ledger().timestamp();
+killswitch.schedule_unpause(&(now + 86_400)); 
+
+// ... time passes ...
+
+// 3. Epoch End: Normal resolution
+env.ledger().with_mut(|li| li.timestamp = now + 86_500);
+killswitch.unpause();
+assert!(!killswitch.is_paused());
+```
+
+## Related Documentation
+- [Emergency Killswitch Timelock Design](killswitch-timelock.md)
+- [Pause Playbook](PAUSE_PLAYBOOK.md)


### PR DESCRIPTION
Description
  This PR addresses the need for centralized documentation regarding the "emergency epoch" concept in the
  emergency_killswitch contract. Previously, the lifecycle of an emergency epoch (start/pause, cooling/schedule,
  end/unpause) was tribal knowledge. This documentation enables reviewers to verify behavior against documented
  intent and helps support teams answer common questions without engineering intervention.

  Changes
   - New Documentation: Added docs/KILL_SWITCH_EPOCHS.md.
     - Defines the "emergency epoch" lifecycle.
     - Documents the three phases: Epoch Start, Cooling Period, and Epoch End.
     - Provides a concrete Rust code example for managing an emergency epoch lifecycle.
   - Documentation Updates:
     - Linked docs/KILL_SWITCH_EPOCHS.md in the main README.md under the Documentation section.

  Acceptance Criteria
   - [x] Documentation added (docs/KILL_SWITCH_EPOCHS.md).
   - [x] Linked from README.md.
   - [x] Examples in document reflect real contract usage.
   - [x] No unrelated changes.

  Verification
   - Documentation renders correctly with Markdown formatting.
   - Cross-references to existing documentation (killswitch-timelock.md, PAUSE_PLAYBOOK.md) are maintained.


  Closes #1294 