### PR TITLE
feat: cross-contract invariants doc, migration guards, and view-fn lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This workspace contains the core smart contracts that power RemitWise's post-rem
 - **[remitwise-common](remitwise-common/README.md)**: Shared types and utilities used across contracts
 - **[docs/PERIOD_INVARIANTS.md](docs/PERIOD_INVARIANTS.md)**: Time-bound period invariants, ledger timestamp rules, and execution windows
 - **[docs/AMOUNT_INVARIANTS.md](docs/AMOUNT_INVARIANTS.md)**: Amount zero-handling rules across contract entrypoints
+- **[docs/CROSS_CONTRACT_INVARIANTS.md](docs/CROSS_CONTRACT_INVARIANTS.md)**: Invariants that span multiple contracts — split conservation, replay protection, epoch guards, and reviewer checklist
 
 ## Shared Components
 

--- a/data_migration/src/lib.rs
+++ b/data_migration/src/lib.rs
@@ -580,6 +580,11 @@ pub enum MigrationError {
     ValidationFailed(String),
     DeserializeError(String),
     DuplicateImport,
+    /// Returned by [`verify_migration_completed`] when the caller attempts a write
+    /// operation before the migration has been explicitly marked complete via
+    /// [`MigrationTracker::mark_completed`]. This guard prevents partially-applied
+    /// migrations from being overwritten with live writes before they are finished.
+    MigrationNotCompleted,
 }
 
 impl std::fmt::Display for MigrationError {
@@ -624,6 +629,10 @@ impl std::fmt::Display for MigrationError {
             MigrationError::ValidationFailed(s) => write!(f, "validation failed: {}", s),
             MigrationError::DeserializeError(s) => write!(f, "deserialize error: {}", s),
             MigrationError::DuplicateImport => write!(f, "duplicate payload import detected"),
+            MigrationError::MigrationNotCompleted => write!(
+                f,
+                "migration not completed: write operations are not permitted until the migration is marked complete"
+            ),
         }
     }
 }
@@ -634,13 +643,36 @@ impl std::error::Error for MigrationError {}
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct MigrationTracker {
     imported_payloads: HashMap<(String, u32), u64>,
+    /// Set to `true` after the operator explicitly calls `mark_completed`.
+    /// [`verify_migration_completed`] checks this flag and returns
+    /// [`MigrationError::MigrationNotCompleted`] until it is set.
+    pub completed: bool,
 }
 
 impl MigrationTracker {
     pub fn new() -> Self {
         Self {
             imported_payloads: HashMap::new(),
+            completed: false,
         }
+    }
+
+    /// Mark the migration as fully applied and ready for live writes.
+    ///
+    /// Call this only after every import step has succeeded and the contract
+    /// state is in a coherent, fully-migrated condition. After this call,
+    /// [`verify_migration_completed`] will no longer return an error.
+    ///
+    /// This is intentionally separate from the last `mark_imported` call so
+    /// that multi-step migrations can import several snapshots before signalling
+    /// completion.
+    pub fn mark_completed(&mut self) {
+        self.completed = true;
+    }
+
+    /// Returns `true` if the migration has been marked complete.
+    pub fn is_completed(&self) -> bool {
+        self.completed
     }
 
     /// Mark a payload as imported.
@@ -670,6 +702,43 @@ impl MigrationTracker {
     pub fn unmark_imported_by_identity(&mut self, checksum: &str, version: u32) {
         let identity = (checksum.to_string(), version);
         self.imported_payloads.remove(&identity);
+    }
+}
+
+/// Check that a migration has been explicitly marked complete before allowing writes.
+///
+/// # Threat mitigated
+///
+/// Without this gate a contract could begin accepting live writes over a
+/// partially-applied migration, producing an inconsistent mix of migrated and
+/// un-migrated data. This is especially dangerous during a batched or
+/// multi-step migration that is interrupted mid-way: subsequent writes would
+/// silently land on top of an incomplete on-chain state, and the corruption
+/// would only surface when the missing records are referenced.
+///
+/// # Usage
+///
+/// Call this function at the top of every write entrypoint that operates on
+/// data that may be in the process of being migrated. If the `tracker` has not
+/// had [`MigrationTracker::mark_completed`] called on it, this function returns
+/// [`MigrationError::MigrationNotCompleted`] and the caller should propagate
+/// that error without performing any state mutation.
+///
+/// ```rust
+/// use data_migration::{MigrationTracker, verify_migration_completed};
+///
+/// fn some_write_entrypoint(tracker: &MigrationTracker, value: u32) -> Result<(), data_migration::MigrationError> {
+///     // Defence-in-depth: refuse writes until migration is marked complete.
+///     verify_migration_completed(tracker)?;
+///     // ... perform write ...
+///     Ok(())
+/// }
+/// ```
+pub fn verify_migration_completed(tracker: &MigrationTracker) -> Result<(), MigrationError> {
+    if tracker.is_completed() {
+        Ok(())
+    } else {
+        Err(MigrationError::MigrationNotCompleted)
     }
 }
 
@@ -4312,5 +4381,420 @@ mod tests {
 
         assert_eq!(first.payload, second.payload);
         assert_eq!(first.header.checksum, second.header.checksum);
+    }
+}
+
+// =============================================================================
+// Issue #1281 — verify_migration_completed() tests
+//
+// These tests exercise the write-gate helper that prevents live writes from
+// landing on top of an incomplete migration. The negative test (writing before
+// completion) is the primary acceptance criterion.
+// =============================================================================
+#[cfg(test)]
+mod verify_migration_completed_tests {
+    use super::*;
+
+    // -----------------------------------------------------------------------
+    // Happy path: after mark_completed the gate opens.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn verify_migration_completed_passes_after_mark_completed() {
+        let mut tracker = MigrationTracker::new();
+        tracker.mark_completed();
+
+        assert_eq!(
+            verify_migration_completed(&tracker),
+            Ok(()),
+            "verify_migration_completed must return Ok after mark_completed"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Negative test: before mark_completed the gate is closed.
+    //
+    // This is the primary acceptance criterion for issue #1281.
+    // -----------------------------------------------------------------------
+
+    /// A write operation attempted before the migration is marked complete must
+    /// be rejected with MigrationError::MigrationNotCompleted.
+    ///
+    /// Threat mitigated: without this guard a caller could perform writes over
+    /// partially-applied on-chain state (e.g. a multi-step migration interrupted
+    /// mid-way), silently mixing migrated and un-migrated records in the same
+    /// storage namespace. The corruption surfaces only when the missing records
+    /// are later referenced — long after the migration window has closed.
+    #[test]
+    fn verify_migration_completed_rejects_before_mark_completed() {
+        let tracker = MigrationTracker::new();
+
+        assert_eq!(
+            verify_migration_completed(&tracker),
+            Err(MigrationError::MigrationNotCompleted),
+            "verify_migration_completed must return Err(MigrationNotCompleted) \
+             before mark_completed is called — write operations must be refused \
+             until the migration gate is explicitly opened"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // is_completed reflects the flag state.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn is_completed_is_false_on_new_tracker() {
+        let tracker = MigrationTracker::new();
+        assert!(!tracker.is_completed(), "new tracker must not be completed");
+    }
+
+    #[test]
+    fn is_completed_is_true_after_mark_completed() {
+        let mut tracker = MigrationTracker::new();
+        tracker.mark_completed();
+        assert!(
+            tracker.is_completed(),
+            "tracker must report completed after mark_completed"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // mark_completed is idempotent (calling twice must not panic or change state).
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn mark_completed_is_idempotent() {
+        let mut tracker = MigrationTracker::new();
+        tracker.mark_completed();
+        tracker.mark_completed(); // second call must be a no-op
+        assert!(tracker.is_completed());
+        assert_eq!(verify_migration_completed(&tracker), Ok(()));
+    }
+
+    // -----------------------------------------------------------------------
+    // Error display message is meaningful.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn migration_not_completed_error_display_is_descriptive() {
+        let msg = MigrationError::MigrationNotCompleted.to_string();
+        assert!(
+            msg.contains("migration not completed"),
+            "error message should mention 'migration not completed': {msg}"
+        );
+        assert!(
+            msg.contains("write"),
+            "error message should mention writes: {msg}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Completed flag is independent of the import tracker.
+    // A tracker can have imports recorded but still not be completed.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn can_have_imports_without_being_completed() {
+        let snapshot = ExportSnapshot::new(
+            SnapshotPayload::RemittanceSplit(RemittanceSplitExport {
+                owner: "GABC".into(),
+                spending_percent: 5000,
+                savings_percent: 3000,
+                bills_percent: 1500,
+                insurance_percent: 500,
+            }),
+            ExportFormat::Json,
+        );
+        let bytes = export_to_json(&snapshot).unwrap();
+
+        let mut tracker = MigrationTracker::new();
+        import_from_json(&bytes, &mut tracker, 1_000).unwrap();
+
+        // Import recorded but not yet completed — write gate must still be closed.
+        assert!(tracker.is_imported(&snapshot));
+        assert!(!tracker.is_completed());
+        assert_eq!(
+            verify_migration_completed(&tracker),
+            Err(MigrationError::MigrationNotCompleted),
+            "having imports recorded does not implicitly open the write gate"
+        );
+
+        // Explicitly complete the migration — gate opens.
+        tracker.mark_completed();
+        assert_eq!(verify_migration_completed(&tracker), Ok(()));
+    }
+}
+
+// =============================================================================
+// Issue #1279 — Upgrade-epoch guard boundary tests
+//
+// `check_version_compatibility` (data_migration/src/lib.rs) enforces the
+// schema-version boundary for migration imports:
+//   - Accepted range: MIN_SUPPORTED_VERSION ..= SCHEMA_VERSION  (inclusive)
+//   - Anything outside that range is rejected with IncompatibleVersion
+//
+// These tests cover the same tiers as the orchestrator epoch-guard suite
+// (orchestrator/tests/dispute_epoch_guard.rs) but applied to the migration
+// schema version boundary:
+//
+//   • current  — SCHEMA_VERSION is accepted
+//   • min      — MIN_SUPPORTED_VERSION is accepted (lower boundary)
+//   • prior    — MIN_SUPPORTED_VERSION - 1 is rejected (one below the floor)
+//   • ancient  — 0 is always rejected (no staleness window)
+//   • future   — SCHEMA_VERSION + 1 is rejected (no forward acceptance)
+//   • sweep    — representative values outside the window all produce the
+//                same typed IncompatibleVersion error (with correct bounds)
+//   • snapshot — ExportSnapshot::is_version_compatible mirrors the check
+// =============================================================================
+#[cfg(test)]
+mod upgrade_epoch_guard_tests {
+    use super::*;
+
+    // -----------------------------------------------------------------------
+    // `current` tier — SCHEMA_VERSION is accepted.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn accepts_current_schema_version() {
+        assert_eq!(
+            check_version_compatibility(SCHEMA_VERSION),
+            Ok(()),
+            "SCHEMA_VERSION ({}) must be accepted by the version guard",
+            SCHEMA_VERSION
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // `min` tier — MIN_SUPPORTED_VERSION is the lower boundary and is accepted.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn accepts_min_supported_version() {
+        assert_eq!(
+            check_version_compatibility(MIN_SUPPORTED_VERSION),
+            Ok(()),
+            "MIN_SUPPORTED_VERSION ({}) must be accepted — it is the lower boundary",
+            MIN_SUPPORTED_VERSION
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // `prior` tier — one below the floor is rejected.
+    //
+    // If MIN_SUPPORTED_VERSION > 0 we can check MIN - 1; if it is already 0
+    // we skip to the `ancient` test instead (which uses 0 directly). In
+    // practice MIN_SUPPORTED_VERSION == 1 for this codebase.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn rejects_one_below_min_supported_version() {
+        if MIN_SUPPORTED_VERSION == 0 {
+            // Can't go below 0 for a u32; skip the off-by-one tier.
+            return;
+        }
+        let prior = MIN_SUPPORTED_VERSION - 1;
+        assert_eq!(
+            check_version_compatibility(prior),
+            Err(MigrationError::IncompatibleVersion {
+                found: prior,
+                min: MIN_SUPPORTED_VERSION,
+                max: SCHEMA_VERSION,
+            }),
+            "version {} (MIN - 1) must be rejected; equality at the floor is the only accepted boundary",
+            prior
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // `ancient` tier — version 0 is always rejected after bumps.
+    //
+    // Mirrors the orchestrator test `rejects_ancient_epoch_at_zero_after_many_bumps`.
+    // There is no staleness window and no special-cased leniency for version 0.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn rejects_ancient_version_zero() {
+        // Version 0 predates the schema and must always be rejected.
+        // This pins the invariant: there is no staleness window, no lower
+        // leniency, and no special case for the "zeroth" version.
+        if MIN_SUPPORTED_VERSION == 0 {
+            // If the floor is 0 then 0 is accepted — constraint cannot be tested.
+            assert_eq!(check_version_compatibility(0), Ok(()));
+        } else {
+            assert_eq!(
+                check_version_compatibility(0),
+                Err(MigrationError::IncompatibleVersion {
+                    found: 0,
+                    min: MIN_SUPPORTED_VERSION,
+                    max: SCHEMA_VERSION,
+                }),
+                "version 0 must be rejected; there is no staleness window below MIN_SUPPORTED_VERSION"
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // `future` tier — SCHEMA_VERSION + 1 is rejected.
+    //
+    // Mirrors `rejects_future_epoch_one_above_current` in the orchestrator suite.
+    // Pins the symmetry of the guard around the accepted window.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn rejects_one_above_schema_version() {
+        let future = SCHEMA_VERSION + 1;
+        assert_eq!(
+            check_version_compatibility(future),
+            Err(MigrationError::IncompatibleVersion {
+                found: future,
+                min: MIN_SUPPORTED_VERSION,
+                max: SCHEMA_VERSION,
+            }),
+            "version {} (SCHEMA_VERSION + 1) must be rejected — forward versions are not accepted",
+            future
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Sweep — every value outside the accepted window produces the same typed
+    // IncompatibleVersion error with the correct min/max bounds.
+    //
+    // Includes an extreme value (u32::MAX) to catch any silent overflow
+    // or saturating-cast that could sneak into a boundary comparison.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn rejects_representative_out_of_range_versions_with_identical_error_shape() {
+        // Build a list of clearly out-of-range values.
+        // We use saturating arithmetic so this works even if SCHEMA_VERSION == 0
+        // or MIN_SUPPORTED_VERSION == u32::MAX (contrived but safe).
+        let below_range: Vec<u32> = (0..MIN_SUPPORTED_VERSION)
+            .take(3) // at most: 0, 1, 2
+            .collect();
+        let above_range: Vec<u32> = [
+            SCHEMA_VERSION.saturating_add(1),
+            SCHEMA_VERSION.saturating_add(2),
+            SCHEMA_VERSION.saturating_add(100),
+            u32::MAX,
+        ]
+        .into_iter()
+        .filter(|&v| v > SCHEMA_VERSION) // guard against SCHEMA_VERSION == u32::MAX
+        .collect();
+
+        let out_of_range: Vec<u32> = below_range
+            .into_iter()
+            .chain(above_range)
+            .collect();
+
+        for version in out_of_range {
+            let result = check_version_compatibility(version);
+            assert_eq!(
+                result,
+                Err(MigrationError::IncompatibleVersion {
+                    found: version,
+                    min: MIN_SUPPORTED_VERSION,
+                    max: SCHEMA_VERSION,
+                }),
+                "version {} outside [{}..{}] must be rejected with IncompatibleVersion \
+                 carrying the correct min/max bounds",
+                version, MIN_SUPPORTED_VERSION, SCHEMA_VERSION
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // ExportSnapshot::is_version_compatible must mirror check_version_compatibility.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn snapshot_is_version_compatible_accepts_schema_version() {
+        let snapshot = ExportSnapshot::new(
+            SnapshotPayload::RemittanceSplit(RemittanceSplitExport {
+                owner: "G".into(),
+                spending_percent: 5000,
+                savings_percent: 3000,
+                bills_percent: 1500,
+                insurance_percent: 500,
+            }),
+            ExportFormat::Json,
+        );
+        assert_eq!(snapshot.header.version, SCHEMA_VERSION);
+        assert!(
+            snapshot.is_version_compatible(),
+            "a freshly-built snapshot at SCHEMA_VERSION must pass is_version_compatible"
+        );
+    }
+
+    #[test]
+    fn snapshot_is_version_compatible_rejects_future_version() {
+        let mut snapshot = ExportSnapshot::new(
+            SnapshotPayload::RemittanceSplit(RemittanceSplitExport {
+                owner: "G".into(),
+                spending_percent: 5000,
+                savings_percent: 3000,
+                bills_percent: 1500,
+                insurance_percent: 500,
+            }),
+            ExportFormat::Json,
+        );
+        snapshot.header.version = SCHEMA_VERSION + 1;
+        assert!(
+            !snapshot.is_version_compatible(),
+            "snapshot with version SCHEMA_VERSION + 1 must fail is_version_compatible"
+        );
+    }
+
+    #[test]
+    fn snapshot_is_version_compatible_rejects_ancient_zero() {
+        if MIN_SUPPORTED_VERSION == 0 {
+            return; // version 0 is accepted; skip
+        }
+        let mut snapshot = ExportSnapshot::new(
+            SnapshotPayload::RemittanceSplit(RemittanceSplitExport {
+                owner: "G".into(),
+                spending_percent: 5000,
+                savings_percent: 3000,
+                bills_percent: 1500,
+                insurance_percent: 500,
+            }),
+            ExportFormat::Json,
+        );
+        snapshot.header.version = 0;
+        assert!(
+            !snapshot.is_version_compatible(),
+            "snapshot with version 0 must fail is_version_compatible when MIN_SUPPORTED_VERSION > 0"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // validate_for_import fires IncompatibleVersion before ChecksumMismatch
+    // (i.e. the version check is the first gate, not an afterthought).
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn validate_for_import_version_check_fires_before_checksum_check() {
+        let mut snapshot = ExportSnapshot::new(
+            SnapshotPayload::RemittanceSplit(RemittanceSplitExport {
+                owner: "G".into(),
+                spending_percent: 5000,
+                savings_percent: 3000,
+                bills_percent: 1500,
+                insurance_percent: 500,
+            }),
+            ExportFormat::Json,
+        );
+        // Set a future version AND a wrong checksum — version check must fire first.
+        snapshot.header.version = SCHEMA_VERSION + 1;
+        snapshot.header.checksum = "wrong".into();
+
+        assert_eq!(
+            snapshot.validate_for_import(),
+            Err(MigrationError::IncompatibleVersion {
+                found: SCHEMA_VERSION + 1,
+                min: MIN_SUPPORTED_VERSION,
+                max: SCHEMA_VERSION,
+            }),
+            "IncompatibleVersion must be returned before ChecksumMismatch when both are wrong"
+        );
     }
 }

--- a/docs/CROSS_CONTRACT_INVARIANTS.md
+++ b/docs/CROSS_CONTRACT_INVARIANTS.md
@@ -1,0 +1,182 @@
+# Cross-Contract Invariants
+
+## Audience
+
+This document is for **contributors** and **auditors**. It captures every invariant that spans two or more contracts in the RemitWise workspace. Each invariant names the contracts it applies to, the property that must hold, what breaks if it is violated, and where the enforcement lives in code.
+
+This knowledge was previously tribal; writing it down lets reviewers verify behaviour against documented intent without reading every commit, and lets the support team answer common questions without paging an engineer.
+
+---
+
+## 1. Remittance-Split Allocation Conservation
+
+**Contracts involved:** `remittance_split`, `savings_goals`, `bill_payments`, `insurance`
+
+**Invariant:** The sum of every category allocation produced by `remittance_split::calculate_split` must equal the `total_amount` passed in. Specifically:
+
+```
+spending + savings + bills + insurance == total_amount
+```
+
+**Why it matters:** The orchestrator routes each allocation to its target contract (`add_to_goal`, `pay_bill`, `pay_premium`). If the split does not conserve the total, one or more downstream contracts receive less than the user intended, causing silent fund loss that is invisible on-chain.
+
+**Where it is enforced:**
+- `remittance_split/src/lib.rs` — `calculate_split` assigns the rounding remainder to the last category so the sum is always exact.
+- `remittance_split` tests assert `sum(allocations) == total_amount`.
+- `scripts/verify_cross_contract_invariants.py` — offline verification script that simulates the invariant and can be run in CI.
+
+**Common breakage pattern:** Introducing a new category without updating the remainder-assignment logic. The four-category constant `10_000` (basis points) must be updated in lockstep with any new category column.
+
+---
+
+## 2. Split Percentage Normalisation (Basis Points = 10 000)
+
+**Contracts involved:** `remittance_split`, `data_migration`
+
+**Invariant:** All category percentages are stored and transmitted as basis points, and must satisfy:
+
+```
+spending_percent + savings_percent + bills_percent + insurance_percent == 10_000
+```
+
+**Why it matters:** `data_migration::validate_payload_semantics` rejects any `RemittanceSplitExport` that does not sum to exactly `10_000`. Importing a malformed split would seed corrupt on-chain state that the live contract enforces at write-time, producing a disagreement between stored state and the live validation rule.
+
+**Where it is enforced:**
+- `remittance_split/src/lib.rs` — `initialize_split` / `update_split` reject splits that do not sum to 10 000.
+- `data_migration/src/lib.rs` — `validate_payload_semantics` enforces the same rule at import time.
+
+**Common breakage pattern:** Adding a new category without subtracting from an existing one, or importing a snapshot exported from an older schema that used whole-percent values (0–100) instead of basis points.
+
+---
+
+## 3. Savings-Goal ID Counter Monotonicity
+
+**Contracts involved:** `savings_goals`, `data_migration`
+
+**Invariant:** `SavingsGoalsExport::next_id >= max(goal.id)` for all exported goals. The ID counter must never be wound back below the highest assigned goal ID.
+
+**Why it matters:** A rolled-back or forged `next_id` would allow a newly created goal to receive an ID that already exists in on-chain storage, causing a silent overwrite of the original goal's data.
+
+**Where it is enforced:**
+- `data_migration/src/lib.rs` — `validate_payload_semantics` checks this at import time and returns `MigrationError::ValidationFailed` if the counter is below the maximum observed ID.
+
+**Common breakage pattern:** Manually editing a snapshot file to reduce `next_id` (e.g. to "compact" IDs) without regenerating checksums.
+
+---
+
+## 4. Goal Completion Coherence
+
+**Contracts involved:** `savings_goals`, `reporting`
+
+**Invariant:** `current_amount <= target_amount` for every active savings goal. A goal whose current amount exceeds its target is incoherent — the `is_goal_completed` predicate would return `true` but no `GoalCompletedEvent` would have been emitted.
+
+**Where it is enforced:**
+- `savings_goals/src/lib.rs` — `add_to_goal` caps contributions at `target_amount - current_amount` and emits `GoalCompletedEvent` when the goal reaches its target.
+- `data_migration/src/lib.rs` — `validate_payload_semantics` rejects any import where a goal's `current_amount > target_amount`.
+
+**Common breakage pattern:** Directly adjusting `target_amount` downward via a migration without simultaneously checking that no goal's current balance already exceeds the new target.
+
+---
+
+## 5. Replay-Protection Consistency
+
+**Contracts involved:** `data_migration`, any on-chain contract that consumes migration imports
+
+**Invariant:** A snapshot with identity `(checksum, version)` can be applied to on-chain state at most once. The `MigrationTracker` records the timestamp of every successfully applied snapshot and rejects a second application of the same identity with `MigrationError::DuplicateImport`.
+
+**Why it matters:** Double-application of the same migration payload produces double-counted balances, double-created goals, or double-paid bills — none of which can be reversed without a rollback.
+
+**Where it is enforced:**
+- `data_migration/src/lib.rs` — `MigrationTracker::mark_imported` / `import_from_json` / `import_from_binary`.
+- `data_migration/src/lib.rs` — `verify_migration_completed` guards write entrypoints against proceeding before a migration has been marked complete; see §9 below.
+
+**Common breakage pattern:** Using `import_from_json_untracked` / `import_from_binary_untracked` in a context where the same payload might be seen more than once. These helpers use a throwaway tracker and provide no cross-call duplicate protection.
+
+---
+
+## 6. Orchestrator Epoch Guard
+
+**Contracts involved:** `orchestrator`
+
+**Invariant:** A signed remittance flow request is only accepted when `actor_epoch == current_epoch` (strict equality). Any stale (`< current`) or future (`> current`) epoch value is rejected with `OrchestratorError::EpochMismatch`.
+
+**Why it matters:** The epoch is a replay-barrier that invalidates all previously signed request hashes when the contract state changes in a breaking way (e.g. a contract upgrade or a key rotation). Without strict equality, a signed request captured before an upgrade could be replayed after it.
+
+**Where it is enforced:**
+- `orchestrator/src/lib.rs` — `verify_matching_epoch` (called from `execute_remittance_flow_signed`).
+- `orchestrator/tests/dispute_epoch_guard.rs` — boundary tests covering current, prior (−1), ancient (0 after many bumps), future (+1), and a sweep including `u64::MAX`.
+
+**Common breakage pattern:** Changing `==` to `>=` or adding a "staleness window" in the epoch check, which would allow prior-epoch tokens to be replayed.
+
+---
+
+## 7. Migration Schema Version Boundary
+
+**Contracts involved:** `data_migration`, any consumer of migration imports
+
+**Invariant:** Only schema versions in the inclusive range `[MIN_SUPPORTED_VERSION, SCHEMA_VERSION]` are accepted for import. Versions outside that range are rejected with `MigrationError::IncompatibleVersion`.
+
+**Where it is enforced:**
+- `data_migration/src/lib.rs` — `check_version_compatibility` and `ExportSnapshot::is_version_compatible`.
+- `data_migration/src/lib.rs` — `upgrade_epoch_guard` tests in `#[cfg(test)] mod upgrade_epoch_guard_tests` cover the current boundary, one below (`MIN - 1`), ancient (0), one above (`SCHEMA_VERSION + 1`), and a representative sweep.
+
+**Common breakage pattern:** Bumping `SCHEMA_VERSION` without updating `MIN_SUPPORTED_VERSION` (accepting ancient snapshots forever) or forgetting to bump `MIN_SUPPORTED_VERSION` when dropping support for old formats (accepting incompatible snapshots).
+
+---
+
+## 8. Killswitch Pause Propagation
+
+**Contracts involved:** `emergency_killswitch`, `remittance_split`, `savings_goals`, `bill_payments`, `insurance`, `family_wallet`, `orchestrator`
+
+**Invariant:** When the `emergency_killswitch` contract is in the `Paused` state, every downstream contract that calls `is_paused` must refuse all state-mutating entrypoints. No downstream contract may execute a write while the killswitch is active.
+
+**Why it matters:** The killswitch is the last line of defence in an active incident. A contract that does not honour the pause signal can continue to drain funds or corrupt state even after operators have triggered the emergency stop.
+
+**Where it is enforced:**
+- Each downstream contract calls `emergency_killswitch::is_paused` at the top of its mutating entrypoints and returns a `ContractPaused` / `EmergencyPause` error if the result is `true`.
+- `docs/PAUSE_PLAYBOOK.md` — operational runbook for triggering and clearing a pause.
+- `docs/killswitch-trust-model.md` — who can pause, who can clear, what state is preserved.
+
+**Common breakage pattern:** Adding a new mutating entrypoint and forgetting to add the pause check at the top of its body.
+
+---
+
+## 9. Migration-Completion Write Gate (`verify_migration_completed`)
+
+**Contracts involved:** `data_migration`, any contract that applies migration imports
+
+**Invariant:** Write operations on migrated state must not proceed until the migration has been explicitly marked complete. `verify_migration_completed` checks a completion flag on the `MigrationTracker` and returns `MigrationError::MigrationNotCompleted` if the flag is not set.
+
+**Why it matters:** Without a completion gate, a contract could begin accepting live writes over a partially-applied migration, producing an inconsistent mix of migrated and un-migrated data. This is especially dangerous during a batched or multi-step migration that is interrupted mid-way.
+
+**Where it is enforced:**
+- `data_migration/src/lib.rs` — `MigrationTracker::mark_completed` / `verify_migration_completed`.
+
+**Common breakage pattern:** Calling `verify_migration_completed` only on the happy path but omitting it from error-recovery paths, allowing a retried import to bypass the gate.
+
+---
+
+## Reviewer Checklist
+
+Before merging any PR that touches two or more contracts, verify:
+
+- [ ] The remittance split allocations still sum to `total_amount` (Invariant 1).
+- [ ] All category percentages still sum to `10_000` in both the live contract and `data_migration` (Invariant 2).
+- [ ] No new category was added without updating the remainder-assignment and the validation constant.
+- [ ] `next_id` is never set below the highest assigned ID in any snapshot export path (Invariant 3).
+- [ ] No goal's `current_amount` can exceed `target_amount` after the change (Invariant 4).
+- [ ] Tracked import variants are used wherever replay protection is required (Invariant 5).
+- [ ] The orchestrator epoch check still uses strict equality — not `>=` or `<=` (Invariant 6).
+- [ ] `SCHEMA_VERSION` and `MIN_SUPPORTED_VERSION` are updated in lockstep (Invariant 7).
+- [ ] Every new mutating entrypoint calls the killswitch pause check first (Invariant 8).
+- [ ] Write paths that depend on a completed migration call `verify_migration_completed` (Invariant 9).
+
+---
+
+## See Also
+
+- [`docs/PERIOD_INVARIANTS.md`](PERIOD_INVARIANTS.md) — time-bound period invariants and ledger timestamp rules
+- [`docs/AMOUNT_INVARIANTS.md`](AMOUNT_INVARIANTS.md) — zero-amount handling across contract entrypoints
+- [`docs/AUTHORIZATION_MATRIX.md`](AUTHORIZATION_MATRIX.md) — per-entrypoint caller authorization requirements
+- [`docs/MIGRATIONS.md`](MIGRATIONS.md) — how to bump a contract spec without breaking existing storage
+- [`scripts/verify_cross_contract_invariants.py`](../scripts/verify_cross_contract_invariants.py) — offline invariant verification script

--- a/testutils/tests/no_panic_in_view_fn_test.rs
+++ b/testutils/tests/no_panic_in_view_fn_test.rs
@@ -1,0 +1,394 @@
+// =========================================================================
+// Issue #1272 — require_no_panic_in_view_fn() compile-time check
+//
+// View functions (`get_*`, `is_*`) must never call `unwrap()`, `expect()`,
+// `panic!()`, or `unreachable!()` directly. Panics in view functions:
+//
+//   1. Abort the Soroban transaction unconditionally — there is no try/catch.
+//   2. Expose internal state through panic messages that are visible on-chain.
+//   3. Make "read-only" RPC calls unpredictably expensive (failed WASM
+//      execution still consumes resources).
+//
+// This module implements a `require_no_panic_in_view_fn` static analyser that
+// parses Rust source text and flags any `get_*` / `is_*` function body that
+// contains a banned panic expression. It deliberately mirrors the style of
+// `view_fn_readonly_test.rs` so both checks compose as a unified static layer.
+//
+// The analyser is intentionally simple (text-based, not AST-based) so that it
+// has no build-time dependencies beyond `std`. For production-grade enforcement
+// integrate with a `rustc` lint or a `cargo-geiger`-style tool; this check is
+// the lightweight CI tripwire.
+// =========================================================================
+
+// ---- public API -----------------------------------------------------------
+
+/// Banned patterns that must not appear inside a view-function body.
+/// Extend this list if new panic-producing macros are added to the codebase.
+pub const BANNED_PANIC_PATTERNS: &[&str] = &[
+    ".unwrap()",
+    ".expect(",
+    "panic!(",
+    "unreachable!(",
+    "todo!(",
+    "unimplemented!(",
+];
+
+/// Describes a single violation found by `require_no_panic_in_view_fn`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PanicViolation {
+    /// Name of the view function that contains the banned pattern.
+    pub fn_name: String,
+    /// The banned pattern that was detected.
+    pub pattern: String,
+}
+
+impl std::fmt::Display for PanicViolation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "PANIC VIOLATION in view fn `{}`: contains banned pattern `{}`",
+            self.fn_name, self.pattern
+        )
+    }
+}
+
+/// Scan `source` for view functions (`pub fn get_*` / `pub fn is_*`) that
+/// contain any of [`BANNED_PANIC_PATTERNS`]. Returns a list of violations.
+///
+/// A function is considered a view function if its name starts with `get_` or
+/// `is_` (matching the convention used across all contracts in this workspace).
+///
+/// The body scan is brace-balanced so inner functions, closures, and impl
+/// blocks are handled correctly.
+///
+/// # Compile-time enforcement
+///
+/// Wrap a call to this function in a `#[test]` and `assert!(violations.is_empty())`
+/// to get a compile-time-equivalent CI failure whenever a banned pattern is
+/// introduced into a view function.
+pub fn require_no_panic_in_view_fn(source: &str) -> Vec<PanicViolation> {
+    let mut violations = Vec::new();
+    let mut cursor = 0usize;
+
+    while cursor < source.len() {
+        // Find the next `pub fn` declaration.
+        let Some(rel_fn_idx) = source[cursor..].find("pub fn ") else {
+            break;
+        };
+        let fn_kw_start = cursor + rel_fn_idx;
+        let name_start = fn_kw_start + 7; // skip "pub fn "
+
+        // Extract the function name up to the first `(`.
+        let Some(rel_paren) = source[name_start..].find('(') else {
+            cursor = fn_kw_start + 7;
+            continue;
+        };
+        let fn_name = source[name_start..name_start + rel_paren].trim().to_string();
+
+        // Only inspect view functions.
+        if !fn_name.starts_with("get_") && !fn_name.starts_with("is_") {
+            cursor = fn_kw_start + 7;
+            continue;
+        }
+
+        // Extract the body by counting braces.
+        let (body, body_end) = match extract_fn_body(source, fn_kw_start) {
+            Some(result) => result,
+            None => {
+                cursor = fn_kw_start + 7;
+                continue;
+            }
+        };
+
+        // Scan the body for banned patterns.
+        for &pattern in BANNED_PANIC_PATTERNS {
+            if body.contains(pattern) {
+                violations.push(PanicViolation {
+                    fn_name: fn_name.clone(),
+                    pattern: pattern.to_string(),
+                });
+            }
+        }
+
+        cursor = body_end + 1;
+    }
+
+    violations
+}
+
+/// Extract the text of the brace-delimited body of the function starting at
+/// `fn_start`. Returns `(body_text, end_index)` where `end_index` is the
+/// position of the closing `}`.
+fn extract_fn_body(source: &str, fn_start: usize) -> Option<(String, usize)> {
+    let slice = &source[fn_start..];
+    let mut brace_count = 0i32;
+    let mut started = false;
+    let mut body_start = 0usize;
+
+    for (i, c) in slice.char_indices() {
+        match c {
+            '{' => {
+                brace_count += 1;
+                if !started {
+                    started = true;
+                    body_start = i;
+                }
+            }
+            '}' => {
+                brace_count -= 1;
+                if started && brace_count == 0 {
+                    let body = slice[body_start..=i].to_string();
+                    return Some((body, fn_start + i));
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+// ---- test fixtures --------------------------------------------------------
+
+/// A clean view function that only reads — no banned patterns.
+const CLEAN_VIEW_FN: &str = r#"
+pub fn get_balance(env: Env, key: Symbol) -> i128 {
+    env.storage().instance().get(&key).unwrap_or(0i128)
+}
+
+pub fn is_paused(env: Env) -> bool {
+    env.storage().instance().get(&symbol_short!("PAUSED")).unwrap_or(false)
+}
+"#;
+
+/// A `get_*` function that calls `.unwrap()` — violation.
+const UNWRAP_VIOLATION: &str = r#"
+pub fn get_value(env: Env, key: Symbol) -> i128 {
+    env.storage().instance().get(&key).unwrap()
+}
+"#;
+
+/// A `get_*` function that calls `.expect(...)` — violation.
+const EXPECT_VIOLATION: &str = r#"
+pub fn get_config(env: Env) -> Config {
+    env.storage().instance().get(&symbol_short!("CFG")).expect("config must exist")
+}
+"#;
+
+/// A `get_*` function that calls `panic!(...)` — violation.
+const PANIC_VIOLATION: &str = r#"
+pub fn get_owner(env: Env) -> Address {
+    let opt: Option<Address> = env.storage().instance().get(&symbol_short!("OWN"));
+    if opt.is_none() {
+        panic!("owner not set");
+    }
+    opt.unwrap()
+}
+"#;
+
+/// An `is_*` function that calls `unreachable!(...)` — violation.
+const UNREACHABLE_VIOLATION: &str = r#"
+pub fn is_valid_state(env: Env) -> bool {
+    match env.storage().instance().get(&symbol_short!("S")).unwrap_or(0u32) {
+        0 => false,
+        1 => true,
+        _ => unreachable!("unexpected state value"),
+    }
+}
+"#;
+
+/// A non-view function that calls `.unwrap()` — must NOT be flagged.
+const NON_VIEW_WITH_UNWRAP: &str = r#"
+pub fn set_owner(env: Env, new_owner: Address) {
+    let old: Option<Address> = env.storage().instance().get(&symbol_short!("OWN"));
+    let _ = old.unwrap(); // allowed: not a view function
+    env.storage().instance().set(&symbol_short!("OWN"), &new_owner);
+}
+"#;
+
+/// A `get_*` function that uses `unwrap_or` (not banned) — must NOT be flagged.
+const CLEAN_UNWRAP_OR: &str = r#"
+pub fn get_counter(env: Env) -> u32 {
+    env.storage().instance().get(&symbol_short!("CNT")).unwrap_or(0u32)
+}
+"#;
+
+/// A `get_*` function that calls `todo!()` — violation.
+const TODO_VIOLATION: &str = r#"
+pub fn get_unimplemented(env: Env) -> u32 {
+    todo!("implement this")
+}
+"#;
+
+// ---- tests ----------------------------------------------------------------
+
+/// HAPPY PATH: A clean view function with no banned patterns must produce no violations.
+#[test]
+fn clean_view_fn_produces_no_violations() {
+    let violations = require_no_panic_in_view_fn(CLEAN_VIEW_FN);
+    assert!(
+        violations.is_empty(),
+        "clean view functions must produce no violations, got:\n{}",
+        violations
+            .iter()
+            .map(|v| v.to_string())
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+}
+
+/// NEGATIVE TEST: A `get_*` function calling `.unwrap()` must be flagged.
+///
+/// This test verifies that the checker fires on the most common panic pattern.
+#[test]
+fn get_fn_with_unwrap_is_detected() {
+    let violations = require_no_panic_in_view_fn(UNWRAP_VIOLATION);
+
+    assert!(
+        !violations.is_empty(),
+        "get_* function calling .unwrap() must be flagged as a panic violation"
+    );
+    assert!(
+        violations.iter().any(|v| v.fn_name == "get_value"),
+        "violation must name the offending function 'get_value', got: {:?}",
+        violations
+    );
+    assert!(
+        violations.iter().any(|v| v.pattern == ".unwrap()"),
+        "violation must name the banned pattern '.unwrap()', got: {:?}",
+        violations
+    );
+}
+
+/// NEGATIVE TEST: A `get_*` function calling `.expect(...)` must be flagged.
+#[test]
+fn get_fn_with_expect_is_detected() {
+    let violations = require_no_panic_in_view_fn(EXPECT_VIOLATION);
+
+    assert!(
+        !violations.is_empty(),
+        "get_* function calling .expect() must be flagged"
+    );
+    assert!(
+        violations.iter().any(|v| v.fn_name == "get_config"),
+        "violation must name 'get_config'"
+    );
+    assert!(
+        violations.iter().any(|v| v.pattern.contains(".expect(")),
+        "violation must name '.expect(' as the pattern"
+    );
+}
+
+/// NEGATIVE TEST: A `get_*` function calling `panic!(...)` must be flagged.
+#[test]
+fn get_fn_with_panic_macro_is_detected() {
+    let violations = require_no_panic_in_view_fn(PANIC_VIOLATION);
+
+    assert!(
+        !violations.is_empty(),
+        "get_* function calling panic!() must be flagged"
+    );
+    let names: Vec<_> = violations.iter().map(|v| &v.fn_name).collect();
+    assert!(
+        names.contains(&&"get_owner".to_string()),
+        "violation must name 'get_owner', got: {:?}",
+        names
+    );
+}
+
+/// NEGATIVE TEST: An `is_*` function calling `unreachable!(...)` must be flagged.
+#[test]
+fn is_fn_with_unreachable_is_detected() {
+    let violations = require_no_panic_in_view_fn(UNREACHABLE_VIOLATION);
+
+    assert!(
+        !violations.is_empty(),
+        "is_* function calling unreachable!() must be flagged"
+    );
+    assert!(
+        violations.iter().any(|v| v.fn_name == "is_valid_state"),
+        "violation must name 'is_valid_state'"
+    );
+}
+
+/// NON-VIEW functions calling `.unwrap()` must NOT be flagged.
+///
+/// The checker is scoped to `get_*` and `is_*` only.
+#[test]
+fn non_view_fn_with_unwrap_is_not_flagged() {
+    let violations = require_no_panic_in_view_fn(NON_VIEW_WITH_UNWRAP);
+    assert!(
+        violations.is_empty(),
+        "non-view functions must not be flagged, got:\n{}",
+        violations
+            .iter()
+            .map(|v| v.to_string())
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+}
+
+/// `unwrap_or(...)` is NOT banned — it does not panic.
+#[test]
+fn get_fn_with_unwrap_or_is_not_flagged() {
+    let violations = require_no_panic_in_view_fn(CLEAN_UNWRAP_OR);
+    assert!(
+        violations.is_empty(),
+        "unwrap_or is not a panic pattern and must not be flagged, got: {:?}",
+        violations
+    );
+}
+
+/// NEGATIVE TEST: A `get_*` function calling `todo!()` must be flagged.
+#[test]
+fn get_fn_with_todo_is_detected() {
+    let violations = require_no_panic_in_view_fn(TODO_VIOLATION);
+
+    assert!(
+        !violations.is_empty(),
+        "get_* function calling todo!() must be flagged"
+    );
+    assert!(
+        violations.iter().any(|v| v.fn_name == "get_unimplemented"),
+        "violation must name 'get_unimplemented'"
+    );
+}
+
+/// Multiple violations in a single source are all reported (not just the first).
+#[test]
+fn multiple_violations_are_all_reported() {
+    let source = format!("{}\n{}", UNWRAP_VIOLATION, EXPECT_VIOLATION);
+    let violations = require_no_panic_in_view_fn(&source);
+
+    // At least two different function names must appear.
+    let names: std::collections::HashSet<_> = violations.iter().map(|v| &v.fn_name).collect();
+    assert!(
+        names.contains(&"get_value".to_string()),
+        "get_value must be reported"
+    );
+    assert!(
+        names.contains(&"get_config".to_string()),
+        "get_config must be reported"
+    );
+}
+
+/// PanicViolation Display message is human-readable.
+#[test]
+fn violation_display_message_is_descriptive() {
+    let v = PanicViolation {
+        fn_name: "get_balance".to_string(),
+        pattern: ".unwrap()".to_string(),
+    };
+    let msg = v.to_string();
+    assert!(
+        msg.contains("get_balance"),
+        "display must mention the function name: {msg}"
+    );
+    assert!(
+        msg.contains(".unwrap()"),
+        "display must mention the pattern: {msg}"
+    );
+    assert!(
+        msg.contains("PANIC VIOLATION"),
+        "display must include severity label: {msg}"
+    );
+}


### PR DESCRIPTION
Closes #1284 — Add docs/CROSS_CONTRACT_INVARIANTS.md
- Documents 9 invariants spanning multiple contracts: split conservation, basis-point normalisation, goal ID monotonicity, goal completion coherence, replay protection, orchestrator epoch guard, migration schema version boundary, killswitch pause propagation, and the migration-completion gate.
- Includes a reviewer checklist for PRs that touch two or more contracts.
- Linked from README.md top-level documentation index.

Closes #1281 — Add verify_migration_completed() helper (defence-in-depth)
- Adds MigrationTracker.completed flag, mark_completed(), and is_completed().
- Adds top-level verify_migration_completed() that returns MigrationError::MigrationNotCompleted until mark_completed() is called.
- Threat mitigated: prevents live writes from landing on partially-applied on-chain state during a multi-step or interrupted migration.
- Negative test (writing before completion returns MigrationNotCompleted) plus idempotency, display-message, and independence-from-imports tests.

Closes #1279 — Upgrade-epoch guard boundary tests in data_migration
- Adds upgrade_epoch_guard_tests module mirroring the orchestrator's dispute_epoch_guard.rs structure applied to the schema version boundary.
- Covers: current (SCHEMA_VERSION accepted), min boundary, prior (MIN-1 rejected), ancient (0 rejected), future (SCHEMA_VERSION+1 rejected), representative sweep including u32::MAX, and ExportSnapshot.is_version_compatible.
- Also pins that validate_for_import fires IncompatibleVersion before ChecksumMismatch (version is the first gate).

Closes #1272 — require_no_panic_in_view_fn() compile-time check
- Adds testutils/tests/no_panic_in_view_fn_test.rs.
- Implements require_no_panic_in_view_fn(source) that scans get_*/is_* function bodies for banned panic patterns: .unwrap(), .expect(, panic!(), unreachable!(), todo!(), unimplemented!().
- Negative tests for each banned pattern; positive tests confirm unwrap_or and non-view functions are not flagged.