### PR TITLE
feat: add require_matching_cross_contract_epoch guard

### DIFF
--- a/remitwise-common/src/lib.rs
+++ b/remitwise-common/src/lib.rs
@@ -311,6 +311,39 @@ pub fn require_no_pending_dispute_epoch(env: &Env, ep: u64) -> Result<(), Disput
     Ok(())
 }
 
+/// Typed error returned when a caller supplies an outdated cross-contract epoch.
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum CrossContractEpochError {
+    /// The supplied cross-contract epoch does not match the current contract epoch.
+    EpochMismatch = 37,
+}
+
+pub const STORAGE_CROSS_CONTRACT_EPOCH: Symbol = symbol_short!("XC_EPOCH");
+
+/// Guards against executing cross-contract operations with a stale epoch.
+///
+/// This is a defence-in-depth fix. If a cross-contract message carrying an old epoch
+/// is replayed after the epoch has been bumped, it could lead to state corruption
+/// or unauthorised actions. Rejecting stale epochs ensures only fresh cross-contract
+/// calls are processed.
+///
+/// # Arguments
+/// * `env` - Soroban environment
+/// * `ep` - The cross-contract epoch supplied by the caller
+///
+/// # Returns
+/// * `Ok(())` if the epoch matches the current cross-contract epoch exactly
+/// * `Err(CrossContractEpochError::EpochMismatch)` if the epoch is outdated
+pub fn require_matching_cross_contract_epoch(env: &Env, ep: u64) -> Result<(), CrossContractEpochError> {
+    let current_epoch: u64 = env.storage().instance().get(&STORAGE_CROSS_CONTRACT_EPOCH).unwrap_or(0);
+    if ep != current_epoch {
+        return Err(CrossContractEpochError::EpochMismatch);
+    }
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // BytesN validation
 // ---------------------------------------------------------------------------

--- a/remitwise-common/src/tests.rs
+++ b/remitwise-common/src/tests.rs
@@ -1224,6 +1224,34 @@ fn test_verify_slash_signature_invalid() {
     });
 }
 
+// ─── cross_contract_epoch tests ──────────────────────────────────────────
+
+#[test]
+fn test_require_matching_cross_contract_epoch() {
+    let env = Env::default();
+    
+    // Default is 0, so epoch 0 matches
+    assert_eq!(require_matching_cross_contract_epoch(&env, 0), Ok(()));
+    
+    // Set epoch to 5
+    env.storage().instance().set(&STORAGE_CROSS_CONTRACT_EPOCH, &5u64);
+    
+    // Exact match is accepted
+    assert_eq!(require_matching_cross_contract_epoch(&env, 5), Ok(()));
+    
+    // Stale epoch (less than current) is rejected
+    assert_eq!(
+        require_matching_cross_contract_epoch(&env, 4),
+        Err(CrossContractEpochError::EpochMismatch)
+    );
+    
+    // Future epoch (greater than current) is rejected
+    assert_eq!(
+        require_matching_cross_contract_epoch(&env, 6),
+        Err(CrossContractEpochError::EpochMismatch)
+    );
+}
+
 // ─── distribute_pro_rata tests (#1085) ───────────────────────────────────────
 
 /// Distributes an indivisible total across unequal weights — remainder benefits smallest recipient.


### PR DESCRIPTION
Closes #1285 


This PR adds the `require_matching_cross_contract_epoch` guard to `remitwise-common` along with the typed `CrossContractEpochError::EpochMismatch` contract error, fulfilling the security baseline requirement to reject calls that reference stale cross-contract epochs.

## Threat Mitigated (Defence in Depth)
Cross-contract calls often carry tokens or state meant for a specific era of contract execution. If an attacker intercepts a valid cross-contract call payload, they might wait until after the cross-contract epoch has been bumped (e.g., following a security event, a contract upgrade, or a key rotation) and attempt to replay the intercepted call. 

If downstream contracts do not enforce that the epoch explicitly matches the current active epoch, they could blindly process these replayed calls, leading to:
1. Unauthorized actions (e.g., executing transactions that were meant to be invalidated).
2. State corruption (e.g., applying operations to a new contract version using outdated state representations).

This new guard acts as a strict replay barrier. By enforcing `ep != current_epoch`, it invalidates all older (and future) cross-contract calls instantly upon an epoch rotation, effectively closing this exploitation gap.

## Changes Made
- **Typed Error Surface:** Introduced `CrossContractEpochError` with discriminant `37` in `remitwise-common/src/lib.rs` to surface a clear `EpochMismatch` instead of generic panics.
- **Cross-Contract Epoch Guard:** Added the `require_matching_cross_contract_epoch(env: &Env, ep: u64)` function which fetches `XC_EPOCH` from instance storage and performs a strict equality check to prevent both stale and future epoch replay attacks.
- **Testing (`remitwise-common/src/tests.rs`):**
  - Added a positive test to ensure exact epoch matches execute successfully (both the default `0` case and after setting a specific epoch).
  - Added a negative test that explicitly rejects both stale (`current - 1`) and future (`current + 1`) epochs with `Err(CrossContractEpochError::EpochMismatch)`, successfully meeting the requirement for a test that exercises the guard.

## Acceptance Criteria Checklist
- [x] The change implements `require_matching_cross_contract_epoch(ep)`.
- [x] A negative test exercises the new check.
- [x] The PR description names the threat being mitigated.
- [x] Uses a typed error (`#[contracterror]`) rather than panicking or returning 500.
- [x] Code maintains `#![no_std]` discipline and uses only `soroban_sdk` primitives.