### PR TITLE
test(family-wallet): cover archive integrity guard for executed tx me…

### DIFF
--- a/family_wallet/src/test.rs
+++ b/family_wallet/src/test.rs
@@ -8044,3 +8044,46 @@ fn test_configure_multisig_blocked_by_pending_operations() {
         "configure_multisig must reject when pending proposals exist"
     );
 }
+
+// ============================================================================
+// Archive Integrity Tests (SC-004)
+//
+// Verify that archive_old_transactions fails closed when EXEC_TXS contains
+// a corrupted entry whose map key does not match meta.tx_id.
+// ============================================================================
+
+#[test]
+#[should_panic(expected = "Inconsistent executed transaction metadata")]
+fn test_archive_integrity_rejects_mismatched_tx_id() {
+    let env = Env::default();
+    env.mock_all_auths();
+    set_ledger_time(&env, 100, 50_000);
+
+    let contract_id = env.register_contract(None, FamilyWallet);
+    let client = FamilyWalletClient::new(&env, &contract_id);
+    let owner = Address::generate(&env);
+    client.init(&owner, &vec![&env]);
+
+    // Inject a corrupted ExecutedTxMeta directly into instance storage.
+    // Map key = 999, but meta.tx_id = 42 — a deliberate mismatch that
+    // archive_old_transactions must detect and abort on.
+    env.as_contract(&contract_id, || {
+        let mut corrupted_map: Map<u64, ExecutedTxMeta> = Map::new(&env);
+        corrupted_map.set(
+            999_u64,
+            ExecutedTxMeta {
+                tx_id: 42,
+                tx_type: TransactionType::RegularWithdrawal,
+                proposer: owner.clone(),
+                executed_at: 1_000,
+            },
+        );
+        env.storage()
+            .instance()
+            .set(&symbol_short!("EXEC_TXS"), &corrupted_map);
+    });
+
+    // Archive with a cutoff well after executed_at so the corrupted entry
+    // would be eligible for archiving — triggering the integrity check.
+    client.archive_old_transactions(&owner, &10_000);
+}


### PR DESCRIPTION
closes #1409 

Title: test(family_wallet): cover archive integrity guard for executed tx metadata (#1409 SC-004)
Body:
## Description

Adds a negative test that verifies `archive_old_transactions` fails closed when `EXEC_TXS` contains a corrupted entry whose map key does not match `meta.tx_id`.

## Motivation

`archive_old_transactions` already panics if `meta.tx_id != map_key` (defense-in-depth against storage corruption), but no test exercised this guard. This test proves the invariant holds and prevents silent archive corruption.

## Changes

- **`family_wallet/src/test.rs`**: Added `test_archive_integrity_rejects_mismatched_tx_id` — injects a corrupted `ExecutedTxMeta` (map key `999`, `meta.tx_id = 42`) directly into instance storage via `env.as_contract`, then asserts the archive call panics with `"Inconsistent executed transaction metadata"`.

## Test

```bash
cargo test -p family_wallet test_archive_integrity_rejects_mismatched_tx_id -- --nocapture
Checklist
- Covers the meta.tx_id != map_key panic path at lib.rs:1658
- Uses #[should_panic(expected = "...")] for precise assertion
- Injects corruption via env.as_contract (test-only bypass)
- Follows existing test conventions (mock_all_auths, set_ledger_time, Map::new