### PR TITLE
docs: add RESERVED_STORAGE_KEYS.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ To run an example, use `cargo run --example <example_name>`:
 - [String and Bytes Canonicalisation](docs/CANONICALISATION.md) - Tag casefold, currency trim/uppercase, external-ref charset, and migration checksum byte-order
 - [Type-Safe Percent Conversion](docs/type-safe-percent-conversion.md) - Converting whole percentages to basis points with checked overflow arithmetic
 - [Storage Layout Reference](STORAGE_LAYOUT.md)
+- [Reserved Storage Keys](docs/RESERVED_STORAGE_KEYS.md) - Storage keys reserved for roadmap features to prevent collisions (contributor guide)
 - [Contract Specs & Migrations](docs/MIGRATIONS.md) - How to bump a contract spec without breaking existing storage
 - [Event Indexer](indexer/README.md) - Off-chain event indexing and querying
 - [Audit Trail](docs/AUDIT_TRAIL.md) - How to reconstruct historical state from events alone

--- a/docs/RESERVED_STORAGE_KEYS.md
+++ b/docs/RESERVED_STORAGE_KEYS.md
@@ -1,0 +1,55 @@
+# Reserved Storage Keys
+
+**Audience: Contributors**
+
+This document tracks storage keys in the Remitwise smart contracts that are **reserved for future use**. As a contributor, you must **not** use these keys for new features, temporary variables, or migrations. Using these keys will cause storage collisions when the planned features are rolled out.
+
+## Why are these keys reserved?
+
+We reserve keys ahead of time for roadmap features (e.g., yield generation, staking, advanced access control) to ensure that the storage layout remains contiguous and collision-free. Reviewers will reject PRs that attempt to store data under these namespaces.
+
+## List of Reserved Keys
+
+All reserved keys follow the [Storage Key Naming Conventions](storage-key-naming-conventions.md) (UPPERCASE_WITH_UNDERSCORES, max 9 characters).
+
+| Reserved Key | Intended Future Feature | Do Not Use Because... |
+|--------------|-------------------------|------------------------|
+| `YIELD_CFG`  | Yield Generation V2 | Will store the configuration for external yield integration protocols. |
+| `STAKE_POL`  | Staking & Rewards | Planned for the staking mechanism where users earn rewards on saved balances. |
+| `REWARD_CF`  | Staking & Rewards | Reserved for the reward emission rate and token configuration. |
+| `V2_MIGR`    | Next-Gen Migration | Reserved as a staging pointer for when the V2 contracts are deployed. |
+| `TMP_LOCK`   | Advanced Time-Locks | Will handle multi-phase time-locks for family wallet large withdrawals. |
+
+## Concrete Examples
+
+If you are adding a feature for "Notification Preferences", do **not** use a reserved key like `REWARD_CF` or a generic key that might collide with future features.
+
+**❌ Incorrect: Using a reserved or generic key**
+```rust
+use soroban_sdk::{symbol_short, Env, Symbol};
+
+// DO NOT USE - this is a reserved key for staking features!
+const KEY_REWARD: Symbol = symbol_short!("REWARD_CF"); 
+
+pub fn set_notification(env: Env, enabled: bool) {
+    env.storage().instance().set(&KEY_REWARD, &enabled);
+}
+```
+
+**✅ Correct: Using an isolated, descriptive key**
+```rust
+use soroban_sdk::{symbol_short, Env, Symbol};
+
+const KEY_NOTIF: Symbol = symbol_short!("NOTIF_CFG");
+
+pub fn set_notification(env: Env, enabled: bool) {
+    env.storage().instance().set(&KEY_NOTIF, &enabled);
+}
+```
+
+## Reviewer Verification
+
+When reviewing PRs, verify that:
+1. No `symbol_short!` macro invocation uses a key from the table above.
+2. The storage layout tests in `testutils/tests/storage_key_naming_test.rs` are passing.
+3. If the PR implements the future feature for a reserved key, the key is removed from this document and added to the [Storage Key Naming Conventions](storage-key-naming-conventions.md#common-storage-keys) table.

--- a/docs/storage-key-naming-conventions.md
+++ b/docs/storage-key-naming-conventions.md
@@ -221,6 +221,7 @@ const KEY_rate_lim: Symbol = symbol_short!("rate_lim");  // lowercase - wrong fo
 ## References
 
 - [STORAGE_LAYOUT.md](../STORAGE_LAYOUT.md) - Complete storage layout documentation
+- [RESERVED_STORAGE_KEYS.md](RESERVED_STORAGE_KEYS.md) - Keys reserved for future roadmap features
 - [Soroban Storage Documentation](https://developers.stellar.org/docs/build/smart-contracts/example-contracts/storage)
 - [Soroban Symbol Documentation](https://docs.rs/soroban-sdk/latest/soroban_sdk/struct.Symbol.html)
 


### PR DESCRIPTION
Closes #1274 

## Summary
Adds `docs/RESERVED_STORAGE_KEYS.md` to document storage keys that are reserved for future roadmap features (such as yield generation, staking, and advanced access control). 

## Background
We rely on this information internally but it was previously tribal knowledge. Writing it down lets reviewers verify behavior against the documented intent, helps new contributors get productive without reading every commit, and ensures our storage layout remains contiguous and collision-free.

## Changes Made
- Added `docs/RESERVED_STORAGE_KEYS.md` targeting contributors.
- Provided concrete examples showing a reserved key vs. an acceptable isolated key.
- Cross-linked the new document from the root `README.md` and `docs/storage-key-naming-conventions.md`.

## Verification
- [x] Document is cross-linked from existing top-level documentation (`README.md`).
- [x] Examples in the document are syntactically valid.
- [x] Linting and type-checks pass locally.