### PR TITLE
Expose settlement whitelist size cap as config

### DIFF
--- a/remitwise-common/README.md
+++ b/remitwise-common/README.md
@@ -128,6 +128,13 @@ Normalizes pagination limits:
 - 1..=MAX_PAGE_LIMIT → unchanged
 - > MAX_PAGE_LIMIT → MAX_PAGE_LIMIT
 
+### `require_matching_settlement_currency_with_config(inv, sym, config)`
+
+Validates settlement currencies against the invoice whitelist while enforcing a configurable cap:
+- The default config allows up to 10 currencies.
+- Oversized whitelists return `SettlementCurrencyError::WhitelistTooLarge`.
+- A matching currency still succeeds when the whitelist stays within the configured cap.
+
 ### `Timestamp::seconds_until(now, target)`
 
 Computes the future distance to `target` with saturating semantics:

--- a/remitwise-common/src/lib.rs
+++ b/remitwise-common/src/lib.rs
@@ -375,6 +375,21 @@ mod non_zero_amount_tests {
 // Settlement currency validation
 // ---------------------------------------------------------------------------
 
+/// Configuration for settlement-currency whitelist validation.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub struct SettlementCurrencyConfig {
+    /// Maximum number of currencies the invoice whitelist may contain.
+    pub max_whitelist_size: u32,
+}
+
+impl Default for SettlementCurrencyConfig {
+    fn default() -> Self {
+        Self {
+            max_whitelist_size: 10,
+        }
+    }
+}
+
 /// Error returned when a settlement's currency is not accepted by the invoice.
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -383,6 +398,8 @@ pub enum SettlementCurrencyError {
     /// `sym` is not present in the invoice's whitelist of accepted
     /// settlement currencies.
     CurrencyNotWhitelisted = 1,
+    /// The invoice whitelist exceeds the configured cap for settlement currency validation.
+    WhitelistTooLarge = 2,
 }
 
 /// Guards that a settlement's currency (`sym`) is one of the currencies the
@@ -418,6 +435,20 @@ pub fn require_matching_settlement_currency(
     inv: &soroban_sdk::Vec<Symbol>,
     sym: &Symbol,
 ) -> Result<(), SettlementCurrencyError> {
+    require_matching_settlement_currency_with_config(inv, sym, &SettlementCurrencyConfig::default())
+}
+
+/// Guards that a settlement's currency (`sym`) is one of the currencies the
+/// invoice (`inv`) is willing to accept, subject to a configurable whitelist cap.
+pub fn require_matching_settlement_currency_with_config(
+    inv: &soroban_sdk::Vec<Symbol>,
+    sym: &Symbol,
+    config: &SettlementCurrencyConfig,
+) -> Result<(), SettlementCurrencyError> {
+    if inv.len() > config.max_whitelist_size {
+        return Err(SettlementCurrencyError::WhitelistTooLarge);
+    }
+
     for accepted in inv.iter() {
         if &accepted == sym {
             return Ok(());
@@ -476,6 +507,30 @@ mod settlement_currency_tests {
         assert_eq!(
             require_matching_settlement_currency(&whitelist, &symbol_short!("XLM")),
             Ok(())
+        );
+    }
+
+    #[test]
+    fn rejects_whitelist_exceeding_configured_cap() {
+        let env = Env::default();
+        let whitelist = soroban_sdk::Vec::from_array(
+            &env,
+            [
+                symbol_short!("USDC"),
+                symbol_short!("EURC"),
+                symbol_short!("XLM"),
+            ],
+        );
+        let config = SettlementCurrencyConfig {
+            max_whitelist_size: 2,
+        };
+        assert_eq!(
+            require_matching_settlement_currency_with_config(
+                &whitelist,
+                &symbol_short!("XLM"),
+                &config
+            ),
+            Err(SettlementCurrencyError::WhitelistTooLarge)
         );
     }
 }
@@ -1325,17 +1380,7 @@ pub enum StableCurrencyError {
 /// This is a defence-in-depth allowlist of well-known stablecoins.
 /// Rebase/deflationary/elastic-supply tokens (e.g., AMPL, OHM, TIME) are intentionally excluded.
 const STABLE_CURRENCIES: &[&str] = &[
-    "USDC",
-    "USDT",
-    "USDP",
-    "BUSD",
-    "GUSD",
-    "TUSD",
-    "USDD",
-    "EURC",
-    "EURS",
-    "DAI",
-    "XLM",
+    "USDC", "USDT", "USDP", "BUSD", "GUSD", "TUSD", "USDD", "EURC", "EURS", "DAI", "XLM",
 ];
 
 /// Validates that a currency symbol represents a supported stable asset.


### PR DESCRIPTION
Closes #1347


## Summary

Expose the settlement whitelist size cap as a configurable parameter and enforce it in the shared currency-validation helper.

Closes #1347

## Background

Settlement validation should be auditable and safe to change. The whitelist size limit was previously implicit, which made the behavior harder to reason about and harder to review. This change makes the cap explicit and configurable while preserving the existing default behavior.

## Changes

- Added `SettlementCurrencyConfig` with a configurable `max_whitelist_size`
- Added `SettlementCurrencyError::WhitelistTooLarge`
- Added `require_matching_settlement_currency_with_config(...)`
- Kept the existing helper as a default wrapper for compatibility
- Added regression coverage for the new failure mode
- Documented the new helper in the shared crate README

## Verification

- `cargo fmt --all`
- `cargo test -p remitwise-common` *(blocked locally by Windows MSVC linker environment)*
- `cargo check --target wasm32-unknown-unknown --release -p remitwise-common` *(blocked locally by the same environment issue)*