### PR TITLE
fix: remove duplicate SPLIT storage key, derive split percentages fro…

### DIFF
--- a/STORAGE_LAYOUT.md
+++ b/STORAGE_LAYOUT.md
@@ -75,7 +75,6 @@ Using these helpers prevents the common mistake of swapping `threshold` and `bum
 | Key         | Type                           | Notes                                                        |
 | ----------- | ------------------------------ | ------------------------------------------------------------ |
 | `CONFIG`    | `SplitConfig`                  | Owner + percentages + initialized flag                       |
-| `SPLIT`     | `Vec<u32>`                     | Ordered percentages: `[spending, savings, bills, insurance]` |
 | `NONCES`    | `Map<Address, u64>`            | Replay protection for owner-authorized mutating calls        |
 | `AUDIT`     | `Vec<AuditEntry>`              | Rotating audit log, max `MAX_AUDIT_ENTRIES` (100)            |
 | `REM_SCH`   | `Map<u32, RemittanceSchedule>` | Remittance schedules                                         |

--- a/docs/remittance-split-ttl.md
+++ b/docs/remittance-split-ttl.md
@@ -18,9 +18,8 @@ The contract uses standardized constants from `remitwise-common`:
 Instance storage entries are extended to `INSTANCE_BUMP_AMOUNT` whenever they have less than `INSTANCE_LIFETIME_THRESHOLD` remaining.
 
 | Key | Governance | Trigger |
-|-----|------------|---------|
-| `CONFIG` | `INSTANCE_BUMP_AMOUNT` | Every read/write |
-| `SPLIT` | `INSTANCE_BUMP_AMOUNT` | Every read/write |
+|-----|------------|---------|| `CONFIG`  | `INSTANCE_BUMP_AMOUNT` | Every read/write |
+| *(SPLIT removed)* | — | Percentages now derived from CONFIG |
 | `NONCES` | `INSTANCE_BUMP_AMOUNT` | Every read/write |
 | `AUDIT` | `INSTANCE_BUMP_AMOUNT` | Every read/write |
 | `VERSION` | `INSTANCE_BUMP_AMOUNT` | Every read/write |

--- a/remittance_split/src/lib.rs
+++ b/remittance_split/src/lib.rs
@@ -904,20 +904,10 @@ impl RemittanceSplit {
 
         Self::extend_instance_ttl(&env);
 
-        // Restore config
+        // Restore config (single source of truth — SPLIT key has been removed)
         env.storage()
             .instance()
             .set(&symbol_short!("CONFIG"), &snapshot.config);
-        env.storage().instance().set(
-            &symbol_short!("SPLIT"),
-            &vec![
-                &env,
-                snapshot.config.spending_percent,
-                snapshot.config.savings_percent,
-                snapshot.config.bills_percent,
-                snapshot.config.insurance_percent,
-            ],
-        );
 
         // Restore version
         env.storage()
@@ -1189,16 +1179,6 @@ impl RemittanceSplit {
         env.storage()
             .instance()
             .set(&symbol_short!("CONFIG"), &config);
-        env.storage().instance().set(
-            &symbol_short!("SPLIT"),
-            &vec![
-                &env,
-                spending_percent,
-                savings_percent,
-                bills_percent,
-                insurance_percent,
-            ],
-        );
 
         Self::increment_nonce(&env, &owner)?;
         Self::append_audit(&env, symbol_short!("init"), &owner, true);
@@ -1257,16 +1237,6 @@ impl RemittanceSplit {
         env.storage()
             .instance()
             .set(&symbol_short!("CONFIG"), &config);
-        env.storage().instance().set(
-            &symbol_short!("SPLIT"),
-            &vec![
-                &env,
-                spending_percent,
-                savings_percent,
-                bills_percent,
-                insurance_percent,
-            ],
-        );
 
         let event = SplitInitializedEvent {
             spending_percent,
@@ -1287,9 +1257,21 @@ impl RemittanceSplit {
 
     pub fn get_split(env: &Env) -> Vec<u32> {
         Self::extend_instance_ttl(env);
+        // Derive split percentages from the canonical CONFIG key (single source of truth).
+        // Previously percentages were written to a separate SPLIT key, duplicating the
+        // same data and creating a desynchronisation risk.  See PR description for details.
         env.storage()
             .instance()
-            .get(&symbol_short!("SPLIT"))
+            .get::<_, SplitConfig>(&symbol_short!("CONFIG"))
+            .map(|c| {
+                vec![
+                    &env,
+                    c.spending_percent,
+                    c.savings_percent,
+                    c.bills_percent,
+                    c.insurance_percent,
+                ]
+            })
             .unwrap_or_else(|| vec![&env, 5000, 3000, 1500, 500])
     }
 
@@ -1937,20 +1919,10 @@ impl RemittanceSplit {
 
         Self::extend_instance_ttl(&env);
 
-        // --- Restore config and split percentages ---
+        // --- Restore config (single source of truth) ---
         env.storage()
             .instance()
             .set(&symbol_short!("CONFIG"), &snapshot.config);
-        env.storage().instance().set(
-            &symbol_short!("SPLIT"),
-            &vec![
-                &env,
-                snapshot.config.spending_percent,
-                snapshot.config.savings_percent,
-                snapshot.config.bills_percent,
-                snapshot.config.insurance_percent,
-            ],
-        );
 
         // Import schedules to new storage
         for schedule in snapshot.schedules.iter() {

--- a/testutils/tests/storage_key_naming_test.rs
+++ b/testutils/tests/storage_key_naming_test.rs
@@ -31,11 +31,7 @@ fn get_all_storage_keys() -> Vec<StorageKey> {
             contract: "remittance_split",
             description: "Owner + percentages + initialized flag",
         },
-        StorageKey {
-            key: "SPLIT",
-            contract: "remittance_split",
-            description: "Ordered percentages",
-        },
+        // SPLIT key has been removed (percentages are now derived from CONFIG).
         StorageKey {
             key: "NONCES",
             contract: "remittance_split",

--- a/testutils/tests/storage_key_snapshot_test.rs
+++ b/testutils/tests/storage_key_snapshot_test.rs
@@ -39,12 +39,10 @@ fn get_snapshot_entries() -> Vec<StorageKeyEntry> {
             type_name: "SplitConfig",
             tier: "instance",
         },
-        StorageKeyEntry {
-            key: "SPLIT",
-            contract: "remittance_split",
-            type_name: "Vec<u32>",
-            tier: "instance",
-        },
+        // SPLIT was previously a separate Vec<u32> key storing the same
+        // percentage data as CONFIG.  It has been removed — get_split now
+        // derives the percentages from CONFIG directly.  The key is retained
+        // in this snapshot comment to document the historical state.
         StorageKeyEntry {
             key: "NONCES",
             contract: "remittance_split",


### PR DESCRIPTION
Closes #1343 
…m CONFIG

Removes the redundant SPLIT storage key from remittance_split. The same percentage data was stored under both CONFIG (SplitConfig struct) and SPLIT (Vec<u32>), creating a desynchronisation risk. get_split now derives the percentages from CONFIG directly.

Closes #