### PR TITLE
fix(family-wallet): reject role expiry timestamps in the past

### DIFF
--- a/family_wallet/src/lib.rs
+++ b/family_wallet/src/lib.rs
@@ -404,6 +404,8 @@ pub enum Error {
     /// in-flight could cause orphaned signatures, silently-invalid quorum
     /// calculations, or execution against stale configuration.
     PendingOperationsExist = 27,
+    /// The supplied expiry timestamp is in the past.
+    RoleExpiryInPast = 28,
 }
 
 #[contractimpl]
@@ -1869,6 +1871,16 @@ impl FamilyWallet {
             .unwrap_or_else(|| panic!("Wallet not initialized"));
         if members.get(member.clone()).is_none() {
             panic!("Member not found");
+        }
+
+        // Reject expiry timestamps that are in the past — setting an already-
+        // expired role timestamp would immediately lock the member out of
+        // their role with no way to recover except through admin intervention.
+        if let Some(t) = expires_at {
+            let now = env.ledger().timestamp();
+            if t <= now {
+                panic_with_error!(&env, Error::RoleExpiryInPast);
+            }
         }
 
         let mut m: Map<Address, u64> = env


### PR DESCRIPTION
## Overview

Reject expiry timestamps in `set_role_expiry` that are in the past (≤ current ledger timestamp). Setting an already-expired role timestamp would immediately lock the member out of their role with no way to recover except through admin intervention.

## Related Issue
Closes #1344

## Changes
- [ADD] `Error::RoleExpiryInPast` (code 28) — structured error variant for past expiry timestamps
- [MODIFY] `set_role_expiry` — validates `expires_at` is strictly greater than the current ledger time before persisting

## Verification Results
- `cargo build --target wasm32-unknown-unknown --release` — pending CI
- Changes follow existing patterns (`panic_with_error!` with typed enum error)

## Acceptance Criteria
| Criteria | Status |
|----------|--------|
| Reject bad input at the boundary | ✅ (in `set_role_expiry` at the public API surface) |
| Error is structured (typed enum) | ✅ (`Error::RoleExpiryInPast`) |
| PR references the issue | ✅ (`Closes #1344`) |
