### PR TITLE
docs: add docs/PERIOD_KEYS.md — model + consumer contract for period_key

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This workspace contains the core smart contracts that power RemitWise's post-rem
 - **[emergency_killswitch](emergency_killswitch/README.md)**: Centralized emergency pause controls across contracts
 - **[remitwise-common](remitwise-common/README.md)**: Shared types and utilities used across contracts
 - **[docs/PERIOD_INVARIANTS.md](docs/PERIOD_INVARIANTS.md)**: Time-bound period invariants, ledger timestamp rules, and execution windows
+- **[docs/PERIOD_KEYS.md](docs/PERIOD_KEYS.md)**: Model + consumer contract for `period_key` period identifiers and report storage
 - **[docs/AMOUNT_INVARIANTS.md](docs/AMOUNT_INVARIANTS.md)**: Amount zero-handling rules across contract entrypoints
 
 ## Shared Components

--- a/docs/CONTRIBUTOR_OVERVIEW.md
+++ b/docs/CONTRIBUTOR_OVERVIEW.md
@@ -121,6 +121,7 @@ Before opening a pull request, run the following verification steps locally:
 * [Architecture Overview](../ARCHITECTURE.md)
 * [Storage Layout Reference](../STORAGE_LAYOUT.md)
 * [Period Invariants Specifications](PERIOD_INVARIANTS.md)
+* [Period Keys Specification](PERIOD_KEYS.md)
 * [Amount Invariants Specifications](AMOUNT_INVARIANTS.md)
 * [Authorization Matrix](AUTHORIZATION_MATRIX.md)
 * [Invoice Settlement Windows](SETTLEMENT_WINDOWS.md)

--- a/docs/PERIOD_KEYS.md
+++ b/docs/PERIOD_KEYS.md
@@ -1,0 +1,184 @@
+# Period Keys Specification: Model + Consumer Contract
+
+This document provides the canonical specification for **Period Keys** (`period_key`) within the RemitWise smart contract workspace.
+
+---
+
+## Audience
+
+This document is written for **downstream integrators** (frontend developers, indexers, analytics pipelines, off-chain reconciliation engines) and **contract contributors** interacting with or maintaining period-bound reporting and financial metrics in RemitWise contracts.
+
+---
+
+## 1. Overview & Purpose
+
+In RemitWise, financial health scoring, spending history tracking, micro-insurance premium auditing, and recurring remittance analytics operate across discrete time windows. To scope state data cleanly without locking contracts to a rigid calendar schedule, contracts use a **Period Key** (`period_key`).
+
+A `period_key` is a 64-bit unsigned integer (`u64`) that acts as a unique temporal identifier for a specific accounting or reporting window.
+
+---
+
+## 2. Model Contract (Data Structure & Types)
+
+### 2.1 Primitive Type & Storage Representation
+
+- **Type:** `u64` (native Soroban SDK integer primitive).
+- **Storage Pattern (Composite Keying):**
+  In contract instance storage (e.g., the `reporting` contract), active reports are stored in a Soroban `Map` using a composite tuple key:
+  
+  $$\text{Key}: (\text{Address}, \text{u64}) \longrightarrow \text{Value}: \text{FinancialHealthReport}$$
+
+```rust
+// Storage layout in reporting/src/lib.rs
+// Map<(Address, u64), FinancialHealthReport>
+let mut reports: Map<(Address, u64), FinancialHealthReport> = env
+    .storage()
+    .instance()
+    .get(&symbol_short!("REPORTS"))
+    .unwrap_or_else(|| Map::new(&env));
+```
+
+### 2.2 Domain Structs & Event Payload References
+
+1. **`ArchivedReport` Struct (`reporting` crate):**
+   ```rust
+   #[contracttype]
+   #[derive(Clone)]
+   pub struct ArchivedReport {
+       pub user: Address,
+       pub period_key: u64,
+       pub health_score: u32,
+       pub generated_at: u64,
+       pub archived_at: u64,
+   }
+   ```
+2. **Financial History Tuples:**
+   In reporting calculations, historical financial entries are represented as tuples of `(period_key, amount)`:
+   ```rust
+   // history: Vec<(u64, i128)>
+   let history_entry: (u64, i128) = (202607u64, 150_0000000i128);
+   ```
+3. **Event Topic & Payload:**
+   ```rust
+   // Published upon report storage:
+   env.events().publish(
+       (symbol_short!("report"), ReportEvent::ReportStored),
+       (user, period_key),
+   );
+   ```
+
+### 2.3 Recommended Period Key Encoding Schemes
+
+The `period_key` parameter is caller-defined to allow flexible integration with diverse business calendars. Downstream integrators must adopt a consistent encoding convention across their system.
+
+| Calendar Granularity | Recommended Format | Format Description | Concrete Example (`period_key`) |
+| :--- | :--- | :--- | :--- |
+| **Monthly** | `YYYYMM` | Numeric Year + 2-digit Month | `202607` (July 2026) |
+| **Daily** | `YYYYMMDD` | Numeric Year + Month + Day | `20260725` (July 25, 2026) |
+| **Unix Epoch Window** | `u64` Timestamp | Start boundary timestamp in seconds | `1704067200` (2024-01-01T00:00:00Z) |
+
+---
+
+## 3. Consumer Contract (API Entrypoints & Guarantees)
+
+### 3.1 Public Entrypoints (`reporting` Contract)
+
+Downstream integrators interact with `period_key` primarily through the `reporting` contract entrypoints:
+
+#### `store_report(env, user, report, period_key) -> bool`
+- **Parameters:**
+  - `user: Address`: Target account owner. Requires `user.require_auth()`.
+  - `report: FinancialHealthReport`: Complete health report payload.
+  - `period_key: u64`: Temporal key for the report.
+- **Behavior:**
+  - Validates `user` authorization.
+  - Writes/overwrites the record under `(user, period_key)` in active instance storage.
+  - Emits event topic `(symbol_short!("report"), ReportEvent::ReportStored)` with payload `(user, period_key)`.
+  - Returns `true` on successful persistence.
+
+#### `get_stored_report(env, _caller, user, period_key) -> Option<FinancialHealthReport>`
+- **Parameters:**
+  - `_caller: Address`: Caller address (reserved).
+  - `user: Address`: Account owner to query. Requires `user.require_auth()`.
+  - `period_key: u64`: Specific period key to look up.
+- **Behavior:**
+  - Returns `Some(FinancialHealthReport)` if an active report exists for `(user, period_key)`.
+  - Returns `None` if no report has been submitted for that period key.
+
+---
+
+### 3.2 Guarantees & Constraints
+
+1. **User Key Isolation:**
+   Because storage keys are composite tuples `(user, period_key)`, User A cannot overwrite or access User B's report data, regardless of whether they pass identical `period_key` values.
+
+2. **Idempotent Overwrites:**
+   Calling `store_report` multiple times with the same `(user, period_key)` will update the report payload in-place for that period key, replacing the previous active report.
+
+3. **Stateless Period Range Validation:**
+   When verifying period boundaries (start and end timestamps associated with a `period_key`), contracts enforce `remitwise_common::validate_period(start, end)`, returning `Err(TimeError::InvalidPeriod)` if `start > end`.
+
+4. **`#![no_std]` Strict Discipline:**
+   All `period_key` logic relies strictly on `u64` primitives and `soroban_sdk` structures. No heap-allocated `std` time primitives or floating-point conversions are used.
+
+---
+
+## 4. Concrete Code Examples
+
+### 4.1 Rust Client Interaction (Soroban SDK)
+
+The following example demonstrates how a downstream service or integration test calls the `reporting` contract using Soroban SDK client bindings:
+
+```rust
+use soroban_sdk::{Env, Address, testutils::Address as _};
+use reporting::{ReportingContractClient, FinancialHealthReport};
+
+pub fn record_monthly_report(
+    env: &Env,
+    contract_id: &Address,
+    user: &Address,
+) {
+    let client = ReportingContractClient::new(env, contract_id);
+
+    // Construct a period key for July 2026 (YYYYMM format)
+    let period_key: u64 = 202607;
+
+    // Build report payload
+    let report = FinancialHealthReport {
+        overall_score: 85,
+        savings_health: 90,
+        bill_punctuality: 80,
+        insurance_coverage: 85,
+        generated_at: env.ledger().timestamp(),
+    };
+
+    // Store report under (user, period_key)
+    let success = client.store_report(user, &report, &period_key);
+    assert!(success);
+
+    // Retrieve report by period_key
+    let fetched = client.get_stored_report(user, user, &period_key);
+    assert!(fetched.is_some());
+    assert_eq!(fetched.unwrap().overall_score, 85);
+}
+```
+
+### 4.2 Indexer Event Subscription Pattern
+
+Off-chain indexers monitoring the Stellar ledger parse `report` events to index reports by `period_key`:
+
+```text
+Event Topic 0: Symbol("report")
+Event Topic 1: Symbol("ReportStored")
+Event Data:    (Address(user), u64(period_key))
+```
+
+Indexers can query off-chain databases using `SELECT * FROM health_reports WHERE user_address = ? AND period_key = ?`.
+
+---
+
+## 5. Related Specifications
+
+- **[docs/PERIOD_INVARIANTS.md](PERIOD_INVARIANTS.md)**: Rules governing `env.ledger().timestamp()`, deadline windows, and grace periods across contracts.
+- **[docs/PERIOD_LIFECYCLE.md](PERIOD_LIFECYCLE.md)**: Four-state machine (`Open` $\rightarrow$ `Active` $\rightarrow$ `Closing` $\rightarrow$ `Archived`) for operational settlement periods.
+- **[docs/validate-period.md](validate-period.md)**: Logical range validation utility (`validate_period`).

--- a/integration_tests/tests/orchestrated_multisig_flow.rs
+++ b/integration_tests/tests/orchestrated_multisig_flow.rs
@@ -63,6 +63,7 @@ fn test_orchestrated_multisig_flow() {
     // Set low spending limit for user to force multisig/role change
     family_wallet_client
         .try_update_spending_limit(&admin, &user, &100i128)
+        .unwrap()
         .unwrap();
 
     let mock_usdc = Address::generate(&env);

--- a/remitwise-common/src/lib.rs
+++ b/remitwise-common/src/lib.rs
@@ -786,6 +786,12 @@ impl ToI128Checked for i32 {
 /// so that integer arithmetic can be used without floating point.
 pub const BASIS_POINTS: u32 = 10_000;
 
+/// Basis points per whole percentage point: 100 basis points = 1%.
+pub const BPS_PER_PERCENT: u32 = 100;
+
+/// Alias for BPS_PER_PERCENT for readability across crates.
+pub const BASIS_POINTS_PER_PERCENT: u32 = BPS_PER_PERCENT;
+
 /// Supported units for externally supplied rate inputs.
 ///
 /// Remitwise contracts currently accept only basis points. Treating a raw rate
@@ -921,6 +927,22 @@ impl Rate {
     #[inline(always)]
     pub fn from_bps(bps: u32) -> Self {
         Self(bps)
+    }
+
+    /// Create a `Rate` from a whole percentage value.
+    ///
+    /// Returns `Ok(Rate)` if `percent * 100` fits in `u32`, or `Err(RateError::Overflow)` otherwise.
+    pub fn from_percent(percent: u32) -> Result<Self, RateError> {
+        percent
+            .checked_mul(BPS_PER_PERCENT)
+            .map(Self::from_bps)
+            .ok_or(RateError::Overflow)
+    }
+
+    /// Create a `Rate` from a typed [`Percent`] value.
+    #[inline(always)]
+    pub fn from_percent_type(percent: Percent) -> Result<Self, RateError> {
+        Self::from_percent(percent.to_percentage())
     }
 
     /// Construct a `Rate` from an externally supplied raw value plus unit.

--- a/reporting/README.md
+++ b/reporting/README.md
@@ -5,7 +5,7 @@ Aggregates financial health data from the remittance_split, savings_goals, bill_
 ## Features
 
 - Generate financial health reports (health score, remittance summary, savings, bills, insurance)
-- Store and retrieve reports per `(user, period_key)`
+- Store and retrieve reports per `(user, period_key)` (see [`docs/PERIOD_KEYS.md`](../docs/PERIOD_KEYS.md) for period key specification)
 - Admin-only archival and cleanup of old reports
 - Storage TTL management (instance: ~30 days, archive: ~180 days)
 


### PR DESCRIPTION
Closes #1233

## Summary

Adds `docs/PERIOD_KEYS.md`, the canonical specification for `period_key` period identifiers across RemitWise smart contracts. This document ends the tribal-knowledge gap by writing down everything reviewers, contributors, and the support team need to understand how period keys work and how to use them.

**Audience:** downstream integrators (frontend developers, indexers, analytics pipelines, off-chain reconciliation engines).

---

## What Changed

### New File: `docs/PERIOD_KEYS.md`
Covers the full model + consumer contract:
- **Model contract:** `u64` primitive type, composite storage keying `(Address, u64)` → `FinancialHealthReport` in the `reporting` contract, struct references (`ArchivedReport`, history tuples), and event topic / payload format (`ReportEvent::ReportStored`)
- **Recommended encoding schemes:** `YYYYMM`, `YYYYMMDD`, Unix epoch timestamp with a reference table
- **Consumer contract:** public entrypoints (`store_report`, `get_stored_report`), guarantees (user key isolation, idempotent overwrites, stateless range validation)
- **Invariants:** `#![no_std]` discipline confirmed — no `std::` heap-allocated time primitives
- **Concrete Rust client integration example** using Soroban SDK bindings
- **Indexer event subscription pattern**
- **Related specs cross-links:** `PERIOD_INVARIANTS.md`, `PERIOD_LIFECYCLE.md`, `validate-period.md`

### Updated: `remitwise-common/src/lib.rs`
- Added `BPS_PER_PERCENT: u32 = 100` and `BASIS_POINTS_PER_PERCENT` constants (required by existing `Percent` / `Rate` code that referenced them but they were missing from the module scope)
- Added `Rate::from_percent(percent: u32) -> Result<Self, RateError>` method
- Added `Rate::from_percent_type(percent: Percent) -> Result<Self, RateError>` method

### Updated: documentation cross-links
- `README.md` — linked `docs/PERIOD_KEYS.md` in the Overview table
- `docs/CONTRIBUTOR_OVERVIEW.md` — linked under Related Documentation
- `reporting/README.md` — linked inline next to the `(user, period_key)` feature bullet

### Updated: `integration_tests/tests/orchestrated_multisig_flow.rs`
- Fixed pre-existing clippy warning: unused `Result` from `try_update_spending_limit` now explicitly unwrapped (was causing `-D unused-must-use` failure under `-D warnings`)

---

## Key Design Decisions

- **Audience is downstream integrators**, not all three audiences at once — the doc focuses on the API contract (what values to pass, what to expect back) rather than internal invariants (those live in `PERIOD_INVARIANTS.md`).
- **caller-defined `u64` encoding** is documented with three concrete encoding conventions so integrators can pick one and document their choice consistently.
- **No new dependencies introduced** — all examples use existing Soroban SDK primitives.

---

## Acceptance Criteria Checklist

- [x] The change matches the summary (Model + Consumer contract for `period_key`)
- [x] `docs/PERIOD_KEYS.md` linked from `README.md`, `docs/CONTRIBUTOR_OVERVIEW.md`, and `reporting/README.md`
- [x] Code examples in the doc are syntactically valid Soroban Rust SDK code (no `foo()` placeholders)
- [x] `cargo build --target wasm32-unknown-unknown --release` passes
- [x] `cargo test -p reporting` passes (165 unit + 12 gas bench + 4 insurance ratio tests)
- [x] `cargo clippy --workspace -- -D warnings` passes

---

## Test Output

```
test result: ok. 165 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 57.48s
test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.92s (gas_bench)
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.39s (insurance_report_ratio)
```

`cargo clippy --workspace -- -D warnings`: Finished `dev` profile — no warnings, no errors.

---

## Follow-up (out of scope for this PR)

- Pre-existing `emit_tests.rs` and `canonicalise_symbol` failures in `remitwise-common` test target (failing since before this PR, tracked separately in AGENTS.md)