### PR TITLE
docs: clarify ledger monotonicity assumption

### DIFF
--- a/docs/CONTRACT_SEMANTICS.md
+++ b/docs/CONTRACT_SEMANTICS.md
@@ -523,6 +523,15 @@ This is an automatic recovery mechanism — a timed pause expires without operat
 
 ---
 
+### 8.3 Ledger Monotonicity Assumption
+
+Contracts that compare ledger timestamps or sequence numbers assume that these values
+advance monotonically between successful ledger closes. Time-based features such as
+scheduled unpause operations rely on this property and do not attempt to compensate
+for non-monotonic ledger values.
+
+See also: `docs/LEDGER_MONOTONICITY.md`.
+
 ## 9. no_std Compilation Discipline
 
 All contract crates compile with `#![no_std]` for the WASM target. This means:


### PR DESCRIPTION
## Summary

This PR clarifies the ledger monotonicity assumption in the contract semantics documentation.

## Changes

- Added a new "Ledger Monotonicity Assumption" subsection.
- Documented that contracts relying on ledger timestamps or sequence numbers assume they advance monotonically.
- Added a reference to `docs/LEDGER_MONOTONICITY.md` for additional details.

## Why

This documentation makes the expected behavior explicit for contributors working on time-based features such as scheduled unpause operations and other ledger-dependent logic.

No functional code changes.

Closes #1129