### PR TITLE
fix: add canonicalise_symbol(s) helper matching the doc

### DIFF
--- a/docs/CANONICALISATION.md
+++ b/docs/CANONICALISATION.md
@@ -15,7 +15,8 @@
 2. [Currency codes — trim, uppercase, and default](#2-currency-codes--trim-uppercase-and-default)
 3. [External references — charset validation (case-preserving)](#3-external-references--charset-validation-case-preserving)
 4. [Migration snapshot checksum — byte-order and input ordering](#4-migration-snapshot-checksum--byte-order-and-input-ordering)
-5. [What is explicitly *not* normalised](#5-what-is-explicitly-not-normalised)
+5. [Symbol keys — trim, casefold and charset validation](#5-symbol-keys--trim-casefold-and-charset-validation)
+6. [What is explicitly *not* normalised](#6-what-is-explicitly-not-normalised)
 
 ---
 
@@ -181,7 +182,77 @@ algorithm; `ChecksumAlgorithm::Sha256` is the default for new exports.
 
 ---
 
-## 5. What is explicitly *not* normalised
+## 5. Symbol keys — trim, casefold and charset validation
+
+**Where:** `remitwise-common/src/lib.rs`  
+**Functions:** `canonicalise_symbol`, `canonicalise_symbol_checked`, `canonicalise_symbols`
+
+Soroban `Symbol` values are used as storage keys, event action names, and pause-channel
+identifiers. Accepting caller-supplied strings without normalisation means two strings that
+a human would treat as the same key (`"MyKey"` and `"mykey"`) map to different storage
+slots. This section documents the shared normalisation helpers that prevent that split.
+
+### Rules
+
+| Step | Behaviour |
+|------|-----------|
+| **Trim** | Strip leading and trailing ASCII whitespace (space, tab, newline, carriage return). |
+| **Empty check** | Trimmed length = 0 → error/panic. |
+| **Length check** | Trimmed length > `SYMBOL_MAX_LEN` (32 bytes) → error/panic. |
+| **Casefold** | ASCII `A–Z` silently folded to lowercase. |
+| **Charset check** | Every byte after folding must be in `[a-z0-9_]`. Any other byte (hyphens, spaces, `@`, `.`, `!`, …) is rejected. |
+| **Idempotency** | Applying to an already-canonical string is a no-op. |
+
+### Charset comparison
+
+| Function | Charset after trim + fold | Invalid byte behaviour |
+|---|---|---|
+| `canonicalise_symbol` | `[a-z0-9_]` | panic with position |
+| `canonicalise_symbol_checked` | `[a-z0-9_]` | `Err(SymbolValidationError::InvalidChar { position })` |
+| `canonicalise_symbols` (batch) | `[a-z0-9_]` | short-circuit `Err` on first invalid element |
+
+> **Comparison with tags:** `canonicalize_tags` allows hyphens (`-`) in its charset
+> but `canonicalise_symbol` does not, because Soroban `Symbol` values disallow `-`.
+
+### Error type
+
+```rust
+pub enum SymbolValidationError {
+    Empty,                          // empty or whitespace-only after trim
+    TooLong,                        // trimmed byte length > 32
+    InvalidChar { position: u32 },  // first offending byte index (post-trim)
+}
+```
+
+### When to use each variant
+
+| Call site | Preferred function | Reason |
+|---|---|---|
+| Trusted internal call (known-good constant input) | `canonicalise_symbol` | Simple, no error plumbing needed |
+| Untrusted caller input, typed error needed | `canonicalise_symbol_checked` | Returns `Err` — caller maps it to a contract error |
+| Entry point accepting a list of symbol keys | `canonicalise_symbols` | Validates + normalises a whole batch atomically |
+
+### Example
+
+```rust
+use remitwise_common::{canonicalise_symbol_checked, canonicalise_symbols, SymbolValidationError};
+
+// Single, checked
+match canonicalise_symbol_checked(&env, &raw_key) {
+    Ok(sym)                                       => { /* use sym */ }
+    Err(SymbolValidationError::Empty)             => panic_with_error!(&env, MyError::InvalidKey),
+    Err(SymbolValidationError::TooLong)           => panic_with_error!(&env, MyError::InvalidKey),
+    Err(SymbolValidationError::InvalidChar { .. }) => panic_with_error!(&env, MyError::InvalidKey),
+}
+
+// Batch
+let syms = canonicalise_symbols(&env, &raw_keys)
+    .unwrap_or_else(|_| panic_with_error!(&env, MyError::InvalidKey));
+```
+
+---
+
+## 6. What is explicitly *not* normalised
 
 | Input | Behaviour |
 |-------|-----------|

--- a/remitwise-common/README.md
+++ b/remitwise-common/README.md
@@ -14,7 +14,8 @@ Shared types, constants, and utilities used across all Remitwise Soroban smart c
 - Event taxonomy: EventCategory, EventPriority, RemitwiseEvents emitter
 - Pagination utilities: clamp_limit
 - Storage TTL constants
-- Tag canonicalization and validation
+- Tag canonicalisation and validation
+- **Symbol canonicalisation:** `canonicalise_symbol`, `canonicalise_symbol_checked`, `canonicalise_symbols` — trim, casefold, charset validation
 - Encoding stability tests
 
 ## Quickstart
@@ -155,6 +156,29 @@ Computes the future distance to `target` with saturating semantics:
 ### `canonicalize_tags_checked(env, tags)`
 
 Validates and canonicalizes tags with error handling.
+
+### Symbol canonicalisation
+
+Three functions in `remitwise-common` normalise caller-supplied strings into Soroban `Symbol` values. All three apply the same rules: **trim → casefold to lowercase → charset validation (`[a-z0-9_]`).**
+
+| Function | Behaviour on invalid input | Use when |
+|---|---|---|
+| `canonicalise_symbol(env, s)` | panics with a descriptive message | Internal/trusted call sites |
+| `canonicalise_symbol_checked(env, s)` | `Err(SymbolValidationError)` | Untrusted input, need typed error |
+| `canonicalise_symbols(env, vec)` | `Err(SymbolValidationError)` on first bad element | Batch / list entry points |
+
+```rust
+use remitwise_common::{canonicalise_symbol_checked, SymbolValidationError};
+
+match canonicalise_symbol_checked(&env, &raw_key) {
+    Ok(sym)  => { /* store/compare sym */ },
+    Err(SymbolValidationError::Empty)              => { /* reject empty */ },
+    Err(SymbolValidationError::TooLong)            => { /* reject too long */ },
+    Err(SymbolValidationError::InvalidChar { position }) => { /* reject bad char */ },
+}
+```
+
+See [`docs/CANONICALISATION.md §5`](../docs/CANONICALISATION.md) for the full specification.
 
 ### `RemitwiseEvents::emit(env, category, priority, action, data)`
 

--- a/remitwise-common/src/lib.rs
+++ b/remitwise-common/src/lib.rs
@@ -539,14 +539,14 @@ mod rate_limiting_tests {
 
         // First request should succeed
         assert_eq!(
-            check_and_increment_rate_limit(&env, &caller, operation, limit),
+            check_and_increment_rate_limit(&env, &caller, operation.clone(), limit),
             Ok(())
         );
 
         // Multiple requests within limit should succeed
         for _ in 0..4 {
             assert_eq!(
-                check_and_increment_rate_limit(&env, &caller, operation, limit),
+                check_and_increment_rate_limit(&env, &caller, operation.clone(), limit),
                 Ok(())
             );
         }
@@ -569,21 +569,21 @@ mod rate_limiting_tests {
 
         // Caller1 uses up their limit
         assert_eq!(
-            check_and_increment_rate_limit(&env, &caller1, operation, limit),
+            check_and_increment_rate_limit(&env, &caller1, operation.clone(), limit),
             Ok(())
         );
         assert_eq!(
-            check_and_increment_rate_limit(&env, &caller1, operation, limit),
+            check_and_increment_rate_limit(&env, &caller1, operation.clone(), limit),
             Ok(())
         );
         assert_eq!(
-            check_and_increment_rate_limit(&env, &caller1, operation, limit),
+            check_and_increment_rate_limit(&env, &caller1, operation.clone(), limit),
             Err(RateLimitError::RateLimitExceeded)
         );
 
         // Caller2 should still be able to make requests
         assert_eq!(
-            check_and_increment_rate_limit(&env, &caller2, operation, limit),
+            check_and_increment_rate_limit(&env, &caller2, operation.clone(), limit),
             Ok(())
         );
         assert_eq!(
@@ -602,7 +602,7 @@ mod rate_limiting_tests {
 
         // Use up limit for operation1
         assert_eq!(
-            check_and_increment_rate_limit(&env, &caller, operation1, limit),
+            check_and_increment_rate_limit(&env, &caller, operation1.clone(), limit),
             Ok(())
         );
         assert_eq!(
@@ -631,11 +631,11 @@ mod rate_limiting_tests {
 
         // Use up the limit in the first window
         assert_eq!(
-            check_and_increment_rate_limit(&env, &caller, operation, limit),
+            check_and_increment_rate_limit(&env, &caller, operation.clone(), limit),
             Ok(())
         );
         assert_eq!(
-            check_and_increment_rate_limit(&env, &caller, operation, limit),
+            check_and_increment_rate_limit(&env, &caller, operation.clone(), limit),
             Err(RateLimitError::RateLimitExceeded)
         );
 
@@ -659,18 +659,18 @@ mod rate_limiting_tests {
         let limit = 3u32;
 
         // Initially should have 0 count
-        let (count, window_end) = get_rate_limit_status(&env, &caller, operation);
+        let (count, window_end) = get_rate_limit_status(&env, &caller, operation.clone());
         assert_eq!(count, 0);
         assert_eq!(window_end, RATE_LIMIT_WINDOW_SECONDS);
 
         // After one request, count should be 1
-        check_and_increment_rate_limit(&env, &caller, operation, limit).unwrap();
-        let (count, _) = get_rate_limit_status(&env, &caller, operation);
+        check_and_increment_rate_limit(&env, &caller, operation.clone(), limit).unwrap();
+        let (count, _) = get_rate_limit_status(&env, &caller, operation.clone());
         assert_eq!(count, 1);
 
         // After two more requests, count should be 3
-        check_and_increment_rate_limit(&env, &caller, operation, limit).unwrap();
-        check_and_increment_rate_limit(&env, &caller, operation, limit).unwrap();
+        check_and_increment_rate_limit(&env, &caller, operation.clone(), limit).unwrap();
+        check_and_increment_rate_limit(&env, &caller, operation.clone(), limit).unwrap();
         let (count, _) = get_rate_limit_status(&env, &caller, operation);
         assert_eq!(count, 3);
     }
@@ -826,45 +826,186 @@ impl ToI128Checked for i32 {
     }
 }
 
-/// Normalizes a `soroban_sdk::String` into a `Symbol` by stripping leading/trailing
-/// whitespace and lowercasing ASCII letters.
-pub fn canonicalise_symbol(env: &Env, input: &soroban_sdk::String) -> Symbol {
-    let len = input.len();
-    if len == 0 {
-        panic!("symbol input must contain between 1 and 32 characters after trimming");
-    }
-    let mut buf = [0u8; 256];
-    if len as usize > buf.len() {
-        panic!("symbol input is too long");
-    }
-    input.copy_into_slice(&mut buf[..len as usize]);
 
-    let s = core::str::from_utf8(&buf[..len as usize])
+// ---------------------------------------------------------------------------
+// Symbol canonicalisation — trim, casefold, charset validation
+// ---------------------------------------------------------------------------
+
+/// Maximum byte length of a canonicalised symbol (mirrors Soroban's limit).
+pub const SYMBOL_MAX_LEN: usize = 32;
+
+/// Error returned by [`canonicalise_symbol_checked`] and
+/// [`canonicalise_symbols`] when an input string cannot be turned into a
+/// valid canonical `Symbol`.
+///
+/// All variants carry enough context for the caller to map them to a
+/// contract-specific `#[contracterror]` without losing the error category.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub enum SymbolValidationError {
+    /// Input was empty or contained only ASCII whitespace after trimming.
+    Empty,
+    /// Trimmed input exceeds [`SYMBOL_MAX_LEN`] bytes.
+    TooLong,
+    /// A byte at `position` is not in the allowed charset `[a-z0-9_]` after
+    /// ASCII uppercase folding.  Internal ASCII spaces (mid-string) are caught
+    /// here rather than being silently stripped.
+    InvalidChar { position: u32 },
+}
+
+/// Allowed charset predicate after uppercase folding.
+///
+/// `[a-z0-9_]` — identical to the Soroban `Symbol` charset restriction
+/// minus the uppercase letters (which we fold away).
+#[inline(always)]
+fn is_symbol_char(b: u8) -> bool {
+    b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'_'
+}
+
+/// Validate and canonicalise a `soroban_sdk::String` into a `Symbol`,
+/// returning a typed error instead of panicking on bad input.
+///
+/// ## Transformation rules (applied in order)
+///
+/// | Step | Rule |
+/// |---|---|
+/// | **Trim** | Strip leading and trailing ASCII whitespace (`\t \n \r`). |
+/// | **Empty check** | Trimmed length = 0 → `Err(SymbolValidationError::Empty)`. |
+/// | **Length check** | Trimmed length > 32 → `Err(SymbolValidationError::TooLong)`. |
+/// | **Casefold** | ASCII `A-Z` → `a-z`. |
+/// | **Charset check** | Every byte must be in `[a-z0-9_]`. First offending byte → `Err(SymbolValidationError::InvalidChar { position })`. |
+///
+/// ## Examples
+///
+/// ```rust,ignore
+/// // Valid
+/// assert!(canonicalise_symbol_checked(&env, &String::from_str(&env, "Hello_World")).is_ok());
+/// // → Symbol("hello_world")
+///
+/// // Invalid char
+/// assert_eq!(
+///     canonicalise_symbol_checked(&env, &String::from_str(&env, "bad-char")),
+///     Err(SymbolValidationError::InvalidChar { position: 3 })
+/// );
+///
+/// // Too long
+/// assert_eq!(
+///     canonicalise_symbol_checked(&env, &String::from_str(&env, &"x".repeat(33))),
+///     Err(SymbolValidationError::TooLong)
+/// );
+/// ```
+pub fn canonicalise_symbol_checked(
+    env: &Env,
+    input: &soroban_sdk::String,
+) -> Result<Symbol, SymbolValidationError> {
+    let len = input.len() as usize;
+    if len == 0 {
+        return Err(SymbolValidationError::Empty);
+    }
+    // 256 bytes is enough: valid symbols are ≤32 bytes; anything longer is
+    // rejected by the TooLong check after trimming.
+    let mut buf = [0u8; 256];
+    let read_len = len.min(buf.len());
+    input.copy_into_slice(&mut buf[..read_len]);
+
+    // Interpret as UTF-8 (Soroban strings are always valid UTF-8).
+    let s = core::str::from_utf8(&buf[..read_len])
         .unwrap_or_else(|_| panic!("symbol input is not valid UTF-8"));
 
+    // Step 1: trim
     let trimmed = s.trim();
     let trimmed_len = trimmed.len();
     if trimmed_len == 0 {
-        panic!("symbol input must contain at least one non-whitespace character");
+        return Err(SymbolValidationError::Empty);
     }
-    if trimmed_len > 32 {
-        panic!("symbol input must contain between 1 and 32 characters after trimming");
+    if trimmed_len > SYMBOL_MAX_LEN {
+        return Err(SymbolValidationError::TooLong);
     }
 
+    // Step 2: casefold + charset validation
     let trimmed_bytes = trimmed.as_bytes();
-    let mut canonical = [0u8; 32];
+    let mut canonical = [0u8; SYMBOL_MAX_LEN];
     for (i, &byte) in trimmed_bytes.iter().enumerate() {
-        canonical[i] = if byte.is_ascii_uppercase() {
+        let folded = if byte.is_ascii_uppercase() {
             byte.to_ascii_lowercase()
         } else {
             byte
         };
+        if !is_symbol_char(folded) {
+            return Err(SymbolValidationError::InvalidChar {
+                position: i as u32,
+            });
+        }
+        canonical[i] = folded;
     }
 
     let canonical_str = core::str::from_utf8(&canonical[..trimmed_len])
         .unwrap_or_else(|_| panic!("canonicalised symbol is not valid UTF-8"));
 
-    Symbol::new(env, canonical_str)
+    Ok(Symbol::new(env, canonical_str))
+}
+
+/// Canonicalise a `soroban_sdk::String` into a `Symbol`, panicking with a
+/// descriptive message on invalid input.
+///
+/// This is a thin panic wrapper around [`canonicalise_symbol_checked`].
+/// Prefer the checked variant when the calling contract needs a typed error
+/// for the caller (e.g. to return `InvalidSymbol` instead of aborting the
+/// transaction).  Use this variant only at trusted call sites where bad input
+/// is a programming error rather than untrusted user input.
+///
+/// ## Transformation rules
+///
+/// Identical to [`canonicalise_symbol_checked`]: trim → casefold → charset
+/// check (`[a-z0-9_]`).
+///
+/// ## Panics
+///
+/// - Empty or whitespace-only input after trimming.
+/// - Trimmed input longer than 32 bytes.
+/// - Any byte outside `[a-z0-9_]` after uppercase folding (includes hyphens,
+///   spaces, `@`, `.`, `!`, etc.).
+pub fn canonicalise_symbol(env: &Env, input: &soroban_sdk::String) -> Symbol {
+    match canonicalise_symbol_checked(env, input) {
+        Ok(sym) => sym,
+        Err(SymbolValidationError::Empty) => {
+            panic!("symbol input must contain at least one non-whitespace character")
+        }
+        Err(SymbolValidationError::TooLong) => {
+            panic!("symbol input must contain between 1 and 32 characters after trimming")
+        }
+        Err(SymbolValidationError::InvalidChar { position }) => {
+            panic!("invalid Symbol character at position {}", position)
+        }
+    }
+}
+
+/// Canonicalise every string in `inputs`, returning a `Vec<Symbol>` in the
+/// same order, or the first validation error encountered.
+///
+/// This batch variant is the natural companion to [`canonicalise_symbol_checked`]
+/// for entry points that accept a list of symbol keys (e.g. a list of category
+/// labels or pause-channel names).  Processing short-circuits on the first
+/// error; the `position` field inside
+/// [`SymbolValidationError::InvalidChar`] refers to the byte position
+/// within the **failing element**, not its index in the batch.
+///
+/// ## Errors
+///
+/// Returns the first [`SymbolValidationError`] encountered.  The order of
+/// validation matches the iteration order of `inputs`.
+pub fn canonicalise_symbols(
+    env: &Env,
+    inputs: &soroban_sdk::Vec<soroban_sdk::String>,
+) -> Result<soroban_sdk::Vec<Symbol>, SymbolValidationError> {
+    if inputs.is_empty() {
+        return Err(SymbolValidationError::Empty);
+    }
+    let mut out = soroban_sdk::Vec::new(env);
+    for item in inputs.iter() {
+        let sym = canonicalise_symbol_checked(env, &item)?;
+        out.push_back(sym);
+    }
+    Ok(out)
 }
 
 // ---------------------------------------------------------------------------
@@ -2145,7 +2286,7 @@ where
     #[cfg(test)]
     {
         use soroban_sdk::xdr::ToXdr;
-        use soroban_sdk::TryFromVal;
+        use soroban_sdk::{IntoVal, TryFromVal};
         let val: soroban_sdk::Val = data.into_val(env);
         if let Ok(sc_val) = soroban_sdk::xdr::ScVal::try_from_val(env, &val) {
             let size = soroban_sdk::xdr::ToXdr::to_xdr(sc_val, env).len();
@@ -2168,7 +2309,7 @@ where
 #[cfg(test)]
 mod emit_audit_tests {
     use super::*;
-    use soroban_sdk::{symbol_short, testutils::Address as _, Env};
+    use soroban_sdk::{symbol_short, testutils::Address as _, testutils::Events as _, Env};
 
     // -----------------------------------------------------------------------
     // Schema / topic tests

--- a/remitwise-common/src/tests.rs
+++ b/remitwise-common/src/tests.rs
@@ -600,6 +600,267 @@ proptest! {
     }
 }
 
+// ─── canonicalise_symbol_checked ─────────────────────────────────────────────
+
+/// Lowercase–only input is returned unchanged.
+#[test]
+fn test_checked_symbol_lowercase_passthrough() {
+    let env = Env::default();
+    let input = soroban_sdk::String::from_str(&env, "hello");
+    let out = canonicalise_symbol_checked(&env, &input).unwrap();
+    assert_eq!(symbol_str(&out), "hello");
+}
+
+/// Uppercase letters are folded to lowercase.
+#[test]
+fn test_checked_symbol_uppercase_folded() {
+    let env = Env::default();
+    let input = soroban_sdk::String::from_str(&env, "HELLO");
+    let out = canonicalise_symbol_checked(&env, &input).unwrap();
+    assert_eq!(symbol_str(&out), "hello");
+}
+
+/// Mixed-case input is fully lowercased.
+#[test]
+fn test_checked_symbol_mixed_case_folded() {
+    let env = Env::default();
+    let input = soroban_sdk::String::from_str(&env, "HelloWorld");
+    let out = canonicalise_symbol_checked(&env, &input).unwrap();
+    assert_eq!(symbol_str(&out), "helloworld");
+}
+
+/// Leading whitespace is stripped.
+#[test]
+fn test_checked_symbol_leading_whitespace_stripped() {
+    let env = Env::default();
+    let input = soroban_sdk::String::from_str(&env, "  hello");
+    let out = canonicalise_symbol_checked(&env, &input).unwrap();
+    assert_eq!(symbol_str(&out), "hello");
+}
+
+/// Trailing whitespace is stripped.
+#[test]
+fn test_checked_symbol_trailing_whitespace_stripped() {
+    let env = Env::default();
+    let input = soroban_sdk::String::from_str(&env, "hello  ");
+    let out = canonicalise_symbol_checked(&env, &input).unwrap();
+    assert_eq!(symbol_str(&out), "hello");
+}
+
+/// Underscore is valid.
+#[test]
+fn test_checked_symbol_underscore_allowed() {
+    let env = Env::default();
+    let input = soroban_sdk::String::from_str(&env, "my_symbol");
+    let out = canonicalise_symbol_checked(&env, &input).unwrap();
+    assert_eq!(symbol_str(&out), "my_symbol");
+}
+
+/// Digits are valid.
+#[test]
+fn test_checked_symbol_digits_allowed() {
+    let env = Env::default();
+    let input = soroban_sdk::String::from_str(&env, "goal2025");
+    let out = canonicalise_symbol_checked(&env, &input).unwrap();
+    assert_eq!(symbol_str(&out), "goal2025");
+}
+
+/// Empty string returns Err(Empty).
+#[test]
+fn test_checked_symbol_empty_returns_err() {
+    let env = Env::default();
+    let input = soroban_sdk::String::from_str(&env, "");
+    assert_eq!(
+        canonicalise_symbol_checked(&env, &input),
+        Err(SymbolValidationError::Empty),
+    );
+}
+
+/// Whitespace-only string returns Err(Empty).
+#[test]
+fn test_checked_symbol_whitespace_only_returns_err() {
+    let env = Env::default();
+    let input = soroban_sdk::String::from_str(&env, "   ");
+    assert_eq!(
+        canonicalise_symbol_checked(&env, &input),
+        Err(SymbolValidationError::Empty),
+    );
+}
+
+/// Trimmed input longer than 32 bytes returns Err(TooLong).
+#[test]
+fn test_checked_symbol_too_long_returns_err() {
+    let env = Env::default();
+    // 33 lowercase letters — one over the limit
+    let input = soroban_sdk::String::from_str(&env, "abcdefghijklmnopqrstuvwxyzabcdefg");
+    assert_eq!(
+        canonicalise_symbol_checked(&env, &input),
+        Err(SymbolValidationError::TooLong),
+    );
+}
+
+/// Exactly 32 bytes (the boundary) succeeds.
+#[test]
+fn test_checked_symbol_exactly_32_bytes_passes() {
+    let env = Env::default();
+    let input = soroban_sdk::String::from_str(&env, "abcdefghijklmnopqrstuvwxyzabcdef");
+    let out = canonicalise_symbol_checked(&env, &input).unwrap();
+    assert_eq!(symbol_str(&out), "abcdefghijklmnopqrstuvwxyzabcdef");
+}
+
+/// Hyphen at position 5 returns Err(InvalidChar { position: 5 }).
+#[test]
+fn test_checked_symbol_hyphen_returns_invalid_char() {
+    let env = Env::default();
+    let input = soroban_sdk::String::from_str(&env, "hello-world");
+    assert_eq!(
+        canonicalise_symbol_checked(&env, &input),
+        Err(SymbolValidationError::InvalidChar { position: 5 }),
+    );
+}
+
+/// Internal space (after trimming) returns Err(InvalidChar) at the correct byte position.
+#[test]
+fn test_checked_symbol_internal_space_returns_invalid_char() {
+    let env = Env::default();
+    // leading space is trimmed; remaining "hello world" has space at position 5
+    let input = soroban_sdk::String::from_str(&env, " hello world");
+    assert_eq!(
+        canonicalise_symbol_checked(&env, &input),
+        Err(SymbolValidationError::InvalidChar { position: 5 }),
+    );
+}
+
+/// `@` at position 0 returns Err(InvalidChar { position: 0 }).
+#[test]
+fn test_checked_symbol_at_sign_returns_invalid_char() {
+    let env = Env::default();
+    let input = soroban_sdk::String::from_str(&env, "@admin");
+    assert_eq!(
+        canonicalise_symbol_checked(&env, &input),
+        Err(SymbolValidationError::InvalidChar { position: 0 }),
+    );
+}
+
+/// Dot (`.`) at position 4 returns Err(InvalidChar { position: 4 }).
+#[test]
+fn test_checked_symbol_dot_returns_invalid_char() {
+    let env = Env::default();
+    let input = soroban_sdk::String::from_str(&env, "v1_0.1");
+    assert_eq!(
+        canonicalise_symbol_checked(&env, &input),
+        Err(SymbolValidationError::InvalidChar { position: 4 }),
+    );
+}
+
+/// Short-circuits on the FIRST bad byte, not the last.
+#[test]
+fn test_checked_symbol_short_circuits_on_first_invalid_char() {
+    let env = Env::default();
+    // '!' at index 3; '@' at index 5 — only position 3 should be reported
+    let input = soroban_sdk::String::from_str(&env, "bad!xy@z");
+    assert_eq!(
+        canonicalise_symbol_checked(&env, &input),
+        Err(SymbolValidationError::InvalidChar { position: 3 }),
+    );
+}
+
+/// Idempotence: applying checked twice yields the same Symbol.
+#[test]
+fn test_checked_symbol_idempotent() {
+    let env = Env::default();
+    let input = soroban_sdk::String::from_str(&env, "  HeLLo_WORLD  ");
+    let once = canonicalise_symbol_checked(&env, &input).unwrap();
+    let once_str = symbol_str(&once);
+    let twice_input = soroban_sdk::String::from_str(&env, &once_str);
+    let twice = canonicalise_symbol_checked(&env, &twice_input).unwrap();
+    assert_eq!(symbol_str(&once), symbol_str(&twice));
+}
+
+// ─── canonicalise_symbols (batch) ────────────────────────────────────────────
+
+/// Empty batch returns Err(Empty).
+#[test]
+fn test_canonicalise_symbols_empty_batch_returns_err() {
+    let env = Env::default();
+    let empty: soroban_sdk::Vec<soroban_sdk::String> = soroban_sdk::Vec::new(&env);
+    assert_eq!(
+        canonicalise_symbols(&env, &empty),
+        Err(SymbolValidationError::Empty),
+    );
+}
+
+/// Valid batch — all symbols canonicalised in order.
+#[test]
+fn test_canonicalise_symbols_valid_batch() {
+    let env = Env::default();
+    let mut inputs: soroban_sdk::Vec<soroban_sdk::String> = soroban_sdk::Vec::new(&env);
+    inputs.push_back(soroban_sdk::String::from_str(&env, "Hello"));
+    inputs.push_back(soroban_sdk::String::from_str(&env, "WORLD"));
+    inputs.push_back(soroban_sdk::String::from_str(&env, "my_key"));
+
+    let out = canonicalise_symbols(&env, &inputs).unwrap();
+    assert_eq!(out.len(), 3);
+    assert_eq!(symbol_str(&out.get(0).unwrap()), "hello");
+    assert_eq!(symbol_str(&out.get(1).unwrap()), "world");
+    assert_eq!(symbol_str(&out.get(2).unwrap()), "my_key");
+}
+
+/// Order is preserved in the batch output.
+#[test]
+fn test_canonicalise_symbols_order_preserved() {
+    let env = Env::default();
+    let mut inputs: soroban_sdk::Vec<soroban_sdk::String> = soroban_sdk::Vec::new(&env);
+    inputs.push_back(soroban_sdk::String::from_str(&env, "zebra"));
+    inputs.push_back(soroban_sdk::String::from_str(&env, "apple"));
+    inputs.push_back(soroban_sdk::String::from_str(&env, "mango"));
+
+    let out = canonicalise_symbols(&env, &inputs).unwrap();
+    assert_eq!(symbol_str(&out.get(0).unwrap()), "zebra");
+    assert_eq!(symbol_str(&out.get(1).unwrap()), "apple");
+    assert_eq!(symbol_str(&out.get(2).unwrap()), "mango");
+}
+
+/// First invalid element short-circuits the batch.
+#[test]
+fn test_canonicalise_symbols_invalid_element_short_circuits() {
+    let env = Env::default();
+    let mut inputs: soroban_sdk::Vec<soroban_sdk::String> = soroban_sdk::Vec::new(&env);
+    inputs.push_back(soroban_sdk::String::from_str(&env, "valid_one"));
+    inputs.push_back(soroban_sdk::String::from_str(&env, "bad-char"));  // hyphen at pos 3
+    inputs.push_back(soroban_sdk::String::from_str(&env, "valid_two"));
+
+    assert_eq!(
+        canonicalise_symbols(&env, &inputs),
+        Err(SymbolValidationError::InvalidChar { position: 3 }),
+    );
+}
+
+/// Too-long element in a batch returns Err(TooLong).
+#[test]
+fn test_canonicalise_symbols_too_long_element() {
+    let env = Env::default();
+    let mut inputs: soroban_sdk::Vec<soroban_sdk::String> = soroban_sdk::Vec::new(&env);
+    inputs.push_back(soroban_sdk::String::from_str(&env, "ok"));
+    inputs.push_back(soroban_sdk::String::from_str(&env, "abcdefghijklmnopqrstuvwxyzabcdefg")); // 33 chars
+
+    assert_eq!(
+        canonicalise_symbols(&env, &inputs),
+        Err(SymbolValidationError::TooLong),
+    );
+}
+
+/// Single-element batch works end-to-end.
+#[test]
+fn test_canonicalise_symbols_single_element() {
+    let env = Env::default();
+    let mut inputs: soroban_sdk::Vec<soroban_sdk::String> = soroban_sdk::Vec::new(&env);
+    inputs.push_back(soroban_sdk::String::from_str(&env, "  MyKey  "));
+    let out = canonicalise_symbols(&env, &inputs).unwrap();
+    assert_eq!(out.len(), 1);
+    assert_eq!(symbol_str(&out.get(0).unwrap()), "mykey");
+}
+
 // ─── clamp_limit ─────────────────────────────────────────────────────────────
 
 /// 0 is treated as "use default" and returns DEFAULT_PAGE_LIMIT.
@@ -1788,7 +2049,7 @@ proptest! {
 #[test]
 fn require_valid_symbol_length_empty_input_returns_empty_error() {
     assert_eq!(
-        require_valid_symbol_length(b""),
+        require_valid_symbol_length_bytes(b""),
         Err(SymbolLengthError::Empty),
         "empty name must be rejected with SymbolLengthError::Empty"
     );
@@ -1798,7 +2059,7 @@ fn require_valid_symbol_length_empty_input_returns_empty_error() {
 #[test]
 fn require_valid_symbol_length_one_char_returns_ok() {
     assert_eq!(
-        require_valid_symbol_length(b"A"),
+        require_valid_symbol_length_bytes(b"A"),
         Ok(()),
         "1-byte name is the lower boundary and must be accepted"
     );
@@ -1811,7 +2072,7 @@ fn require_valid_symbol_length_nine_chars_returns_ok() {
     const NAME: &[u8] = b"NINE_BYTE"; // 9 bytes
     const _: () = assert!(NAME.len() == 9);
     assert_eq!(
-        require_valid_symbol_length(NAME),
+        require_valid_symbol_length_bytes(NAME),
         Ok(()),
         "9-byte name is exactly at the symbol_short! cap and must be accepted"
     );
@@ -1823,7 +2084,7 @@ fn require_valid_symbol_length_ten_chars_returns_too_long_error() {
     const NAME: &[u8] = b"TEN_BYTES_"; // 10 bytes
     const _: () = assert!(NAME.len() == 10);
     assert_eq!(
-        require_valid_symbol_length(NAME),
+        require_valid_symbol_length_bytes(NAME),
         Err(SymbolLengthError::TooLong),
         "10-byte name exceeds the symbol_short! cap and must be rejected with SymbolLengthError::TooLong"
     );
@@ -1834,7 +2095,7 @@ fn require_valid_symbol_length_ten_chars_returns_too_long_error() {
 fn require_valid_symbol_length_very_long_input_returns_too_long_error() {
     let name = b"TOOLONGKEYNAME"; // 14 bytes
     assert_eq!(
-        require_valid_symbol_length(name),
+        require_valid_symbol_length_bytes(name),
         Err(SymbolLengthError::TooLong),
         "names well above the cap must also be rejected with SymbolLengthError::TooLong"
     );


### PR DESCRIPTION
# Description

This PR introduces robust canonicalisation helpers for Soroban `Symbol` values in the `remitwise-common` crate. The previous implementation silently bypassed uppercase translations securely, lacking explicit charset validation that caused unpredictable errors on Soroban boundary conditions.

This updates `canonicalise_symbol` and introduces typed equivalents, `canonicalise_symbol_checked`, and a batch map processor `canonicalise_symbols` that closely meet the defined documentation requirements:
- **Trim:** Implicitly strips leading and trailing ASCII whitespace.
- **Casefold:** Silently converts ASCII alphabetical characters to lowercase.
- **Charset Validation:** Actively evaluates bytes and explicitly rejects elements outside the expected subset `[a-z0-9_]`. Offending indices safely return `SymbolValidationError::InvalidChar { position }`. Empty strings and long variants (max 32 chars) correctly fail via `Empty` and `TooLong`.

### Changes Summary
- Completely rewrote `canonicalise_symbol` with validated mapping against the Soroban base `[a-z0-9_]` charset. Pre-runtime boundary checks now return precise descriptive panics instead of failing invisibly at environment bindings.
- Created `SymbolValidationError` to model precise execution failures (`Empty`, `TooLong`, `InvalidChar`).
- Exposed the typed `canonicalise_symbol_checked` and iterative `canonicalise_symbols`.
- Fixed existing unresolved test suite overlaps and wrote comprehensive unit tests mapping all conditions for edge-case coverage on the canonicalisation utility functions.
- Updated the canonical reference guide (`docs/CANONICALISATION.md`) under Section 5 to highlight structural rules for the key.
- Adjusted features summary in `remitwise-common/README.md`.

### Threat Model & Impact
- Pre-emptively maps any variant of trailing gaps to the same canonical baseline, ensuring `MyKey` and `  mykey  ` act identically and cannot shadow equivalent configurations.
- Filters spaces in multi-word elements proactively (e.g. `bad char`), generating typed errors before state persistence, which mitigates hidden panics later in execution boundaries.

All features are tested against `cargo test` and `release` configurations successfully.

Closes #1147