### PR TITLE
Fix: Add tests for the first-or-error helper (Auto-Generated)

### DIFF
--- a/integration_tests/tests/first_or_error.rs
+++ b/integration_tests/tests/first_or_error.rs
@@ -1,0 +1,30 @@
+use reporting::first_or_error;
+use soroban_sdk::{Env, Vec};
+
+#[test]
+fn first_or_error_returns_error_for_empty_input() {
+    let env = Env::default();
+    let values: Vec<u32> = Vec::new(&env);
+
+    assert!(first_or_error(&values).is_err());
+}
+
+#[test]
+fn first_or_error_returns_single_input_value() {
+    let env = Env::default();
+    let mut values = Vec::new(&env);
+    values.push_back(42_u32);
+
+    assert_eq!(first_or_error(&values).unwrap(), 42_u32);
+}
+
+#[test]
+fn first_or_error_returns_first_value_from_many_inputs() {
+    let env = Env::default();
+    let mut values = Vec::new(&env);
+    values.push_back(7_u32);
+    values.push_back(14_u32);
+    values.push_back(21_u32);
+
+    assert_eq!(first_or_error(&values).unwrap(), 7_u32);
+}


### PR DESCRIPTION
Closes #1247

This PR was generated by the DripTide AI coder and scoped strictly to issue #1247.

### Changes
Adds three tests for empty, single-element, and multi-element inputs to a purported reporting::first_or_error helper.

### Verification
Passed automated self-review (lint + issue-coverage checks).

_Linked with `Closes #1247` so the Drips Wave bot resolves the issue on merge._