### PR TITLE
test: Add Rate::from_percent boundaries tests

### DIFF
--- a/remitwise-common/src/lib.rs
+++ b/remitwise-common/src/lib.rs
@@ -923,6 +923,15 @@ impl Rate {
         Self(bps)
     }
 
+    /// Create a `Rate` from a whole percentage integer value (1 = 1%).
+    #[inline(always)]
+    pub fn from_percent(percent: u32) -> Result<Self, RateError> {
+        percent
+            .checked_mul(BPS_PER_PERCENT)
+            .ok_or(RateError::Overflow)
+            .map(Self::from_bps)
+    }
+
     /// Construct a `Rate` from an externally supplied raw value plus unit.
     ///
     /// This is the safe entry point for untrusted inputs that carry an explicit

--- a/remitwise-common/src/tests.rs
+++ b/remitwise-common/src/tests.rs
@@ -1276,6 +1276,26 @@ fn test_rate_from_percent() {
 }
 
 #[test]
+fn test_rate_from_percent_boundaries() {
+    // 0%
+    assert_eq!(Rate::from_percent(0), Ok(Rate::from_bps(0)));
+
+    // 0.01% is 1 basis point. `from_percent` only takes whole percentages,
+    // so fractional percentages must be constructed via `from_bps`.
+    let point_zero_one = Rate::from_bps(1);
+    assert!(point_zero_one.has_fractional_percent());
+    assert_eq!(point_zero_one.to_percent(), 0);
+
+    // 100%
+    assert_eq!(Rate::from_percent(100), Ok(Rate::from_bps(10_000)));
+
+    // 100.01% is 10,001 basis points.
+    let hundred_point_zero_one = Rate::from_bps(10_001);
+    assert!(hundred_point_zero_one.has_fractional_percent());
+    assert_eq!(hundred_point_zero_one.to_percent(), 100);
+}
+
+#[test]
 fn test_rate_to_percent_and_fractional() {
     let rate_0 = Rate::from_bps(0);
     assert_eq!(rate_0.to_percent(), 0);


### PR DESCRIPTION
Closes #1186 


This PR closes the issue regarding adding `Rate::from_percent` boundaries and locking the contract behavior in place. 

During the fix, it was discovered that `Rate::from_percent` was actually entirely missing from the `Rate` implementation in `remitwise-common/src/lib.rs` despite being invoked in multiple tests and logic sections. It has now been implemented alongside the boundary tests.

The boundary tests explicitly test `Rate::from_percent` and `Rate::from_bps` on the following points:
- 0% (Tested using `Rate::from_percent`)
- 0.01% (Tested using `Rate::from_bps` as fractional percentages cannot be directly constructed through `Rate::from_percent`)
- 100% (Tested using `Rate::from_percent`)
- 100.01% (Tested using `Rate::from_bps` and verified to be fractional)

## Acceptance criteria
- [x] The change matches the summary above.
- [x] The new test fails on the current main before the fix and passes after.
- [x] Tests run on every CI matrix entry, not just the local default.
- [x] Lint, type-check, and tests all pass locally.