### PR TITLE
test: add live source-scan guard for storage key naming conventions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,6 +313,11 @@ jobs:
           cargo test --package testutils storage_key_naming_test -- --nocapture
         continue-on-error: false
 
+      - name: Run storage key source scan (drift detection)
+        run: |
+          cargo test --package testutils --test storage_key_source_scan_test -- --nocapture
+        continue-on-error: false
+
   gas-benchmarks:
     name: Gas Benchmarks
     runs-on: macos-latest

--- a/STORAGE_LAYOUT.md
+++ b/STORAGE_LAYOUT.md
@@ -21,12 +21,13 @@ All storage keys follow strict naming conventions to ensure consistency and comp
 - **Format:** UPPERCASE_WITH_UNDERSCORES
 - **Valid characters:** A-Z, 0-9, \_ (underscore)
 
-These conventions are automatically validated in CI. See [Storage Key Naming Conventions](docs/storage-key-naming-conventions.md) for detailed guidelines and [testutils/tests/README.md](testutils/tests/README.md) for information about the automated validation tests.
+These conventions are automatically validated in CI by two complementary test suites: a hand-maintained catalogue check (`storage_key_naming_test.rs`) and a live source scan (`storage_key_source_scan_test.rs`) that parses each contract's `src/lib.rs` directly so a key added or renamed in code can't silently drift out of sync with the documented conventions. See [Storage Key Naming Conventions](docs/storage-key-naming-conventions.md) for detailed guidelines and [testutils/tests/README.md](testutils/tests/README.md) for information about the automated validation tests.
 
 **Run validation tests:**
 
 ```bash
-cargo test --package testutils storage_key_naming_test -- --nocapture
+# Catalogue check + live source scan
+cargo test --package testutils storage_key -- --nocapture
 ```
 
 ## Common Patterns

--- a/docs/storage-key-naming-conventions.md
+++ b/docs/storage-key-naming-conventions.md
@@ -163,21 +163,50 @@ The following keys are used consistently across multiple contracts:
 
 ## Automated Validation
 
-Storage key naming conventions are automatically validated in CI through the `storage_key_naming_test` test suite located in `testutils/tests/storage_key_naming_test.rs`.
+Storage key naming conventions are automatically validated in CI through two complementary test suites:
+
+1. **`testutils/tests/storage_key_naming_test.rs`** - Validates a hand-maintained
+   catalogue of documented storage keys (see [Common Storage Keys](#common-storage-keys)
+   and [Contract-Specific Keys](#contract-specific-keys) above) against the
+   conventions in this document.
+2. **`testutils/tests/storage_key_source_scan_test.rs`** - Parses each
+   contract crate's `src/lib.rs` directly and extracts every storage-key
+   literal actually passed to a Soroban storage accessor (`.get()`, `.set()`,
+   `.has()`, `.remove()`), then validates those against the same
+   length/format constraints.
+
+The hand-maintained catalogue is easy to read but nothing forces it to stay
+in sync with the code: a key can be renamed or added in source without the
+catalogue (or its checks) ever noticing. The source scan closes that gap by
+validating what the code actually does, independent of whether anyone
+remembered to update the catalogue. Running both together means drift
+between "documented convention" and "real on-chain key" fails CI regardless
+of which side changed.
+
+Note: `savings_goals` and `insurance` primarily use a composite `DataKey`
+enum (`DataKey::Goal(u32)`, `DataKey::Policy(u32)`, ...) for most of their
+storage rather than inline `symbol_short!` literals - see the "Scalable
+DataKey Pattern" note in [STORAGE_LAYOUT.md](../STORAGE_LAYOUT.md). Enum
+variants don't carry a naming-convention string literal at the call site, so
+the source scan only covers their remaining literal-keyed entries (e.g.
+`VERSION`, `SNAP_TS`). This is expected, not a scanner gap.
 
 ### Running Tests Locally
 
 ```bash
-# Run all storage key validation tests
-cargo test --package testutils storage_key_naming_test -- --nocapture
+# Run all storage key validation tests (catalogue + source scan)
+cargo test --package testutils storage_key -- --nocapture
 
 # Run specific test
 cargo test --package testutils test_all_keys_within_max_length -- --nocapture
+
+# Run only the live-source drift scan
+cargo test --package testutils --test storage_key_source_scan_test -- --nocapture
 ```
 
 ### Test Coverage
 
-The automated tests validate:
+The catalogue-based tests (`storage_key_naming_test.rs`) validate:
 
 1. **Length Constraint** - All keys are ≤ 9 characters
 2. **Format Validation** - All keys use UPPERCASE_WITH_UNDERSCORES
@@ -189,11 +218,23 @@ The automated tests validate:
 8. **Documentation Coverage** - All keys have descriptions
 9. **Consistency Check** - Common keys are used consistently
 
+The source-scan tests (`storage_key_source_scan_test.rs`) validate, directly
+against `src/lib.rs` in every contract crate:
+
+1. **Length Constraint** - Every scanned key literal is ≤ 9 characters
+2. **Format Validation** - Every scanned key literal is UPPERCASE_WITH_UNDERSCORES
+3. **Underscore Placement** - No leading/trailing/consecutive underscores
+4. **Scanner Coverage** - A fixed set of well-known keys must still be found,
+   guarding against the parsing heuristic silently regressing
+
 ### CI Integration
 
-The storage key validation runs automatically on every pull request and push to main through the GitHub Actions workflow defined in `.github/workflows/ci.yml`.
+Both test suites run automatically on every pull request and push to main
+through the GitHub Actions workflow defined in `.github/workflows/ci.yml`.
 
-The `storage-key-validation` job will fail if any naming convention violations are detected, preventing non-compliant keys from being merged.
+The `storage-key-validation` job will fail if any naming convention
+violations are detected — by the catalogue check, the source scan, or
+both — preventing non-compliant keys from being merged.
 
 ## Adding New Storage Keys
 

--- a/testutils/tests/README.md
+++ b/testutils/tests/README.md
@@ -4,9 +4,10 @@
 
 This directory contains automated tests that validate storage key naming conventions across all Remitwise smart contracts. These tests ensure that all storage keys comply with Soroban's `symbol_short!` constraints and maintain consistency across the codebase.
 
-## Test File
+## Test Files
 
-- **`storage_key_naming_test.rs`** - Comprehensive validation suite for storage key naming conventions
+- **`storage_key_naming_test.rs`** - Comprehensive validation suite for a hand-maintained catalogue of documented storage keys
+- **`storage_key_source_scan_test.rs`** - Parses each contract crate's `src/lib.rs` directly, extracts every storage-key literal actually passed to a Soroban storage accessor (`.get()`, `.set()`, `.has()`, `.remove()`), and re-validates those against the same conventions. This catches drift that the hand-maintained catalogue can miss: a key can be added or renamed in source without anyone remembering to update `storage_key_naming_test.rs`, and this scan will still catch a convention violation because it reads the real code, not a snapshot of it.
 
 ## What Gets Validated
 
@@ -37,6 +38,22 @@ Ensures every storage key has a description explaining its purpose.
 ### 9. Consistency Checks
 Identifies common keys used across multiple contracts and validates they're used consistently.
 
+## Source Scan (Drift Detection)
+
+`storage_key_source_scan_test.rs` runs the same length/format/underscore
+checks (items 1, 2, 6, 7 above) directly against every storage-key literal
+it finds in each contract's `src/lib.rs`, plus a scanner self-check that a
+fixed set of well-known keys are still found (guards against the parsing
+heuristic silently regressing). It recognizes two shapes:
+
+1. An inline literal: `env.storage().instance().get(&symbol_short!("KEY"))`
+2. A local named constant used at a storage call site:
+   `const KEY: Symbol = symbol_short!("KEY");` ... `.set(&KEY, &v)`
+
+`savings_goals` and `insurance` mostly use a composite `DataKey` enum
+instead of literal keys, so the scan naturally finds fewer entries for
+those two crates - see [STORAGE_LAYOUT.md](../../STORAGE_LAYOUT.md).
+
 ## Running the Tests
 
 ### Run All Storage Key Tests
@@ -59,6 +76,12 @@ cargo test --package testutils test_no_duplicate_keys_within_contract -- --nocap
 
 # View storage key summary
 cargo test --package testutils test_print_storage_key_summary -- --nocapture
+```
+
+### Run the Source Scan Only
+
+```bash
+cargo test --package testutils --test storage_key_source_scan_test -- --nocapture
 ```
 
 ### Run from Workspace Root
@@ -145,9 +168,15 @@ When adding a new storage key to any contract:
    - Add the key to `STORAGE_LAYOUT.md`
    - Add the key to `docs/storage-key-naming-conventions.md`
 
+Note: `storage_key_source_scan_test.rs` validates length/format automatically
+against the real source, so a non-compliant key literal fails CI even if step
+2 (updating the catalogue) is forgotten. The catalogue update in step 2 is
+still required for documentation coverage and consistency checks, which only
+run against the curated list.
+
 ## CI Integration
 
-These tests run automatically in CI through the GitHub Actions workflow (`.github/workflows/ci.yml`). The `storage-key-validation` job will fail if any naming convention violations are detected.
+These tests run automatically in CI through the GitHub Actions workflow (`.github/workflows/ci.yml`). The `storage-key-validation` job will fail if any naming convention violations are detected, either in the hand-maintained catalogue or in the live source scan.
 
 ### CI Job Configuration
 
@@ -156,11 +185,16 @@ storage-key-validation:
   name: Storage Key Naming Convention Validation
   runs-on: macos-latest
   timeout-minutes: 5
-  
+
   steps:
     - name: Run storage key naming convention tests
       run: |
         cargo test --package testutils storage_key_naming_test -- --nocapture
+      continue-on-error: false
+
+    - name: Run storage key source scan (drift detection)
+      run: |
+        cargo test --package testutils --test storage_key_source_scan_test -- --nocapture
       continue-on-error: false
 ```
 

--- a/testutils/tests/storage_key_source_scan_test.rs
+++ b/testutils/tests/storage_key_source_scan_test.rs
@@ -1,0 +1,337 @@
+//! Storage key naming convention: live source scan.
+//!
+//! `storage_key_naming_test.rs` validates a hand-maintained catalogue of
+//! storage keys. That catalogue is a snapshot: nothing forces it to stay in
+//! sync with the actual contract source, so a key can be renamed or added in
+//! code without the catalogue (or its format checks) ever seeing it.
+//!
+//! This module closes that gap by parsing each contract crate's `src/lib.rs`
+//! directly and extracting every storage-key literal actually passed to a
+//! Soroban storage accessor (`.get(...)`, `.set(...)`, `.has(...)`,
+//! `.remove(...)`), then re-running the same length/format constraints
+//! against what the source really contains. A drift between "what the code
+//! does" and "what the catalogue says" now fails CI regardless of which side
+//! changed.
+//!
+//! ## What counts as a storage key here
+//!
+//! Two shapes are recognized:
+//! 1. An inline literal: `env.storage().instance().get(&symbol_short!("KEY"))`
+//! 2. A local named constant: `const KEY: Symbol = symbol_short!("KEY");`
+//!    later passed by name to a storage accessor in the same file, e.g.
+//!    `env.storage().instance().set(&STORAGE_UNPAID_TOTALS, &v)`.
+//!
+//! Anything else passed to these accessors (composite `DataKey` enum
+//! variants, function parameters, cross-crate constants such as
+//! `SNAPSHOT_KEY` from `remitwise-common`) is intentionally skipped: those
+//! don't carry a naming-convention string literal at the call site, so
+//! there is nothing here to validate. Event topics and action symbols
+//! (e.g. `symbol_short!("created")`) are also excluded by construction: the
+//! naming convention only applies to storage keys, and this scan only looks
+//! at arguments of storage accessor calls, not `.events().publish(...)`.
+//!
+//! Reference: `docs/storage-key-naming-conventions.md`, `STORAGE_LAYOUT.md`.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::PathBuf;
+
+/// Same constraint as `storage_key_naming_test.rs` (Soroban `symbol_short!`
+/// limit). Duplicated intentionally: this file validates the source
+/// directly and must not depend on the other test's internal list.
+const MAX_KEY_LENGTH: usize = 9;
+
+/// Crates scanned for storage keys. Excludes crates with no on-chain
+/// Soroban storage of their own (`data_migration`, `cli`, `scenarios`,
+/// `integration_tests`, `testutils`).
+const SCANNED_CRATES: &[&str] = &[
+    "remittance_split",
+    "savings_goals",
+    "bill_payments",
+    "insurance",
+    "family_wallet",
+    "reporting",
+    "orchestrator",
+    "emergency_killswitch",
+    "remitwise-common",
+];
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("testutils has a parent directory")
+        .to_path_buf()
+}
+
+/// Finds every `const NAME: Symbol = symbol_short!("KEY");` (with or
+/// without a `pub` prefix) in `src` and returns a map of `NAME -> KEY`.
+fn find_local_symbol_consts(src: &str) -> BTreeMap<String, String> {
+    let mut consts = BTreeMap::new();
+    let marker = "const ";
+    let mut cursor = 0usize;
+
+    while let Some(rel) = src[cursor..].find(marker) {
+        let name_start = cursor + rel + marker.len();
+        let rest = &src[name_start..];
+
+        let name_end = rest
+            .find(|c: char| !(c.is_alphanumeric() || c == '_'))
+            .unwrap_or(rest.len());
+        let name = &rest[..name_end];
+        cursor = name_start + name_end.max(1);
+
+        if name.is_empty() {
+            continue;
+        }
+
+        let after_name = rest[name_end..].trim_start();
+        let Some(after_colon) = after_name.strip_prefix(':') else {
+            continue;
+        };
+        let after_type = after_colon.trim_start();
+        let Some(after_symbol_ty) = after_type.strip_prefix("Symbol") else {
+            continue;
+        };
+        let after_eq = after_symbol_ty.trim_start();
+        let Some(after_eq) = after_eq.strip_prefix('=') else {
+            continue;
+        };
+        let after_eq = after_eq.trim_start();
+        let Some(after_macro) = after_eq.strip_prefix("symbol_short!(\"") else {
+            continue;
+        };
+        if let Some(quote_end) = after_macro.find('"') {
+            consts.insert(name.to_string(), after_macro[..quote_end].to_string());
+        }
+    }
+
+    consts
+}
+
+/// Returns byte offsets of the opening `(` for every call to `.{accessor}(`
+/// or `.{accessor}::<...>(` in `src`.
+fn find_call_open_parens(src: &str, accessor: &str) -> Vec<usize> {
+    let dotted = format!(".{accessor}");
+    let mut sites = Vec::new();
+    let mut cursor = 0usize;
+
+    while let Some(rel) = src[cursor..].find(&dotted) {
+        let idx = cursor + rel;
+        let after = idx + dotted.len();
+        match src[after..].chars().next() {
+            Some('(') => {
+                sites.push(after);
+                cursor = after + 1;
+            }
+            Some(':') => {
+                if let Some(paren_rel) = src[after..].find('(') {
+                    sites.push(after + paren_rel);
+                    cursor = after + paren_rel + 1;
+                } else {
+                    cursor = after;
+                }
+            }
+            _ => cursor = after,
+        }
+    }
+
+    sites
+}
+
+/// Given the byte offset of a call's opening `(`, returns the source text of
+/// its first top-level argument (i.e. up to the first depth-1 comma, or the
+/// closing `)` if there is only one argument). Handles nested parens such as
+/// `symbol_short!("X")` or `DataKey::Goal(id)`.
+fn extract_first_arg(src: &str, open_idx: usize) -> Option<&str> {
+    let bytes = src.as_bytes();
+    let arg_start = open_idx + 1;
+    let mut depth = 1i32;
+    let mut i = arg_start;
+
+    while i < bytes.len() {
+        match bytes[i] {
+            b'(' => depth += 1,
+            b')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(&src[arg_start..i]);
+                }
+            }
+            b',' if depth == 1 => return Some(&src[arg_start..i]),
+            _ => {}
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Extracts every storage key literal used in `src` (see module docs for
+/// exactly what is and isn't recognized).
+fn extract_storage_keys(src: &str) -> BTreeSet<String> {
+    let local_consts = find_local_symbol_consts(src);
+    let mut keys = BTreeSet::new();
+
+    for accessor in ["get", "set", "has", "remove"] {
+        for open_idx in find_call_open_parens(src, accessor) {
+            let Some(raw_arg) = extract_first_arg(src, open_idx) else {
+                continue;
+            };
+            let arg = raw_arg.trim().trim_start_matches('&').trim();
+
+            if let Some(rest) = arg.strip_prefix("symbol_short!(\"") {
+                if let Some(quote_end) = rest.find('"') {
+                    keys.insert(rest[..quote_end].to_string());
+                }
+                continue;
+            }
+
+            // Bare identifier (no path separators, no nested calls) that
+            // resolves to a local `const NAME: Symbol = symbol_short!(...)`.
+            if !arg.is_empty() && arg.chars().all(|c| c.is_alphanumeric() || c == '_') {
+                if let Some(key) = local_consts.get(arg) {
+                    keys.insert(key.clone());
+                }
+            }
+        }
+    }
+
+    keys
+}
+
+/// Reads `<crate>/src/lib.rs` for every crate in `SCANNED_CRATES` and
+/// returns `(crate_name, storage_key)` pairs for every key found.
+fn scan_all_crates() -> Vec<(&'static str, String)> {
+    let root = workspace_root();
+    let mut found = Vec::new();
+
+    for crate_name in SCANNED_CRATES {
+        let path = root.join(crate_name).join("src").join("lib.rs");
+        let src = fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()));
+
+        for key in extract_storage_keys(&src) {
+            found.push((*crate_name, key));
+        }
+    }
+
+    found
+}
+
+#[test]
+fn scanned_storage_keys_within_max_length() {
+    let violations: Vec<String> = scan_all_crates()
+        .into_iter()
+        .filter(|(_, key)| key.len() > MAX_KEY_LENGTH)
+        .map(|(krate, key)| {
+            format!(
+                "❌ {krate}: '{key}' exceeds max length {MAX_KEY_LENGTH} (actual: {})",
+                key.len()
+            )
+        })
+        .collect();
+
+    assert!(
+        violations.is_empty(),
+        "\n\nStorage key length violations found in live source:\n{}\n\n\
+         A storage key was added or renamed in source without honoring the \
+         {MAX_KEY_LENGTH}-character symbol_short! limit. See \
+         docs/storage-key-naming-conventions.md.\n",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn scanned_storage_keys_are_uppercase_with_underscores() {
+    let violations: Vec<String> = scan_all_crates()
+        .into_iter()
+        .filter(|(_, key)| !key.chars().all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_'))
+        .map(|(krate, key)| format!("❌ {krate}: '{key}' is not UPPERCASE_WITH_UNDERSCORES"))
+        .collect();
+
+    assert!(
+        violations.is_empty(),
+        "\n\nStorage key format violations found in live source:\n{}\n\n\
+         A storage key literal in source does not follow the documented \
+         UPPERCASE_WITH_UNDERSCORES convention. See \
+         docs/storage-key-naming-conventions.md.\n",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn scanned_storage_keys_have_no_leading_trailing_or_double_underscores() {
+    let violations: Vec<String> = scan_all_crates()
+        .into_iter()
+        .filter(|(_, key)| key.starts_with('_') || key.ends_with('_') || key.contains("__") || key.is_empty())
+        .map(|(krate, key)| format!("❌ {krate}: '{key}' has an underscore placement violation"))
+        .collect();
+
+    assert!(
+        violations.is_empty(),
+        "\n\nStorage key underscore-placement violations found in live source:\n{}\n",
+        violations.join("\n")
+    );
+}
+
+/// Sanity check on the scanner itself: it must actually find well-known
+/// keys that are stored as inline `symbol_short!` literals, so a change to
+/// the parsing heuristics that silently stops matching real code is caught
+/// here rather than by every key quietly disappearing from coverage.
+///
+/// Note: `savings_goals` and `insurance` primarily use a composite `DataKey`
+/// enum (`DataKey::Goal(u32)`, `DataKey::Policy(u32)`, ...) rather than
+/// inline `symbol_short!` literals for most of their storage - see
+/// "Scalable DataKey Pattern" in `STORAGE_LAYOUT.md`. Those enum variants
+/// don't carry a naming-convention string literal at the call site, so this
+/// scanner (by design, see module docs) finds only their few remaining
+/// literal-keyed entries (e.g. `SNAP_TS`, `VERSION`), not the full catalogue
+/// in `storage_key_naming_test.rs`.
+#[test]
+fn scanner_finds_known_keys_across_contracts() {
+    let found: BTreeSet<(&'static str, String)> = scan_all_crates().into_iter().collect();
+
+    let expected = [
+        ("remittance_split", "CONFIG"),
+        ("remittance_split", "PAUSE_ADM"),
+        ("savings_goals", "SNAP_TS"),
+        ("bill_payments", "BILLS"),
+        ("bill_payments", "UNPD_TOT"),
+        ("insurance", "VERSION"),
+        ("family_wallet", "OWNER"),
+        ("family_wallet", "MEMBERS"),
+        ("reporting", "ADMIN"),
+        ("orchestrator", "STATS"),
+        ("orchestrator", "AUDIT"),
+    ];
+
+    let missing: Vec<String> = expected
+        .iter()
+        .filter(|(krate, key)| !found.contains(&(*krate, key.to_string())))
+        .map(|(krate, key)| format!("{krate}::{key}"))
+        .collect();
+
+    assert!(
+        missing.is_empty(),
+        "\n\nScanner failed to find expected well-known storage keys: {:?}\n\
+         Either the parsing heuristic regressed, or these keys were \
+         genuinely removed from source (update this test's expectations \
+         if so).\n",
+        missing
+    );
+}
+
+#[test]
+fn print_scanned_storage_key_summary() {
+    let found = scan_all_crates();
+    let mut per_crate: BTreeMap<&str, BTreeSet<String>> = BTreeMap::new();
+    for (krate, key) in found {
+        per_crate.entry(krate).or_default().insert(key);
+    }
+
+    println!("\n📡 Live Source Storage Key Scan:");
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+    for (krate, keys) in &per_crate {
+        println!("  • {krate}: {} keys -> {:?}", keys.len(), keys);
+    }
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
+}


### PR DESCRIPTION
Closes #1419

## Summary

`STORAGE_LAYOUT.md` / `docs/storage-key-naming-conventions.md` document naming conventions for storage keys (≤9 chars, `UPPERCASE_WITH_UNDERSCORES`), and `testutils/tests/storage_key_naming_test.rs` already validates a hand-maintained catalogue of those keys. The problem: nothing forces that catalogue to stay in sync with the actual contract source. A key can be renamed or added in code and the catalogue (and its checks) would never notice — exactly the "accidental drift" this issue asks to guard against.

This PR adds a second, complementary test that closes that gap by scanning the **real source** instead of a hand-maintained list.

## What's new

### `testutils/tests/storage_key_source_scan_test.rs` (new)

Parses each contract crate's `src/lib.rs` directly and extracts every storage-key literal actually passed to a Soroban storage accessor (`.get()`, `.set()`, `.has()`, `.remove()`), recognizing two shapes:

1. An inline literal: `env.storage().instance().get(&symbol_short!("KEY"))`
2. A local named constant used at the call site: `const KEY: Symbol = symbol_short!("KEY");` ... `.set(&KEY, &v)`

It then re-validates every extracted key against the documented conventions:

- `scanned_storage_keys_within_max_length` — ≤ 9 characters
- `scanned_storage_keys_are_uppercase_with_underscores` — UPPERCASE_WITH_UNDERSCORES
- `scanned_storage_keys_have_no_leading_trailing_or_double_underscores`
- `scanner_finds_known_keys_across_contracts` — a scanner self-check: a fixed set of well-known keys must still be found, so a regression in the parsing heuristic itself fails loudly instead of silently reducing coverage
- `print_scanned_storage_key_summary` — prints a per-crate summary for local debugging (`--nocapture`)

Scans `remittance_split`, `savings_goals`, `bill_payments`, `insurance`, `family_wallet`, `reporting`, `orchestrator`, `emergency_killswitch`, and `remitwise-common`.

**It already found real drift**: several storage keys that are compliant with the naming convention but were never added to the hand-maintained catalogue or documented in `STORAGE_LAYOUT.md` — `TRSR_PEND`, `CRIDORS` (`remittance_split`), `PREC_LIM`, `SPND_TRK`, `EM_VOL` (`family_wallet`), `PADM_GT` (`bill_payments`), `INV_EPOCH` (`remitwise-common`). All happen to already be convention-compliant, so nothing is broken today — but this is direct evidence the new scan catches things the old catalogue-only test structurally cannot. (Backfilling those into `STORAGE_LAYOUT.md`'s per-contract tables is a separate documentation task; flagging here rather than silently expanding this PR's scope.)

Note: `savings_goals` and `insurance` mostly use a composite `DataKey` enum (`DataKey::Goal(u32)`, `DataKey::Policy(u32)`, ...) instead of inline `symbol_short!` literals for most of their storage (see "Scalable DataKey Pattern" in `STORAGE_LAYOUT.md`). Enum variants don't carry a naming-convention string literal at the call site, so the scan only covers their remaining literal-keyed entries (`VERSION`, `SNAP_TS`). This is by design, documented in the test file's module doc and in `docs/storage-key-naming-conventions.md`.

## Modified files

- **`.github/workflows/ci.yml`** — added a step to the existing `storage-key-validation` job to also run `cargo test --package testutils --test storage_key_source_scan_test`
- **`docs/storage-key-naming-conventions.md`** — documents both test suites, why the scan exists, and the `DataKey`-enum caveat
- **`STORAGE_LAYOUT.md`** — updated the "Automated Validation" section to mention both suites
- **`testutils/tests/README.md`** — added a "Source Scan (Drift Detection)" section, updated run commands and the CI job snippet

## Implementation details

The scanner is pure `std`, no new dependencies (this sandbox has no network access to fetch new crates, and the existing `deny.toml`/dependency-policy tests gate new dependencies, so this was also the more conservative choice). It:

1. Finds every `.get(`, `.set(`, `.has(`, `.remove(` call site (including turbofish forms like `.get::<_, u32>(`) via straightforward substring scanning.
2. Extracts the first top-level argument via balanced-paren matching (so nested calls like `symbol_short!("X")` or `DataKey::Goal(id)` don't confuse the split).
3. If the argument is an inline `symbol_short!("KEY")`, extracts `KEY` directly.
4. If the argument is a bare identifier (no `::`, no nested calls — which already excludes `DataKey::Variant(...)` and function parameters), resolves it against locally-defined `const NAME: Symbol = symbol_short!("KEY")` constants found in the same file.
5. Everything else (composite `DataKey` enum variants, cross-crate constants like `SNAPSHOT_KEY` from `remitwise-common`, function parameters) is intentionally skipped — those don't carry a naming-convention string literal at the call site.

Event topics and action symbols (e.g. `symbol_short!("created")`, `symbol_short!("funds_add")`) are excluded by construction — the scan only inspects arguments of storage accessor calls, never `.events().publish(...)`, so lowercase event-topic literals are never misclassified as storage keys.

## Tests added

All five `#[test]` functions in `storage_key_source_scan_test.rs` (see above). Verified locally:

```
running 5 tests
test scanned_storage_keys_are_uppercase_with_underscores ... ok
test scanned_storage_keys_within_max_length ... ok
test scanned_storage_keys_have_no_leading_trailing_or_double_underscores ... ok
test scanner_finds_known_keys_across_contracts ... ok
test print_scanned_storage_key_summary ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

The pre-existing `storage_key_naming_test.rs` suite (catalogue-based) still passes unchanged.

Note: `testutils`'s `symbol_length_boundary_test.rs` has one pre-existing, unrelated failure (`nine_char_and_ten_char_symbols_preserve_separate_storage_slots`, a soroban-sdk contract-context API misuse — `this function is not accessible outside of a contract, wrap the call with env.as_contract()`) that reproduces identically on `main` without any of this PR's changes. Not touched or introduced by this PR.

## How to test

```bash
# Just the new scan
cargo test --package testutils --test storage_key_source_scan_test -- --nocapture

# Both storage-key suites together
cargo test --package testutils storage_key -- --nocapture
```
