### PR TITLE
feat: expose current fee schedule via view fn (Closes #1348)

### DIFF
--- a/orchestrator/src/lib.rs
+++ b/orchestrator/src/lib.rs
@@ -19,6 +19,7 @@ mod interface {
     #[contractclient(name = "RemittanceSplitClient")]
     pub trait RemittanceSplitInterface {
         fn calculate_split(env: Env, total_amount: i128) -> Vec<i128>;
+        fn get_split(env: Env) -> Vec<u32>;
     }
 
     #[contractclient(name = "SavingsGoalsClient")]
@@ -698,6 +699,34 @@ impl Orchestrator {
     pub fn get_execution_stats(env: Env) -> Option<ExecutionStats> {
         Self::extend_instance_ttl(&env);
         env.storage().instance().get(&symbol_short!("STATS"))
+    }
+
+    /// Get the current fee schedule (split percentages) from the remittance split contract.
+    ///
+    /// Returns a tuple of (spending_percent, savings_percent, bills_percent, insurance_percent)
+    /// representing the percentage allocation for each category. The percentages are
+    /// in basis points (1% = 100 basis points).
+    ///
+    /// This is a read-only view function that does not require authorization.
+    pub fn get_fee_schedule(env: Env) -> Option<(u32, u32, u32, u32)> {
+        let rs_addr: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("RS_ADDR"))?;
+
+        let rs_client = interface::RemittanceSplitClient::new(&env, &rs_addr);
+        let split = rs_client.get_split();
+
+        if split.len() != 4 {
+            return None;
+        }
+
+        Some((
+            split.get(0)?,
+            split.get(1)?,
+            split.get(2)?,
+            split.get(3)?,
+        ))
     }
 
     /// Claim accrued rewards and transfer them from the reward-token contract

--- a/orchestrator/src/test.rs
+++ b/orchestrator/src/test.rs
@@ -2549,3 +2549,105 @@ fn bump_actor_epoch_overflow_returns_error() {
     // Epoch must remain at u64::MAX — the bump must not have mutated storage.
     assert_eq!(client.get_actor_epoch_public(), u64::MAX);
 }
+
+// ---------------------------------------------------------------------------
+// get_fee_schedule view function tests
+// ---------------------------------------------------------------------------
+
+/// Mock remittance split contract that returns a fixed split.
+mod mock_remittance_split {
+    use soroban_sdk::{contract, contractimpl, Env, Vec};
+
+    #[contract]
+    pub struct Contract;
+
+    #[contractimpl]
+    impl Contract {
+        pub fn get_split(env: Env) -> Vec<u32> {
+            soroban_sdk::vec![&env, 5000u32, 3000u32, 1500u32, 500u32]
+        }
+        pub fn calculate_split(env: Env, _total_amount: i128) -> Vec<i128> {
+            soroban_sdk::vec![&env, 5000i128, 3000i128, 1500i128, 500i128]
+        }
+    }
+}
+
+/// Mock remittance split contract that returns an invalid split (wrong length).
+mod mock_remittance_split_invalid {
+    use soroban_sdk::{contract, contractimpl, Env, Vec};
+
+    #[contract]
+    pub struct Contract;
+
+    #[contractimpl]
+    impl Contract {
+        pub fn get_split(env: Env) -> Vec<u32> {
+            soroban_sdk::vec![&env, 5000u32, 3000u32] // Only 2 entries
+        }
+        pub fn calculate_split(env: Env, _total_amount: i128) -> Vec<i128> {
+            soroban_sdk::vec![&env, 5000i128, 3000i128]
+        }
+    }
+}
+
+#[test]
+fn test_get_fee_schedule_returns_correct_split() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let orchestrator_id = env.register_contract(None, Orchestrator);
+    let client = OrchestratorClient::new(&env, &orchestrator_id);
+    let owner = Address::generate(&env);
+
+    // Initialize with a mock remittance split contract
+    let fw = env.register_contract(None, MockContract);
+    let rs = env.register_contract(None, mock_remittance_split::Contract);
+    let sg = env.register_contract(None, MockContract);
+    let bp = env.register_contract(None, MockContract);
+    let ins = env.register_contract(None, MockContract);
+    client.init(&owner, &fw, &rs, &sg, &bp, &ins);
+
+    // Call the view function
+    let result = client.get_fee_schedule();
+
+    assert!(result.is_some(), "fee schedule should be Some");
+    let (spending, savings, bills, insurance) = result.unwrap();
+    assert_eq!(spending, 5000);
+    assert_eq!(savings, 3000);
+    assert_eq!(bills, 1500);
+    assert_eq!(insurance, 500);
+    // Sum should be 10000 (100%)
+    assert_eq!(spending + savings + bills + insurance, 10000);
+}
+
+#[test]
+fn test_get_fee_schedule_returns_none_when_invalid_split() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let orchestrator_id = env.register_contract(None, Orchestrator);
+    let client = OrchestratorClient::new(&env, &orchestrator_id);
+    let owner = Address::generate(&env);
+
+    // Initialize with a mock remittance split that returns invalid length
+    let fw = env.register_contract(None, MockContract);
+    let rs = env.register_contract(None, mock_remittance_split_invalid::Contract);
+    let sg = env.register_contract(None, MockContract);
+    let bp = env.register_contract(None, MockContract);
+    let ins = env.register_contract(None, MockContract);
+    client.init(&owner, &fw, &rs, &sg, &bp, &ins);
+
+    // Call the view function - should return None for invalid split
+    let result = client.get_fee_schedule();
+    assert!(result.is_none(), "fee schedule should be None for invalid split");
+}
+
+#[test]
+fn test_get_fee_schedule_returns_none_when_not_initialized() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let orchestrator_id = env.register_contract(None, Orchestrator);
+    let client = OrchestratorClient::new(&env, &orchestrator_id);
+
+    // Don't initialize - should return None
+    let result = client.get_fee_schedule();
+    assert!(result.is_none(), "fee schedule should be None when not initialized");
+}


### PR DESCRIPTION
Add get_fee_schedule view function to orchestrator that reads the current split percentages from the remittance split contract.

Changes:
- orchestrator/src/lib.rs: Added get_split to RemittanceSplitInterface trait, implemented get_fee_schedule
- orchestrator/src/test.rs: Added tests for valid/invalid/uninitialized cases

Closes #1348