### PR TITLE
Emit distinct error variant for fee-rounding

### DIFF
--- a/remittance_split/src/lib.rs
+++ b/remittance_split/src/lib.rs
@@ -97,6 +97,8 @@ pub enum RemittanceSplitError {
     UnsupportedTokenContract = 31,
     /// No active treasury has accepted a treasury proposal yet.
     TreasuryNotConfigured = 32,
+    /// The corridor fee has a fractional percentage, which causes rounding issues.
+    FeeRounding = 33,
 }
 
 #[derive(Clone)]
@@ -1071,7 +1073,7 @@ impl RemittanceSplit {
     /// 2. Each `fee_bps` ≤ [`params::MAX_FEE_BPS`].
     /// 3. Each `max_amount` ≥ `min_amount` and `min_amount` ≥ [`params::MIN_CORRIDOR_AMOUNT`].
     /// 4. No duplicate corridor IDs.
-    fn validate_corridors(corridors: &Vec<Corridor>) -> Result<(), RemittanceSplitError> {
+    fn validate_corridors(env: &Env, corridors: &Vec<Corridor>) -> Result<(), RemittanceSplitError> {
         if corridors.len() > params::MAX_CORRIDORS {
             return Err(RemittanceSplitError::CorridorCountExceeded);
         }
@@ -1079,6 +1081,15 @@ impl RemittanceSplit {
             if let Some(c) = corridors.get(i) {
                 if c.fee_bps > params::MAX_FEE_BPS {
                     return Err(RemittanceSplitError::CorridorFeeTooHigh);
+                }
+                if remitwise_common::Rate::from_bps(c.fee_bps).has_fractional_percent() {
+                    soroban_sdk::log!(
+                        env,
+                        "level=ERROR error=FeeRounding corridor_id={} fee_bps={}",
+                        c.id,
+                        c.fee_bps
+                    );
+                    return Err(RemittanceSplitError::FeeRounding);
                 }
                 if c.max_amount < c.min_amount || c.min_amount < params::MIN_CORRIDOR_AMOUNT {
                     return Err(RemittanceSplitError::InvalidCorridorAmountRange);
@@ -1341,7 +1352,7 @@ impl RemittanceSplit {
             return Err(RemittanceSplitError::Unauthorized);
         }
 
-        Self::validate_corridors(&corridors)?;
+        Self::validate_corridors(&env, &corridors)?;
 
         env.storage()
             .instance()

--- a/remittance_split/src/test.rs
+++ b/remittance_split/src/test.rs
@@ -1249,6 +1249,33 @@ fn test_init_corridors_fee_too_high() {
 }
 
 #[test]
+fn test_init_corridors_fee_rounding() {
+    let env = Env::default();
+    env.mock_all_auths();
+    set_time(&env, 1_000);
+
+    let contract_id = env.register_contract(None, RemittanceSplit);
+    let client = RemittanceSplitClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let token_addr = Address::generate(&env);
+
+    client.initialize_split(&owner, &0, &token_addr, &5000, &3000, &1500, &500);
+
+    let bad = Corridor {
+        id: 1,
+        source_currency: symbol_short!("USD"),
+        dest_currency: symbol_short!("NGN"),
+        min_amount: 100,
+        max_amount: 1_000_000,
+        fee_bps: 150, // 1.5% which is a fractional percent
+    };
+    let corridors = vec![&env, bad];
+
+    let result = client.try_init_corridors(&owner, &1, &corridors);
+    assert_eq!(result, Err(Ok(RemittanceSplitError::FeeRounding)));
+}
+#[test]
 fn test_init_corridors_invalid_amount_range() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
Closes #1337 

### Summary
Added `FeeRounding` variant to `RemittanceSplitError`.
Updated `validate_corridors` in `remittance_split` to accept `Env` and check if `fee_bps` is a fractional percent. If so, it logs a structured error (key=value) at `ERROR` level and returns `FeeRounding`. Added an explicit test for the failure mode.

### Acceptance Criteria met
- [x] The change matches the summary.
- [x] Tests cover the new behavior (happy path + one explicit failure mode).
- [x] Lint, type-check, and tests all pass locally.
- [x] PR description references the issue.