### PR TITLE
feat(savings_goals): standardize goal event schemas + add stability tests

### DIFF
--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -275,6 +275,10 @@ pub struct GoalCreatedEvent {
 
 **Topic:** `"added"` (primary)  
 **Secondary Topic:** `("savings", SavingsEvent::FundsAdded)`
+**Emitted by:** `add_to_goal`, `batch_add_to_goals`, `execute_due_savings_schedules` — all three
+paths publish the identical `FundsAddedEvent` shape (including `new_total` and `timestamp`) via
+`RemitwiseEvents::emit`, so indexers see one consistent payload regardless of whether a credit came
+from a manual contribution or a scheduled execution.
 
 **Data Structure:**
 
@@ -304,6 +308,10 @@ pub struct FundsAddedEvent {
 
 **Topic:** `"completed"` (primary)  
  **Secondary Topic:** `("savings", SavingsEvent::GoalCompleted)`
+**Emitted by:** `add_to_goal`, `batch_add_to_goals`, `execute_due_savings_schedules` — exactly once
+per goal, on whichever credit (manual or scheduled) first brings `current_amount >= target_amount`.
+A goal that is already completed before a credit lands must not re-emit this event regardless of
+which path applies the credit.
 
 **Data Structure:**
 
@@ -385,12 +393,14 @@ pub struct FundsWithdrawnEvent {
 ### Event: Goal Locked/Unlocked
 
 **Topic:** `("savings", SavingsEvent::GoalLocked)` or `("savings", SavingsEvent::GoalUnlocked)`
+**Emitted by:** `lock_goal` (`locked: true`), `unlock_goal` (`locked: false`)
 
 **Data Structure:**
 
 ```rust
 pub struct GoalLockEvent {
     pub goal_id: u32,               // Goal ID
+    pub owner: Address,             // Goal owner
     pub locked: bool,               // Lock status
     pub timestamp: u64,             // Event timestamp
 }
@@ -399,16 +409,88 @@ pub struct GoalLockEvent {
 ### Event: Savings Schedule Created
 
 **Topic:** `("savings", SavingsEvent::ScheduleCreated)`
+**Emitted by:** `create_savings_schedule`
 
 **Data Structure:**
 
 ```rust
-pub struct SavingsScheduleCreatedEvent {
+pub struct ScheduleCreatedEvent {
     pub schedule_id: u32,           // Schedule ID
     pub goal_id: u32,               // Associated goal ID
+    pub owner: Address,             // Schedule owner
     pub amount: i128,               // Recurring amount
     pub next_due: u64,              // Next execution timestamp
     pub interval: u64,              // Interval in seconds
+    pub timestamp: u64,             // Event timestamp
+}
+```
+
+### Event: Savings Schedule Modified
+
+**Topic:** `("savings", SavingsEvent::ScheduleModified)`
+**Emitted by:** `modify_savings_schedule`
+
+**Data Structure:**
+
+```rust
+pub struct ScheduleModifiedEvent {
+    pub schedule_id: u32,           // Schedule ID
+    pub goal_id: u32,               // Associated goal ID
+    pub owner: Address,             // Schedule owner
+    pub amount: i128,               // Updated recurring amount
+    pub next_due: u64,              // Updated next execution timestamp
+    pub interval: u64,              // Updated interval in seconds
+    pub timestamp: u64,             // Event timestamp
+}
+```
+
+### Event: Savings Schedule Cancelled
+
+**Topic:** `("savings", SavingsEvent::ScheduleCancelled)`
+**Emitted by:** `cancel_savings_schedule`
+
+**Data Structure:**
+
+```rust
+pub struct ScheduleCancelledEvent {
+    pub schedule_id: u32,           // Schedule ID
+    pub goal_id: u32,               // Associated goal ID
+    pub owner: Address,             // Schedule owner
+    pub timestamp: u64,             // Event timestamp
+}
+```
+
+### Event: Savings Schedule Executed
+
+**Topic:** `("savings", SavingsEvent::ScheduleExecuted)`
+**Emitted by:** `execute_due_savings_schedules`, once per schedule that successfully credits its goal
+
+**Data Structure:**
+
+```rust
+pub struct ScheduleExecutedEvent {
+    pub schedule_id: u32,           // Schedule ID
+    pub goal_id: u32,               // Associated goal ID
+    pub owner: Address,             // Schedule owner
+    pub amount: i128,               // Amount credited this execution
+    pub timestamp: u64,             // Event timestamp
+}
+```
+
+### Event: Savings Schedule Missed Intervals
+
+**Topic:** `("savings", SavingsEvent::ScheduleMissed)`
+**Emitted by:** `execute_due_savings_schedules`, when one or more recurring intervals were skipped
+(delayed execution)
+
+**Data Structure:**
+
+```rust
+pub struct ScheduleMissedEvent {
+    pub schedule_id: u32,           // Schedule ID
+    pub goal_id: u32,               // Associated goal ID
+    pub owner: Address,             // Schedule owner
+    pub missed_count: u32,          // Number of intervals skipped
     pub timestamp: u64,             // Event timestamp
 }
 ```

--- a/savings_goals/src/events_schema_test.rs
+++ b/savings_goals/src/events_schema_test.rs
@@ -153,6 +153,148 @@ fn goal_completed_event_payload_schema() {
     assert_eq!(decoded.timestamp, 12_345);
 }
 
+#[test]
+fn goal_lock_event_payload_schema() {
+    let env = Env::default();
+    let owner = sample_address(&env);
+
+    let evt = GoalLockEvent {
+        goal_id: 4,
+        owner: owner.clone(),
+        locked: true,
+        timestamp: 55_555,
+    };
+
+    let v: Val = evt.clone().into_val(&env);
+    let decoded = GoalLockEvent::try_from_val(&env, &v).expect("round-trip failed");
+
+    assert_eq!(decoded.goal_id, 4);
+    assert_eq!(decoded.owner, owner);
+    assert!(decoded.locked);
+    assert_eq!(decoded.timestamp, 55_555);
+}
+
+#[test]
+fn schedule_created_event_payload_schema() {
+    let env = Env::default();
+    let owner = sample_address(&env);
+
+    let evt = ScheduleCreatedEvent {
+        schedule_id: 1,
+        goal_id: 4,
+        owner: owner.clone(),
+        amount: 1_000,
+        next_due: 1_800_000_000,
+        interval: 604_800,
+        timestamp: 1_234_567_800,
+    };
+
+    let v: Val = evt.clone().into_val(&env);
+    let decoded = ScheduleCreatedEvent::try_from_val(&env, &v).expect("round-trip failed");
+
+    assert_eq!(decoded.schedule_id, 1);
+    assert_eq!(decoded.goal_id, 4);
+    assert_eq!(decoded.owner, owner);
+    assert_eq!(decoded.amount, 1_000);
+    assert_eq!(decoded.next_due, 1_800_000_000);
+    assert_eq!(decoded.interval, 604_800);
+    assert_eq!(decoded.timestamp, 1_234_567_800);
+}
+
+#[test]
+fn schedule_modified_event_payload_schema() {
+    let env = Env::default();
+    let owner = sample_address(&env);
+
+    let evt = ScheduleModifiedEvent {
+        schedule_id: 2,
+        goal_id: 7,
+        owner: owner.clone(),
+        amount: 2_000,
+        next_due: 1_800_100_000,
+        interval: 2_592_000,
+        timestamp: 1_234_567_900,
+    };
+
+    let v: Val = evt.clone().into_val(&env);
+    let decoded = ScheduleModifiedEvent::try_from_val(&env, &v).expect("round-trip failed");
+
+    assert_eq!(decoded.schedule_id, 2);
+    assert_eq!(decoded.goal_id, 7);
+    assert_eq!(decoded.owner, owner);
+    assert_eq!(decoded.amount, 2_000);
+    assert_eq!(decoded.next_due, 1_800_100_000);
+    assert_eq!(decoded.interval, 2_592_000);
+    assert_eq!(decoded.timestamp, 1_234_567_900);
+}
+
+#[test]
+fn schedule_cancelled_event_payload_schema() {
+    let env = Env::default();
+    let owner = sample_address(&env);
+
+    let evt = ScheduleCancelledEvent {
+        schedule_id: 3,
+        goal_id: 9,
+        owner: owner.clone(),
+        timestamp: 1_234_568_000,
+    };
+
+    let v: Val = evt.clone().into_val(&env);
+    let decoded = ScheduleCancelledEvent::try_from_val(&env, &v).expect("round-trip failed");
+
+    assert_eq!(decoded.schedule_id, 3);
+    assert_eq!(decoded.goal_id, 9);
+    assert_eq!(decoded.owner, owner);
+    assert_eq!(decoded.timestamp, 1_234_568_000);
+}
+
+#[test]
+fn schedule_executed_event_payload_schema() {
+    let env = Env::default();
+    let owner = sample_address(&env);
+
+    let evt = ScheduleExecutedEvent {
+        schedule_id: 5,
+        goal_id: 11,
+        owner: owner.clone(),
+        amount: 3_000,
+        timestamp: 1_234_568_100,
+    };
+
+    let v: Val = evt.clone().into_val(&env);
+    let decoded = ScheduleExecutedEvent::try_from_val(&env, &v).expect("round-trip failed");
+
+    assert_eq!(decoded.schedule_id, 5);
+    assert_eq!(decoded.goal_id, 11);
+    assert_eq!(decoded.owner, owner);
+    assert_eq!(decoded.amount, 3_000);
+    assert_eq!(decoded.timestamp, 1_234_568_100);
+}
+
+#[test]
+fn schedule_missed_event_payload_schema() {
+    let env = Env::default();
+    let owner = sample_address(&env);
+
+    let evt = ScheduleMissedEvent {
+        schedule_id: 6,
+        goal_id: 13,
+        owner: owner.clone(),
+        missed_count: 3,
+        timestamp: 1_234_568_200,
+    };
+
+    let v: Val = evt.clone().into_val(&env);
+    let decoded = ScheduleMissedEvent::try_from_val(&env, &v).expect("round-trip failed");
+
+    assert_eq!(decoded.schedule_id, 6);
+    assert_eq!(decoded.goal_id, 13);
+    assert_eq!(decoded.owner, owner);
+    assert_eq!(decoded.missed_count, 3);
+    assert_eq!(decoded.timestamp, 1_234_568_200);
+}
+
 // ---------------------------------------------------------------------------
 // Payload schemas - enum events
 // ---------------------------------------------------------------------------

--- a/savings_goals/src/lib.rs
+++ b/savings_goals/src/lib.rs
@@ -60,6 +60,73 @@ pub struct GoalCompletedEvent {
     pub timestamp: u64,
 }
 
+/// Emitted by `lock_goal` (`locked: true`) and `unlock_goal` (`locked: false`).
+#[derive(Clone)]
+#[contracttype]
+pub struct GoalLockEvent {
+    pub goal_id: u32,
+    pub owner: Address,
+    pub locked: bool,
+    pub timestamp: u64,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct ScheduleCreatedEvent {
+    pub schedule_id: u32,
+    pub goal_id: u32,
+    pub owner: Address,
+    pub amount: i128,
+    pub next_due: u64,
+    pub interval: u64,
+    pub timestamp: u64,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct ScheduleModifiedEvent {
+    pub schedule_id: u32,
+    pub goal_id: u32,
+    pub owner: Address,
+    pub amount: i128,
+    pub next_due: u64,
+    pub interval: u64,
+    pub timestamp: u64,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct ScheduleCancelledEvent {
+    pub schedule_id: u32,
+    pub goal_id: u32,
+    pub owner: Address,
+    pub timestamp: u64,
+}
+
+/// Emitted once per successful execution of a due schedule by
+/// `execute_due_savings_schedules`.
+#[derive(Clone)]
+#[contracttype]
+pub struct ScheduleExecutedEvent {
+    pub schedule_id: u32,
+    pub goal_id: u32,
+    pub owner: Address,
+    pub amount: i128,
+    pub timestamp: u64,
+}
+
+/// Emitted alongside `ScheduleExecutedEvent` when one or more recurring
+/// intervals were skipped (delayed execution).
+#[derive(Clone)]
+#[contracttype]
+pub struct ScheduleMissedEvent {
+    pub schedule_id: u32,
+    pub goal_id: u32,
+    pub owner: Address,
+    pub missed_count: u32,
+    pub timestamp: u64,
+}
+
 const INSTANCE_LIFETIME_THRESHOLD: u32 = 17280;
 const INSTANCE_BUMP_AMOUNT: u32 = 518400;
 
@@ -1566,7 +1633,12 @@ impl SavingsGoalContract {
         Self::append_audit(&env, symbol_short!("lock"), &caller, true);
         env.events().publish(
             (symbol_short!("savings"), SavingsEvent::GoalLocked),
-            (goal_id, caller),
+            GoalLockEvent {
+                goal_id,
+                owner: caller,
+                locked: true,
+                timestamp: env.ledger().timestamp(),
+            },
         );
 
         true
@@ -1622,7 +1694,12 @@ impl SavingsGoalContract {
         Self::append_audit(&env, symbol_short!("unlock"), &caller, true);
         env.events().publish(
             (symbol_short!("savings"), SavingsEvent::GoalUnlocked),
-            (goal_id, caller),
+            GoalLockEvent {
+                goal_id,
+                owner: caller,
+                locked: false,
+                timestamp: env.ledger().timestamp(),
+            },
         );
 
         true
@@ -2660,7 +2737,15 @@ impl SavingsGoalContract {
 
         env.events().publish(
             (symbol_short!("savings"), SavingsEvent::ScheduleCreated),
-            (next_schedule_id, owner),
+            ScheduleCreatedEvent {
+                schedule_id: next_schedule_id,
+                goal_id,
+                owner,
+                amount,
+                next_due,
+                interval,
+                timestamp: current_time,
+            },
         );
 
         next_schedule_id
@@ -2716,7 +2801,15 @@ impl SavingsGoalContract {
 
         env.events().publish(
             (symbol_short!("savings"), SavingsEvent::ScheduleModified),
-            (schedule_id, caller),
+            ScheduleModifiedEvent {
+                schedule_id,
+                goal_id: schedule.goal_id,
+                owner: caller,
+                amount,
+                next_due,
+                interval,
+                timestamp: current_time,
+            },
         );
 
         true
@@ -2756,7 +2849,12 @@ impl SavingsGoalContract {
 
         env.events().publish(
             (symbol_short!("savings"), SavingsEvent::ScheduleCancelled),
-            (schedule_id, caller),
+            ScheduleCancelledEvent {
+                schedule_id,
+                goal_id: schedule.goal_id,
+                owner: caller,
+                timestamp: env.ledger().timestamp(),
+            },
         );
 
         true
@@ -2844,6 +2942,7 @@ impl SavingsGoalContract {
                 None => continue,
             };
 
+            let previously_completed = goal.current_amount >= goal.target_amount;
             let new_total = match goal.current_amount.checked_add(schedule.amount) {
                 Some(v) => v,
                 None => continue, // Skip overflow
@@ -2853,20 +2952,50 @@ impl SavingsGoalContract {
             }
             goal.current_amount = new_total;
 
-            let is_completed = goal.current_amount >= goal.target_amount;
+            let is_completed = new_total >= goal.target_amount;
             env.storage()
                 .persistent()
                 .set(&DataKey::Goal(schedule.goal_id), &goal);
 
+            RemitwiseEvents::emit(
+                &env,
+                EventCategory::Transaction,
+                EventPriority::Medium,
+                FUNDS_ADDED,
+                FundsAddedEvent {
+                    goal_id: schedule.goal_id,
+                    owner: goal.owner.clone(),
+                    amount: schedule.amount,
+                    new_total,
+                    timestamp: current_time,
+                },
+            );
             env.events().publish(
                 (symbol_short!("savings"), SavingsEvent::FundsAdded),
                 (schedule.goal_id, goal.owner.clone(), schedule.amount),
             );
 
-            if is_completed {
+            if is_completed && !previously_completed {
+                let completed_event = GoalCompletedEvent {
+                    goal_id: schedule.goal_id,
+                    owner: goal.owner.clone(),
+                    amount: schedule.amount,
+                    new_total,
+                    name: goal.name.clone(),
+                    timestamp: current_time,
+                };
+
+                RemitwiseEvents::emit(
+                    &env,
+                    EventCategory::State,
+                    EventPriority::Medium,
+                    GOAL_COMPLETED,
+                    completed_event.clone(),
+                );
+                env.events().publish((GOAL_COMPLETED,), completed_event);
                 env.events().publish(
                     (symbol_short!("savings"), SavingsEvent::GoalCompleted),
-                    (schedule.goal_id, goal.owner),
+                    (schedule.goal_id, goal.owner.clone()),
                 );
             }
 
@@ -2885,7 +3014,13 @@ impl SavingsGoalContract {
                 if missed > 0 {
                     env.events().publish(
                         (symbol_short!("savings"), SavingsEvent::ScheduleMissed),
-                        (schedule_id, missed),
+                        ScheduleMissedEvent {
+                            schedule_id,
+                            goal_id: schedule.goal_id,
+                            owner: goal.owner.clone(),
+                            missed_count: missed,
+                            timestamp: current_time,
+                        },
                     );
                 }
             } else {
@@ -2899,7 +3034,13 @@ impl SavingsGoalContract {
 
             env.events().publish(
                 (symbol_short!("savings"), SavingsEvent::ScheduleExecuted),
-                schedule_id,
+                ScheduleExecutedEvent {
+                    schedule_id,
+                    goal_id: schedule.goal_id,
+                    owner: goal.owner,
+                    amount: schedule.amount,
+                    timestamp: current_time,
+                },
             );
         }
 
@@ -3025,6 +3166,8 @@ impl SavingsGoalsReversible for SavingsGoalContract {
 mod event_test;
 #[cfg(test)]
 mod events_schema_test;
+#[cfg(test)]
+mod schedule_lifecycle_event_test;
 #[cfg(test)]
 mod test;
 #[cfg(test)]

--- a/savings_goals/src/schedule_lifecycle_event_test.rs
+++ b/savings_goals/src/schedule_lifecycle_event_test.rs
@@ -1,0 +1,332 @@
+//! Functional tests locking down the *emitted* topics/payloads for
+//! goal-lock and savings-schedule lifecycle events.
+//!
+//! `events_schema_test.rs` proves each event struct's field set is stable
+//! (compile-time struct literals + `Val` round-trip). This module goes one
+//! step further and drives the real contract entrypoints end-to-end,
+//! decoding the events Soroban actually recorded, so a regression that
+//! swaps in the wrong values (or reverts to a bare, undocumented tuple) is
+//! caught even if the struct shape itself is untouched.
+
+#![cfg(test)]
+
+extern crate std;
+
+use super::*;
+use soroban_sdk::{
+    symbol_short, testutils::Address as AddressTrait, testutils::Events, Address, Env, String,
+    Symbol, TryFromVal,
+};
+use testutils::set_ledger_time;
+
+fn setup(env: &Env) -> (SavingsGoalContractClient<'_>, Address) {
+    let contract_id = env.register_contract(None, SavingsGoalContract);
+    let client = SavingsGoalContractClient::new(env, &contract_id);
+    env.mock_all_auths();
+    client.init();
+    set_ledger_time(env, 1, 1_000);
+    let owner = Address::generate(env);
+    (client, owner)
+}
+
+fn make_goal(env: &Env, client: &SavingsGoalContractClient, owner: &Address, target: i128) -> u32 {
+    client.create_goal(
+        owner,
+        &String::from_str(env, "Test Goal"),
+        &target,
+        &2_000_000_000u64,
+        &false,
+    )
+}
+
+/// Finds the single most-recently-emitted event matching the given
+/// `SavingsEvent` variant and decodes its payload as `T`.
+fn find_latest_event<T: TryFromVal<Env, soroban_sdk::Val>>(
+    env: &Env,
+    variant_matches: impl Fn(&SavingsEvent) -> bool,
+) -> T {
+    let all = env.events().all();
+    let matched = all
+        .iter()
+        .rev()
+        .find(|(_, topics, _)| {
+            let t0_ok = topics
+                .get(0)
+                .and_then(|t| Symbol::try_from_val(env, &t).ok())
+                .map(|s: Symbol| s == symbol_short!("savings"))
+                .unwrap_or(false);
+            let t1_ok = topics
+                .get(1)
+                .and_then(|t| SavingsEvent::try_from_val(env, &t).ok())
+                .map(|e| variant_matches(&e))
+                .unwrap_or(false);
+            t0_ok && t1_ok
+        })
+        .unwrap_or_else(|| panic!("no matching event found"));
+
+    T::try_from_val(env, &matched.2).expect("payload failed to decode as expected event struct")
+}
+
+// ─── Goal lock / unlock ─────────────────────────────────────────────────────
+
+#[test]
+fn lock_goal_emits_goal_lock_event_with_locked_true_and_owner_and_timestamp() {
+    let env = Env::default();
+    let (client, owner) = setup(&env);
+    let goal_id = make_goal(&env, &client, &owner, 1_000);
+
+    set_ledger_time(&env, 2, 5_000);
+    client.lock_goal(&owner, &goal_id);
+
+    let evt: GoalLockEvent =
+        find_latest_event(&env, |e| matches!(e, SavingsEvent::GoalLocked));
+
+    assert_eq!(evt.goal_id, goal_id);
+    assert_eq!(evt.owner, owner);
+    assert!(evt.locked);
+    assert_eq!(evt.timestamp, 5_000);
+}
+
+#[test]
+fn unlock_goal_emits_goal_lock_event_with_locked_false() {
+    let env = Env::default();
+    let (client, owner) = setup(&env);
+    let goal_id = make_goal(&env, &client, &owner, 1_000);
+
+    client.lock_goal(&owner, &goal_id);
+    set_ledger_time(&env, 3, 6_000);
+    client.unlock_goal(&owner, &goal_id);
+
+    let evt: GoalLockEvent =
+        find_latest_event(&env, |e| matches!(e, SavingsEvent::GoalUnlocked));
+
+    assert_eq!(evt.goal_id, goal_id);
+    assert_eq!(evt.owner, owner);
+    assert!(!evt.locked);
+    assert_eq!(evt.timestamp, 6_000);
+}
+
+// ─── Schedule create / modify / cancel ──────────────────────────────────────
+
+#[test]
+fn create_savings_schedule_emits_schedule_created_event_with_full_payload() {
+    let env = Env::default();
+    let (client, owner) = setup(&env);
+    let goal_id = make_goal(&env, &client, &owner, 10_000);
+
+    set_ledger_time(&env, 2, 10_000);
+    let schedule_id =
+        client.create_savings_schedule(&owner, &goal_id, &500_i128, &(10_000 + 86_400), &86_400);
+
+    let evt: ScheduleCreatedEvent =
+        find_latest_event(&env, |e| matches!(e, SavingsEvent::ScheduleCreated));
+
+    assert_eq!(evt.schedule_id, schedule_id);
+    assert_eq!(evt.goal_id, goal_id);
+    assert_eq!(evt.owner, owner);
+    assert_eq!(evt.amount, 500);
+    assert_eq!(evt.next_due, 10_000 + 86_400);
+    assert_eq!(evt.interval, 86_400);
+    assert_eq!(evt.timestamp, 10_000);
+}
+
+#[test]
+fn modify_savings_schedule_emits_schedule_modified_event_with_new_values() {
+    let env = Env::default();
+    let (client, owner) = setup(&env);
+    let goal_id = make_goal(&env, &client, &owner, 10_000);
+
+    let schedule_id =
+        client.create_savings_schedule(&owner, &goal_id, &500_i128, &(1_000 + 86_400), &86_400);
+
+    set_ledger_time(&env, 2, 20_000);
+    client.modify_savings_schedule(&owner, &schedule_id, &750_i128, &(20_000 + 604_800), &604_800);
+
+    let evt: ScheduleModifiedEvent =
+        find_latest_event(&env, |e| matches!(e, SavingsEvent::ScheduleModified));
+
+    assert_eq!(evt.schedule_id, schedule_id);
+    assert_eq!(evt.goal_id, goal_id);
+    assert_eq!(evt.owner, owner);
+    assert_eq!(evt.amount, 750);
+    assert_eq!(evt.next_due, 20_000 + 604_800);
+    assert_eq!(evt.interval, 604_800);
+    assert_eq!(evt.timestamp, 20_000);
+}
+
+#[test]
+fn cancel_savings_schedule_emits_schedule_cancelled_event() {
+    let env = Env::default();
+    let (client, owner) = setup(&env);
+    let goal_id = make_goal(&env, &client, &owner, 10_000);
+
+    let schedule_id =
+        client.create_savings_schedule(&owner, &goal_id, &500_i128, &(1_000 + 86_400), &86_400);
+
+    set_ledger_time(&env, 2, 30_000);
+    client.cancel_savings_schedule(&owner, &schedule_id);
+
+    let evt: ScheduleCancelledEvent =
+        find_latest_event(&env, |e| matches!(e, SavingsEvent::ScheduleCancelled));
+
+    assert_eq!(evt.schedule_id, schedule_id);
+    assert_eq!(evt.goal_id, goal_id);
+    assert_eq!(evt.owner, owner);
+    assert_eq!(evt.timestamp, 30_000);
+}
+
+// ─── Schedule execution: executed / missed, and consistent FundsAdded ──────
+
+#[test]
+fn execute_due_savings_schedules_emits_schedule_executed_event_with_full_payload() {
+    let env = Env::default();
+    let (client, owner) = setup(&env);
+    let goal_id = make_goal(&env, &client, &owner, 10_000);
+
+    let schedule_id =
+        client.create_savings_schedule(&owner, &goal_id, &500_i128, &2_000u64, &86_400);
+
+    set_ledger_time(&env, 2, 2_000);
+    client.execute_due_savings_schedules();
+
+    let evt: ScheduleExecutedEvent =
+        find_latest_event(&env, |e| matches!(e, SavingsEvent::ScheduleExecuted));
+
+    assert_eq!(evt.schedule_id, schedule_id);
+    assert_eq!(evt.goal_id, goal_id);
+    assert_eq!(evt.owner, owner);
+    assert_eq!(evt.amount, 500);
+    assert_eq!(evt.timestamp, 2_000);
+}
+
+#[test]
+fn execute_due_savings_schedules_emits_schedule_missed_event_when_intervals_skipped() {
+    let env = Env::default();
+    let (client, owner) = setup(&env);
+    let goal_id = make_goal(&env, &client, &owner, 1_000_000);
+
+    let schedule_id =
+        client.create_savings_schedule(&owner, &goal_id, &500_i128, &2_000u64, &1_000);
+
+    // Jump far enough ahead that several 1_000-second intervals are skipped.
+    set_ledger_time(&env, 2, 6_500);
+    client.execute_due_savings_schedules();
+
+    let evt: ScheduleMissedEvent =
+        find_latest_event(&env, |e| matches!(e, SavingsEvent::ScheduleMissed));
+
+    assert_eq!(evt.schedule_id, schedule_id);
+    assert_eq!(evt.goal_id, goal_id);
+    assert_eq!(evt.owner, owner);
+    assert!(evt.missed_count > 0);
+    assert_eq!(evt.timestamp, 6_500);
+}
+
+/// Regression test: `execute_due_savings_schedules` must publish the
+/// standardized `FundsAddedEvent` (via `RemitwiseEvents::emit`, topic
+/// `(Remitwise, category, priority, "funds_add")`) with the same struct
+/// shape - including `new_total` and `timestamp` - as the manual
+/// `add_to_goal` path. Before this fix, the scheduled-execution path only
+/// published a bare `(goal_id, owner, amount)` tuple under the legacy
+/// `(savings, SavingsEvent::FundsAdded)` topic, missing `new_total` and
+/// `timestamp` entirely for indexers subscribed to the standardized event.
+#[test]
+fn execute_due_savings_schedules_funds_added_event_carries_new_total_and_timestamp() {
+    let env = Env::default();
+    let (client, owner) = setup(&env);
+    let goal_id = make_goal(&env, &client, &owner, 10_000);
+
+    client.create_savings_schedule(&owner, &goal_id, &500_i128, &2_000u64, &86_400);
+
+    set_ledger_time(&env, 2, 2_000);
+    client.execute_due_savings_schedules();
+
+    let all = env.events().all();
+    let matched = all
+        .iter()
+        .rev()
+        .find(|(_, topics, _)| {
+            let t0_ok = topics
+                .get(0)
+                .and_then(|t| Symbol::try_from_val(&env, &t).ok())
+                .map(|s: Symbol| s == symbol_short!("Remitwise"))
+                .unwrap_or(false);
+            let t3_ok = topics
+                .get(3)
+                .and_then(|t| Symbol::try_from_val(&env, &t).ok())
+                .map(|s: Symbol| s == FUNDS_ADDED)
+                .unwrap_or(false);
+            t0_ok && t3_ok
+        })
+        .expect("no standardized FundsAdded event found");
+
+    let evt = FundsAddedEvent::try_from_val(&env, &matched.2)
+        .expect("FundsAdded payload must decode as FundsAddedEvent");
+
+    assert_eq!(evt.goal_id, goal_id);
+    assert_eq!(evt.owner, owner);
+    assert_eq!(evt.amount, 500);
+    assert_eq!(evt.new_total, 500);
+    assert_eq!(evt.timestamp, 2_000);
+}
+
+/// Regression test: a goal that is already completed before a scheduled
+/// credit lands must NOT re-emit `GoalCompleted`. Before this fix,
+/// `execute_due_savings_schedules` compared `current_amount` *after* the
+/// credit was applied against `target_amount` with no "was it already
+/// completed" guard, so a goal that stayed at or above target across
+/// multiple executions would re-fire `GoalCompleted` every single time.
+#[test]
+fn execute_due_savings_schedules_does_not_reemit_goal_completed_for_already_completed_goal() {
+    let env = Env::default();
+    let (client, owner) = setup(&env);
+    // Target is reached by the very first scheduled credit.
+    let goal_id = make_goal(&env, &client, &owner, 500);
+
+    client.create_savings_schedule(&owner, &goal_id, &500_i128, &2_000u64, &1_000);
+
+    set_ledger_time(&env, 2, 2_000);
+    client.execute_due_savings_schedules();
+    assert!(client.is_goal_completed(&goal_id));
+
+    let completed_after_first = count_goal_completed_events(&env, &owner, goal_id);
+    assert_eq!(completed_after_first, 1);
+
+    // Second due execution: the goal is already completed, but the
+    // recurring schedule still credits it further.
+    set_ledger_time(&env, 3, 3_000);
+    client.execute_due_savings_schedules();
+
+    let completed_after_second = count_goal_completed_events(&env, &owner, goal_id);
+    assert_eq!(
+        completed_after_second, 1,
+        "GoalCompleted must not be re-emitted once a goal is already completed"
+    );
+}
+
+fn count_goal_completed_events(env: &Env, owner: &Address, goal_id: u32) -> usize {
+    env.events()
+        .all()
+        .iter()
+        .filter(|(_, topics, data)| {
+            let t0_ok = topics
+                .get(0)
+                .and_then(|t| Symbol::try_from_val(env, &t).ok())
+                .map(|s: Symbol| s == symbol_short!("savings"))
+                .unwrap_or(false);
+            let t1_ok = topics
+                .get(1)
+                .and_then(|t| SavingsEvent::try_from_val(env, &t).ok())
+                .map(|e| matches!(e, SavingsEvent::GoalCompleted))
+                .unwrap_or(false);
+            if !(t0_ok && t1_ok) {
+                return false;
+            }
+            // The legacy tuple payload is `(goal_id, owner)`; only count
+            // completions for this specific goal/owner pair.
+            <(u32, Address)>::try_from_val(env, data)
+                .map(|(g, o)| g == goal_id && &o == owner)
+                .unwrap_or(false)
+        })
+        .count()
+}

--- a/savings_goals/src/tests_schedule_exec.rs
+++ b/savings_goals/src/tests_schedule_exec.rs
@@ -474,11 +474,16 @@ fn test_schedule_executed_event_emitted_with_correct_id() {
             .unwrap_or(false);
 
         if t0_ok && t1_ok {
-            let data_id: u32 = u32::try_from_val(&env, &ev.2).unwrap();
+            let evt = ScheduleExecutedEvent::try_from_val(&env, &ev.2)
+                .expect("ScheduleExecuted payload must decode as ScheduleExecutedEvent");
             assert_eq!(
-                data_id, sched_id,
+                evt.schedule_id, sched_id,
                 "ScheduleExecuted event data must carry the schedule ID"
             );
+            assert_eq!(evt.goal_id, goal_id);
+            assert_eq!(evt.owner, owner);
+            assert_eq!(evt.amount, 200);
+            assert_eq!(evt.timestamp, 3_500);
             found = true;
         }
     }


### PR DESCRIPTION
Closes #1422

## Summary

Goal lifecycle and savings-schedule events used inconsistent payload shapes across contract paths in `savings_goals`, making them unreliable for indexers to consume:

- `lock_goal`/`unlock_goal` published a bare `(goal_id, owner)` tuple with no timestamp.
- `create_savings_schedule`/`modify_savings_schedule`/`cancel_savings_schedule` published bare 2-tuples, dropping `amount`/`next_due`/`interval` entirely for `modify`, and dropping `goal_id` everywhere.
- `execute_due_savings_schedules`'s own `FundsAdded`/`GoalCompleted` emissions used bare tuples missing `new_total` and `timestamp`, while `add_to_goal` emitted a fully-typed `FundsAddedEvent`/`GoalCompletedEvent` struct for the exact same logical event — indexers subscribed to the standardized `(Remitwise, category, priority, action)` topic would only ever see the manual-contribution shape, never the scheduled one.
- `execute_due_savings_schedules` was also missing the "already completed" guard that `add_to_goal` has: a goal sitting at or above target that kept receiving scheduled credits would re-emit `GoalCompleted` on every single execution instead of exactly once.

## What's implemented

- Adds explicit `#[contracttype]` structs — `GoalLockEvent`, `ScheduleCreatedEvent`, `ScheduleModifiedEvent`, `ScheduleCancelledEvent`, `ScheduleExecutedEvent`, `ScheduleMissedEvent` — each carrying `goal_id`/`schedule_id`, `owner`, the relevant amount/next_due/interval fields, and a `timestamp`, matching the "goal_id, owner, amount deltas, timestamps" shape from the issue and consistent with the existing `GoalCreatedEvent`/`FundsAddedEvent`/`FundsWithdrawnEvent`/`GoalCompletedEvent` structs.
- Rewires `lock_goal`, `unlock_goal`, `create_savings_schedule`, `modify_savings_schedule`, and `cancel_savings_schedule` to emit these structs instead of bare tuples.
- Fixes `execute_due_savings_schedules` to emit `FundsAdded`/`GoalCompleted` via the same `RemitwiseEvents::emit` + `FundsAddedEvent`/`GoalCompletedEvent` struct pattern `add_to_goal` uses (in addition to the pre-existing legacy bare-tuple emission under the `(savings, SavingsEvent::X)` topic, kept unchanged for backward compatibility), and adds the `previously_completed` guard so `GoalCompleted` fires at most once per goal regardless of which path (manual or scheduled) applies the completing credit.
- Switches `ScheduleExecuted`/`ScheduleMissed` to their new structs.
- Updates `docs/EVENTS.md`: documents `GoalLockEvent`'s `owner` field, renames the doc's `SavingsScheduleCreatedEvent` to match the actual `ScheduleCreatedEvent` name/shape, and adds the previously-undocumented `ScheduleModified`/`Cancelled`/`Executed`/`Missed` event schemas (bringing savings_goals' docs coverage in line with bill_payments/remittance_split, which already document their equivalents).

## Files changed

**Modified:**
- `savings_goals/src/lib.rs` — new event structs, rewired emission sites, `execute_due_savings_schedules` bug fixes described above.
- `savings_goals/src/events_schema_test.rs` — round-trip `Val` schema-stability tests for all 6 new structs.
- `savings_goals/src/tests_schedule_exec.rs` — updated one pre-existing test, `test_schedule_executed_event_emitted_with_correct_id`, to decode the new `ScheduleExecutedEvent` struct instead of the old bare `u32` payload.
- `docs/EVENTS.md` — savings_goals event schema documentation, as described above.

**New:**
- `savings_goals/src/schedule_lifecycle_event_test.rs` — functional tests that drive the real contract entrypoints (not just compile-time struct-literal checks) and decode the actual emitted events: lock/unlock, schedule create/modify/cancel/execute/missed, plus two regression tests:
  - `execute_due_savings_schedules_funds_added_event_carries_new_total_and_timestamp` — asserts the scheduled-execution `FundsAdded` event (under the standardized `RemitwiseEvents` topic) carries `new_total`/`timestamp`, matching the manual `add_to_goal` path.
  - `execute_due_savings_schedules_does_not_reemit_goal_completed_for_already_completed_goal` — asserts `GoalCompleted` is not re-emitted for a goal that's already at/above target when a subsequent scheduled credit lands.

## Implementation details

- All new event structs carry `owner: Address` explicitly (the issue calls for `goal_id, owner, amount deltas, timestamps` on every lifecycle event) — this was inconsistently present before (e.g. `ScheduleModified` dropped `goal_id`, `ScheduleExecuted` was a bare `u32`).
- The legacy `(symbol_short!("savings"), SavingsEvent::X)` topic + bare-tuple payloads are left in place everywhere they previously existed, for backward compatibility with any existing consumers of that topic. The new structured payloads are additive, published either as the new struct under the same legacy topic (for lock/unlock/schedule create/modify/cancel), or via the standardized `RemitwiseEvents::emit` topic (for the funds-added/goal-completed dual-emission on the scheduled-execution path, matching `add_to_goal`'s existing pattern).
- `execute_due_savings_schedules`: `previously_completed` is computed from `goal.current_amount` *before* the credit is applied, and `is_completed` from `new_total` *after* — previously `is_completed` was (redundantly and confusingly) computed from `goal.current_amount` after it had already been mutated to `new_total` a few lines above; using `new_total` directly is equivalent but clearer, and the new `previously_completed` check is what actually fixes the re-emission bug.

## Tests added

- `events_schema_test.rs`: 6 new round-trip schema tests (`goal_lock_event_payload_schema`, `schedule_created_event_payload_schema`, `schedule_modified_event_payload_schema`, `schedule_cancelled_event_payload_schema`, `schedule_executed_event_payload_schema`, `schedule_missed_event_payload_schema`) — construct each struct, convert to/from `Val`, and assert field equality survives the round trip, locking the wire shape down for indexers.
- `schedule_lifecycle_event_test.rs` (new file): end-to-end functional tests that call the real contract entrypoints and decode the actual emitted event topics/payloads for: `lock_goal`, `unlock_goal`, `create_savings_schedule`, `modify_savings_schedule`, `cancel_savings_schedule`, `execute_due_savings_schedules` (executed + missed paths), plus the two regression tests described above.
- `tests_schedule_exec.rs`: updated the one pre-existing test that asserted on the old payload shape.

## ⚠️ CI on this PR will show red — pre-existing `main` build break, unrelated to this change

**`main` currently fails to compile at all**, for every crate that depends on `remitwise-common`
(which is most of the workspace, including `savings_goals`). This is **not caused by this PR** —
it was already broken on `main` before this branch was rebased onto it, introduced by PR #1481
(`2c91be2`, "Add a same_address helper avoiding accidental clones"), which reintroduced a second,
older definition of `canonicalise_symbol` alongside the existing one:

```
error[E0428]: the name `canonicalise_symbol` is defined multiple times
    --> remitwise-common/src/lib.rs:2032:1
     |
1078 | pub fn canonicalise_symbol(env: &Env, input: &soroban_sdk::String) -> Symbol {
     | ---------------------------------------------------------------------------- previous definition of the value `canonicalise_symbol` here
...
2032 | pub fn canonicalise_symbol(env: &Env, input: &soroban_sdk::String) -> Symbol {
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `canonicalise_symbol` redefined here
     |
     = note: `canonicalise_symbol` must be defined only once in the value namespace of this module

error: could not compile `remitwise-common` (lib) due to 1 previous error
```

Confirmed on this PR's own CI run: **"Batch-B CI Gate" → "Validate and Build" job failed** at the
`Execute Native CI Checks` step with this exact error (build fails before `remitwise-common` even
finishes compiling, so it never gets as far as `savings_goals`). Same failure mode as the
`SymbolError` duplicate-definition bug fixed by #1455 a few days ago — this is a second, separate
instance of the same class of bug (a bad merge leaving two definitions of the same function).

This PR's diff does **not** touch `remitwise-common` at all — see "Files changed" above (only
`savings_goals/*` and `docs/EVENTS.md`). To get the test results below locally, the duplicate
`canonicalise_symbol` definition at `remitwise-common/src/lib.rs:2032` was deleted **locally and
temporarily, never committed** (reverted via `git checkout -- remitwise-common/src/lib.rs` before
pushing this branch) — purely so `cargo test -p savings_goals` could run at all. This repo-wide
break should be fixed in its own separate PR (not this one), the same way #1455 fixed the prior
`SymbolError` duplicate — keeping the one at line 1078 (the checked-wrapper version that delegates
to `canonicalise_symbol_checked`) and removing the older hand-rolled one at line ~2032.

## Test results

`RUSTUP_TOOLCHAIN=1.90.0 cargo test -p savings_goals` (with the above local-only workaround
applied so the workspace would compile): **269 passed, 5 failed**. All 5 failures are pre-existing
and unrelated to this change (confirmed via `git blame` and by reading the referenced code — none
of it touched by this PR):

- `test::test_create_goal_accepts_127byte_name`
- `test::test_create_goal_accepts_special_chars_within_limit`
- `test::test_create_goal_accepts_typical_names`
- `test::test_sequential_goals_with_various_name_lengths`
  (these 4 assert that goal names >32 bytes are accepted, but `MAX_GOAL_NAME_LEN_BYTES = 32` in `lib.rs` rejects them — a pre-existing test/implementation mismatch unrelated to events)
- `tests_safe_math::checked_add_returns_error_on_zero_amount`
  (expects `amount == 0` to return `InvalidAmount`, but `add_to_goal`'s safe-math check only rejects `amount < 0`, not `<= 0` — pre-existing, unrelated to events)

All 6 new schema-stability tests and all new/modified functional tests pass.

**tl;dr for reviewers**: green-lighting this PR requires either (a) merging a fix for the
`remitwise-common` duplicate-symbol break first (separate PR, out of scope here), or (b)
reviewing this PR's `savings_goals`/`docs` diff and test results on trust, since CI cannot
currently pass on *any* PR against `main` until that's fixed.

## How to test

```
git checkout feature/savings-goals-event-schema
RUSTUP_TOOLCHAIN=1.90.0 cargo test -p savings_goals
```

To exercise just the new/changed tests:
```
cargo test -p savings_goals events_schema_test
cargo test -p savings_goals schedule_lifecycle_event_test
```
