### PR TITLE
docs: add DISPUTE_EPOCH_MODEL.md and link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,7 @@ To run an example, use `cargo run --example <example_name>`:
 - [Audit Trail](docs/AUDIT_TRAIL.md) - How to reconstruct historical state from events alone
 - [Settler Whitelist](docs/SETTLER_WHITELIST.md) - Operator guide: how settlers are added, rotated, and revoked
 - [Epoch Model](docs/EPOCH_MODEL.md) - How epoch counters bump, what they invalidate, and the stale-authorization replay threat they mitigate in the emergency killswitch and orchestrator contracts
+- [Dispute Epoch Model](docs/DISPUTE_EPOCH_MODEL.md) - Semantics + when dispute epochs bump
 - [Killswitch Trust Model](docs/killswitch-trust-model.md) - Who can trigger, who can clear, what state is preserved in the emergency killswitch
 - [Ledger Monotonicity](docs/LEDGER_MONOTONICITY.md) - Where and why contract code relies on ledger sequence and timestamp monotonicity
 - [Tagging Feature](TAGGING_FEATURE.md) - Tag-based organization system

--- a/docs/DISPUTE_EPOCH_MODEL.md
+++ b/docs/DISPUTE_EPOCH_MODEL.md
@@ -1,0 +1,102 @@
+# Dispute Epoch Model
+
+**Audience:** Contributors working on cross-contract dispute lifecycle operations and integrators handling dispute-related calls.
+
+---
+
+## What a dispute epoch is
+
+The `remitwise-common` shared library introduces the concept of a **dispute epoch**, a monotonically increasing `u64` counter stored in instance storage under the key `DISP_EP` (`symbol_short!("DISP_EP")`).
+
+This counter tracks the current active generation of dispute resolutions.
+
+```
+┌─────────────────────────────────┐
+│  Contract Instance Storage      │
+│                                 │
+│  DISP_EP  →  u64 (e.g. 5)       │
+└─────────────────────────────────┘
+```
+
+The epoch starts at 0 (implicitly, if unset) and is monotonically incremented when necessary. It never resets.
+
+---
+
+## Why dispute epochs exist
+
+The primary threat mitigated by dispute epochs is **lifecycle bypass via stale operations**.
+
+When a dispute is raised, evaluated, and resolved, various lifecycle rules apply (e.g., locking funds, reversing transactions). If an attacker could execute dispute-related operations tied to an *outdated* dispute generation, they might bypass lifecycle expiration rules, allowing them to manipulate resolutions, unlock funds prematurely, or lock funds unexpectedly.
+
+Bumping the dispute epoch invalidates all pending dispute operations tied to previous epochs.
+
+---
+
+## Coordination and Semantics
+
+### The Guard (`require_no_pending_dispute_epoch`)
+
+```rust
+// remitwise-common/src/lib.rs
+pub fn require_no_pending_dispute_epoch(env: &Env, ep: u64) -> Result<(), DisputeError> {
+    let current_epoch: u64 = env.storage().instance().get(&symbol_short!("DISP_EP")).unwrap_or(0);
+    if ep < current_epoch {
+        return Err(DisputeError::OutdatedEpoch);
+    }
+    Ok(())
+}
+```
+
+Notice the specific check: `ep < current_epoch`.
+Unlike the cross-contract coordination epoch which demands strict equality (`ep == current_epoch`), the dispute epoch allows operations from the *current* or *future* epochs, but explicitly rejects **outdated** epochs (`ep < current_epoch`).
+
+### Epoch Tiers
+
+| Tier | Definition | Guard outcome |
+|---|---|---|
+| **Same** | `supplied_epoch == current_epoch` | ✅ Accepted |
+| **Future** | `supplied_epoch > current_epoch` | ✅ Accepted |
+| **Prior (Outdated)** | `supplied_epoch < current_epoch` | ❌ `DisputeError::OutdatedEpoch` |
+
+---
+
+## Bumping the dispute epoch
+
+Bumping the dispute epoch means advancing the `DISP_EP` counter in instance storage. 
+
+**Effect on callers:** Any pending cross-contract dispute operations carrying an epoch smaller than the new `current_epoch` will instantly become stale and fail with `DisputeError::OutdatedEpoch`.
+
+### When to bump
+
+The dispute epoch should be bumped:
+1. When a major dispute generation completes and the system needs to forcefully invalidate any straggling, unexecuted dispute commands from that generation.
+2. During dispute-related emergency interventions where pending actions must be halted immediately.
+
+---
+
+## Worked example
+
+```text
+Time  On-chain epoch  Event
+────  ─────────────  ─────────────────────────────────────────
+ 0    0              Contract initialized, DISP_EP implicitly 0
+ 1    0              Caller submits dispute operation with ep=0 → ✅ accepted
+ 2    1              Admin bumps dispute epoch → current_epoch = 1
+ 3    1              Attacker replays old dispute operation with ep=0 → ❌ DisputeError::OutdatedEpoch
+ 4    1              Caller submits new dispute operation with ep=1 → ✅ accepted
+ 5    1              Caller anticipates next epoch, submits ep=2 → ✅ accepted
+```
+
+---
+
+## Error reference
+
+| Error | Discriminant | When raised |
+|---|---|---|
+| `DisputeError::OutdatedEpoch` | 36 | `ep < current_epoch` in `require_no_pending_dispute_epoch` |
+
+---
+
+## See also
+
+- [Cross-Contract Epochs](CROSS_CONTRACT_EPOCHS.md) - For the related but strictly-enforced orchestrator actor epochs.


### PR DESCRIPTION
Closes #1245 

This PR introduces `docs/DISPUTE_EPOCH_MODEL.md` to formalize the semantics and lifecycle of dispute epochs within the ecosystem. The document explains when dispute epochs are bumped and how they protect cross-contract dispute operations from replay attacks and lifecycle bypassing.

## Background
Previously, the mechanics of how the dispute epoch (`DISP_EP`) guards against executing dispute-related operations in outdated epochs was tribal knowledge. This lack of explicit documentation made it difficult for new contributors to understand the differences between strict actor epochs and minimum-bounded dispute epochs. 

By writing this down, we:
1. Allow reviewers to verify actual implementation against the documented intent.
2. Unblock new contributors without requiring them to trace through commit histories.
3. Equip the support team with a reference to answer common questions regarding why certain dispute operations might be rejected with `DisputeError::OutdatedEpoch`.

## Changes Included
* **Added `docs/DISPUTE_EPOCH_MODEL.md`**:
  * Written specifically for a **contributor** audience.
  * Details the underlying storage key (`DISP_EP`) and the `require_no_pending_dispute_epoch` guard mechanism.
  * Explains the specific semantics of the guard (`ep < current_epoch` yielding `DisputeError::OutdatedEpoch`), highlighting how it differs from the strict equality check of the cross-contract coordination epoch.
  * Provides a concrete, step-by-step example scenario showing how a bumped epoch invalidates stale operations.
* **Updated `README.md`**:
  * Cross-linked the new document under the "Documentation" section so it remains easily discoverable alongside the existing `EPOCH_MODEL.md` and `CROSS_CONTRACT_EPOCHS.md` docs.

## Acceptance Criteria Met
- [x] The documentation clearly captures the semantics and bump conditions of dispute epochs.
- [x] Written explicitly for the **contributor** audience with concrete, step-by-step examples.
- [x] Cross-linked from the top-level `README.md`.
- [x] Local linting, type-checking, and workspace tests pass successfully.