### PR TITLE
fix: block state destruction while pending operations exist

### DIFF
--- a/family_wallet/src/lib.rs
+++ b/family_wallet/src/lib.rs
@@ -398,6 +398,12 @@ pub enum Error {
     /// percentages do not sum to exactly 100.
     InvalidSplitConfig = 25,
     SnapshotTooOld = 26,
+    /// The requested destructive state change (member removal, multisig
+    /// reconfiguration) was rejected because the wallet has pending
+    /// multisig proposals.  Allowing the change while proposals are
+    /// in-flight could cause orphaned signatures, silently-invalid quorum
+    /// calculations, or execution against stale configuration.
+    PendingOperationsExist = 27,
 }
 
 #[contractimpl]
@@ -729,6 +735,10 @@ impl FamilyWallet {
     ) -> Result<bool, Error> {
         caller.require_auth();
         Self::require_not_paused(&env);
+
+        // Defence-in-depth: block reconfiguration while multisig proposals are
+        // in-flight to prevent execution against stale threshold / signer set.
+        Self::require_no_pending_operations(&env)?;
 
         let members: Map<Address, FamilyMember> = env
             .storage()
@@ -1397,6 +1407,11 @@ impl FamilyWallet {
     pub fn remove_family_member(env: Env, caller: Address, member: Address) -> bool {
         caller.require_auth();
         Self::require_not_paused(&env);
+
+        // Defence-in-depth: block removal while multisig proposals are in-flight
+        // to prevent orphaned signatures and stale quorum calculations.
+        Self::require_no_pending_operations(&env)
+            .unwrap_or_else(|e| panic_with_error!(&env, e));
 
         let owner: Address = env
             .storage()
@@ -3433,6 +3448,24 @@ impl FamilyWallet {
         if Self::get_global_paused(env) {
             panic!("Contract is paused");
         }
+    }
+
+    /// Reject the call when the wallet has pending multisig proposals.
+    ///
+    /// Destructive state changes (member removal, multisig reconfiguration)
+    /// while proposals are in-flight risk orphaned signatures, silently
+    /// invalid quorum calculations, or execution against stale configuration.
+    fn require_no_pending_operations(env: &Env) -> Result<(), Error> {
+        let pending_txs: Map<u64, PendingTransaction> = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("PEND_TXS"))
+            .unwrap_or_else(|| Map::new(env));
+
+        if pending_txs.len() > 0 {
+            return Err(Error::PendingOperationsExist);
+        }
+        Ok(())
     }
 
     fn extend_instance_ttl(env: &Env) {

--- a/family_wallet/src/test.rs
+++ b/family_wallet/src/test.rs
@@ -7951,3 +7951,96 @@ fn slashed_funds_route_to_current_recipient_not_stale_destination() {
         "owner must lose exactly two slash amounts",
     );
 }
+
+// ─── Pending-operations guard (defence-in-depth) ───────────────────────────
+// Destructive state changes must be rejected while multisig proposals are
+// in-flight to prevent orphaned signatures, stale quorum calculations, or
+// execution against an outdated signer set / threshold.
+
+/// Helper: set up a wallet with multisig configs and create one pending proposal.
+fn setup_wallet_with_pending_proposal() -> (Env, FamilyWalletClient<'static>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, FamilyWallet);
+    let client = FamilyWalletClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let member1 = Address::generate(&env);
+    let member2 = Address::generate(&env);
+    let initial_members = vec![&env, member1.clone(), member2.clone()];
+
+    client.init(&owner, &initial_members);
+
+    // Configure multisig for EmergencyTransfer (3-of-3) so propose_emergency_transfer works
+    let all_members = vec![&env, owner.clone(), member1.clone(), member2.clone()];
+    client.configure_multisig(
+        &owner,
+        &TransactionType::RegularWithdrawal,
+        &1,
+        &all_members,
+        &1000_0000000,
+    );
+    client.configure_multisig(
+        &owner,
+        &TransactionType::EmergencyTransfer,
+        &3,
+        &all_members,
+        &0,
+    );
+
+    // Set up token so the proposal can be created
+    let token_admin = Address::generate(&env);
+    let token_contract = env.register_stellar_asset_contract_v2(token_admin.clone());
+    StellarAssetClient::new(&env, &token_contract.address()).mint(&owner, &5000_0000000);
+
+    // Create a pending proposal — this populates PEND_TXS
+    let recipient = Address::generate(&env);
+    client.propose_emergency_transfer(
+        &owner,
+        &token_contract.address(),
+        &recipient,
+        &3000_0000000,
+    );
+
+    (env, client, owner)
+}
+
+#[test]
+fn test_remove_member_blocked_by_pending_operations() {
+    let (env, client, owner) = setup_wallet_with_pending_proposal();
+    let member1 = Address::generate(&env);
+
+    // Try to remove a member while a proposal is pending.
+    // remove_family_member panics with the typed error via panic_with_error!.
+    let result = client.try_remove_family_member(&owner, &member1);
+    assert_eq!(
+        result,
+        Err(Ok(soroban_sdk::Error::from(
+            Error::PendingOperationsExist
+        ))),
+        "remove_family_member must reject when pending proposals exist"
+    );
+}
+
+#[test]
+fn test_configure_multisig_blocked_by_pending_operations() {
+    let (env, client, owner) = setup_wallet_with_pending_proposal();
+    let member1 = Address::generate(&env);
+    let member2 = Address::generate(&env);
+    let signers = vec![&env, owner.clone(), member1.clone(), member2.clone()];
+
+    // Try to reconfigure multisig while a proposal is pending.
+    // configure_multisig returns Result<bool, Error>.
+    let result = client.try_configure_multisig(
+        &owner,
+        &TransactionType::LargeWithdrawal,
+        &2,
+        &signers,
+        &500_0000000,
+    );
+    assert_eq!(
+        result,
+        Err(Ok(Error::PendingOperationsExist)),
+        "configure_multisig must reject when pending proposals exist"
+    );
+}


### PR DESCRIPTION
Closes #1107 

Defence-in-depth: reject member removal and multisig reconfiguration when the wallet has pending multisig proposals in-flight.

Threat model
-----------
An attacker (or a confused admin) who removes a member or reconfigures the multisig threshold/signers while proposals are pending could cause:

1. Orphaned signatures — a removed member's signatures remain counted toward quorum on proposals that will never execute.
2. Stale quorum — raising the threshold after proposals are created can silently make them un-executable without emitting any event.
3. Execution against stale config — rotating signers lets a new signer sign proposals that were created under the old signer set.

Changes
-------
- Add PendingOperationsExist (code 27) typed #[contracterror]
- Add require_no_pending_operations() helper that checks PEND_TXS len
- Guard remove_family_member() and configure_multisig() with the check
- Two negative tests that exercise the new guard:
  - test_remove_member_blocked_by_pending_operations
  - test_configure_multisig_blocked_by_pending_operations

Note: cargo test / clippy / WASM build could not be verified locally due to missing MSVC build tools on this machine. CI will validate.