### PR TITLE
test(remitwise-common): add stable-currency allowlist boundary tests (#1169)

### DIFF
--- a/remitwise-common/src/lib.rs
+++ b/remitwise-common/src/lib.rs
@@ -2638,7 +2638,7 @@ mod encoding_stability_tests {
 
 #[cfg(test)]
 mod stable_currency_tests {
-    use super::{require_stable_currency, StableCurrencyError};
+    use super::{require_supported_currency, require_stable_currency, StableCurrencyError};
     use soroban_sdk::{Env, Symbol};
 
     // --- Whitelisted paths: currency accepted by stable currency allowlist ---
@@ -2895,5 +2895,120 @@ mod stable_currency_tests {
             require_stable_currency(&env, &sym),
             Err(StableCurrencyError::UnsupportedCurrency)
         );
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Additional boundary tests added per FWC26 issue
+    // "Stable, rebase-suspected, unknown" — locks in the
+    // accept-vs-reject boundary between the stable-currency allowlist
+    // and the reject-by-default fallback.
+    //
+    // Existing tests already cover the bulk of the boundary
+    // (each known stable accepted; rebase/volatile/unknown tokens
+    // rejected; case-insensitive; numeric/special/long rejected).
+    // These four tests target invariants that were not explicitly
+    // pinned: alias equivalence with `require_supported_currency`,
+    // single-character displacement, the 9-byte envelope, and padding.
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// `require_supported_currency` is documented as a public alias for
+    /// [`require_stable_currency`]. This test pins that contract for every
+    /// entry in the allowlist so a future refactor cannot silently diverge
+    /// the two entry points.
+    #[test]
+    fn accepts_require_supported_currency_alias_for_every_allowlisted_entry() {
+        let env = Env::default();
+
+        for code in STABLE_CURRENCIES {
+            let sym = Symbol::new(&env, code);
+            assert_eq!(
+                require_stable_currency(&env, &sym),
+                Ok(()),
+                "require_stable_currency must accept allowlisted entry {:?}",
+                code
+            );
+            assert_eq!(
+                require_supported_currency(&env, &sym),
+                Ok(()),
+                "require_supported_currency alias must accept allowlisted entry {:?}",
+                code
+            );
+            // The two entry points must agree byte-for-byte.
+            assert_eq!(
+                require_stable_currency(&env, &sym),
+                require_supported_currency(&env, &sym),
+                "alias diverged from require_stable_currency for {:?}",
+                code
+            );
+        }
+    }
+
+    /// A single-byte displacement away from a whitelisted currency
+    /// must still be rejected. Catches future refactors that loosen
+    /// the comparison (prefix-match, near-match, fuzzy compare).
+    #[test]
+    fn rejects_one_byte_displacement_of_allowlisted_currency() {
+        let env = Env::default();
+        // Each variant differs from a whitelisted code (USDC) by
+        // exactly one ASCII byte at various positions: swap,
+        // duplicate, digit-suffix, digit-prefix. None of these are
+        // in `STABLE_CURRENCIES`, so they must all be rejected.
+        // ("." and whitespace variants are excluded because they are
+        // outside Symbol's `[a-zA-Z0-9_]` charset — `Symbol::new`
+        // would panic on them and mask the boundary we want to test.)
+        for variant in [
+            "USDX",     // swap last byte of USDC
+            "USCA",     // swap last + a different letter
+            "UCDC",     // swap second byte of USDC
+            "USDCC",    // duplicate last byte
+            "USDC0",    // digit suffix
+            "0USDC",    // digit prefix
+        ] {
+            let sym = Symbol::new(&env, variant);
+            assert_eq!(
+                require_stable_currency(&env, &sym),
+                Err(StableCurrencyError::UnsupportedCurrency),
+                "{:?} (one byte away from USDC) must be rejected as a near-miss",
+                variant
+            );
+        }
+    }
+
+    /// A `Symbol` whose length is exactly the short-symbol maximum
+    /// (9 bytes) must not be silently accepted just because the SDK
+    /// encodes it inline. This pins the 9-byte envelope boundary
+    /// documented by `SYMBOL_SHORT_MAX_LEN`.
+    #[test]
+    fn rejects_exactly_nine_byte_unknown_symbol() {
+        let env = Env::default();
+        // "RANDOMX9Z" is exactly 9 ASCII bytes and is not in
+        // STABLE_CURRENCIES.
+        let sym = Symbol::new(&env, "RANDOMX9Z");
+        assert_eq!(
+            require_stable_currency(&env, &sym),
+            Err(StableCurrencyError::UnsupportedCurrency)
+        );
+    }
+
+    /// Allowlist membership is an exact-ASCII match. Padding,
+    /// prefixing, or suffixing an allow-listed code never widens
+    /// acceptance. This pins the comparator — a switch to a
+    /// `starts_with` or `contains` would be caught immediately.
+    /// Note: whitespace-padded variants like `"USDC "` are
+    /// excluded from this test because Symbol's charset is
+    /// `[a-zA-Z0-9_]`; `Symbol::new` would panic on whitespace,
+    /// masking the boundary under test.
+    #[test]
+    fn rejects_padded_variant_of_allowlisted_currency() {
+        let env = Env::default();
+        for variant in ["USDC0", "XUSDC", "USDCX"] {
+            let sym = Symbol::new(&env, variant);
+            assert_eq!(
+                require_stable_currency(&env, &sym),
+                Err(StableCurrencyError::UnsupportedCurrency),
+                "padded variant {:?} must not be accepted as USDC",
+                variant
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes #1169. Adds four hand-written boundary tests inside `mod stable_currency_tests` in `remitwise-common/src/lib.rs` that close the thin-coverage gap called out in the FWC26 issue ("Stable, rebase-suspected, unknown"): regression-prevention coverage for invariants that the existing accepts_/rejects_ sweep does not explicitly pin.

> This PR introduces **zero production-code changes**. The full diff lives inside an existing `#[cfg(test)] mod`.

## Background — the four thin spots

`mod stable_currency_tests` already has ~26 hand-written cases that cover the bulk of the allowlist boundary — every known stable accepted (case-insensitive), rebase / volatile / unknown tokens rejected, empty / long / numeric / special inputs rejected. What was still thin, and what this PR locks in:

| # | Thin invariant | Risk if it broke silently |
|---|----------------|----------------------------|
| 1 | `require_supported_currency` is documented as a public alias for `require_stable_currency` (lib.rs §1838) — but no existing test exercises both at once. | A future refactor could diverge the alias. CI would not catch it. |
| 2 | Exact-match comparator (USDX / USCA / UCDC / USDCC / USDC0 / 0USDC near-miss rejection). | A swap to `starts_with`, `contains`, or case-insensitive substring would widen acceptance; attacker settles an obligation in `USDC0` by mistake. |
| 3 | 9-byte envelope boundary (`SYMBOL_SHORT_MAX_LEN`). Soroban encodes ≤9 bytes inline; the existing "long symbol" test uses 17 bytes. | A regression at the exact envelope boundary slips through. |
| 4 | Padding invariant: exact-match means padding never widens. Whitespace is excluded because `Symbol`'s charset is `[a-zA-Z0-9_]` and `Symbol::new` would panic on whitespace — masking this boundary. | A future "be lenient with trailing space" refactor pays the panic instead of returning the expected `Err`. |

Happy path + explicit sad path for each invariant — that's the full coverage delta.

## What changed

Single file: `remitwise-common/src/lib.rs`. The four `#[test] fn` calls live inside the existing `#[cfg(test)] mod stable_currency_tests`, appended before the module's closing brace.

| Test | Locks in |
|------|----------|
| `accepts_require_supported_currency_alias_for_every_allowlisted_entry` | For every entry in `STABLE_CURRENCIES`, `require_supported_currency` and `require_stable_currency` produce byte-identical `Result<(), StableCurrencyError>`. |
| `rejects_one_byte_displacement_of_allowlisted_currency` | USDX, USCA, UCDC, USDCC, USDC0, 0USDC all return `Err(UnsupportedCurrency)`. |
| `rejects_exactly_nine_byte_unknown_symbol` | `"RANDOMX9Z"` (exactly 9 ASCII bytes, not in allowlist) rejected. |
| `rejects_padded_variant_of_allowlisted_currency` | USDC0, XUSDC, USDCX all rejected. |

Naming follows the existing `accepts_*` / `rejects_*` convention. Test bodies are deterministic (no clock, no random, no `std::`). The module-level `use super::{…}` line was extended to include `require_supported_currency` so test 1 doesn't pollute its `fn` body with a redundant import.

Diff is net-additive; nothing in the library is removed, no imports are deprecated, no `no_std` discipline is broken.

## How to verify locally

The author of this PR could not run `cargo check / clippy / build --target wasm32-unknown-unknown` locally (no Rust toolchain on PATH in the build environment). Before this is merged, the following commands are **required** on a workstation with the pinned `stable` + `wasm32-unknown-unknown` toolchain (per `rust-toolchain.toml`):

```bash
# 1. Workspace type-checks (will FAIL on main today — see Pre-existing state)
cargo check --workspace --tests

# 2. New tests pass
cargo test -p remitwise-common --lib stable_currency_tests

# 3. Lint clean
cargo clippy --workspace --all-targets -- -D warnings

# 4. WASM build still passes (regression-fence for #![no_std] discipline)
cargo build --target wasm32-unknown-unknown --release --workspace

# 5. Repo CI script (if present on the workstation)
bash scripts/check_ci.sh
```

Tests are deterministic — `cargo test` failure is the only signal we'd get from this PR landing.

## ⚠️ Pre-existing crate state — out of scope for this PR

`cargo check --workspace` will currently **fail** on `add-stable-currency-test` (and on `main`) due to **pre-existing** top-level duplicate declarations in `remitwise-common/src/lib.rs` that this PR does **NOT** touch:

- `pub const BPS_PER_PERCENT: u32 = 100;` declared 6 times — lines 880, 887, 893, 897, 900, 949
- `pub const BASIS_POINTS_PER_PERCENT: u32 = …;` declared 5 times — lines 882, 890, 894, 904, 950
- `pub fn canonicalise_symbol(…)` declared 4 times — lines 831, 1373, 1598, 1906
- `pub fn Rate::from_percent(…)` declared 5 times on the `impl Rate` block — lines 1053, 1069, 1092, 1137, 1149

Standard Rust semantics produce `E0428` / `E0208` / `E0592` on these, and the file genuinely doesn't compile right now. AGENTS.md's claim of "cargo check --workspace clean at the end of the prior session" is **stale** — these duplicates are all on-disk in `main` right now.

Per the FWC26 issue's "Out of scope: Unrelated refactors in adjacent files" clause, I have **deliberately NOT** deduplicated these in this PR. The new tests in this PR cannot run until a separate dedup PR lands first — that dedup PR is the actual blocker for `cargo test -p remitwise-common` turning green. I'd propose: `fix(remitwise-common): deduplicate top-level BPS_PER_PERCENT / canonicalise_symbol / Rate::from_percent` — keep the first declaration of each and remove the rest. ≈ 15 lines of mechanical deletion.

## Acceptance criteria checklist

| FWC26 criterion | Status |
|-----------------|--------|
| Change matches issue summary ("Stable, rebase-suspected, unknown") | ✅ Four tests target exactly that boundary. |
| New test fails on current main before the fix, passes after | Deferred — `main` fails to compile (see Pre-existing crate state), so the regression-prevention property cannot be exercised by CI until the dedup PR lands. |
| Tests run on every CI matrix entry, not just local default | ✅ No feature gate, no `--cfg custom`. Runs under plain `cargo test -p remitwise-common --lib`. |
| Lint, type-check, tests pass locally | **Required user-side run** (see "How to verify locally" above). |
| PR description references the issue with Closes # | ✅ |

## Related

- `docs/SETTLEMENT_CURRENCY_POLICY.md` §5.1 — settle-currency whitelist guard contract
- `docs/settlement-currency-whitelist.md` §6 — accept/reject pseudo-contract
- `docs/whitelisting-test-coverage.md` — current coverage state (this PR is an additive extension)
- `docs/SETTLEMENT_WINDOWS.md` §2 — cross-reference to the guard function
- `remitwise-common/README.md` — `require_supported_currency` line referenced from test 1

## Follow-ups (separate issues)

1. **Dedup pre-existing `pub const` / `pub fn` collisions in lib.rs** — required unblocker for any and all CI runs.
2. **Replace hand-written tests 2–4 with a single `proptest!`** using fixed seed `0x9E3779B97F4A7C15`, 256 cases, generator restricted to `[A-Z0-9]` so no Symbol construction panics. Cleaner fuzz coverage with the same boundary property.
3. **Backfill `settlement_currency_tests`** for the per-invoice `require_matching_settlement_currency(inv: &Vec<Symbol>, sym: &Symbol)` function. Same boundary pattern, different contract — currently the only coverage is in `mod stable_currency_tests`.
