### PR TITLE
test: lock in reversible-op cancel-after-execute/cancel-before-execut…

### DIFF
--- a/bill_payments/src/lib.rs
+++ b/bill_payments/src/lib.rs
@@ -4,8 +4,8 @@
 use remitwise_common::reversible_op::{BillPaymentsReversible, ReversibleOpError};
 use remitwise_common::{
     check_and_increment_rate_limit, clamp_limit, require_stable_currency,
-    require_within_settlement_window, EventCategory, EventPriority, RemitwiseEvents,
-    Timestamp, ARCHIVE_BUMP_AMOUNT, ARCHIVE_LIFETIME_THRESHOLD, CONTRACT_VERSION, DEFAULT_CURRENCY,
+    require_within_settlement_window, EventCategory, EventPriority, RemitwiseEvents, Timestamp,
+    ARCHIVE_BUMP_AMOUNT, ARCHIVE_LIFETIME_THRESHOLD, CONTRACT_VERSION, DEFAULT_CURRENCY,
     INSTANCE_BUMP_AMOUNT, INSTANCE_LIFETIME_THRESHOLD, MAX_BATCH_SIZE, MAX_CURRENCY_LEN,
     MAX_SETTLEMENT_WINDOW_SECS, SNAPSHOT_KEY, SNAPSHOT_VERSION,
 };
@@ -889,7 +889,7 @@ impl BillPayments {
         new_admin: Address,
     ) -> Result<(), BillPaymentsError> {
         caller.require_auth();
-        
+
         // Defense-in-depth: Validate admin grant TTL before allowing admin changes
         // Prevents bypass of the 30-day admin grant expiration mechanism
         let current = Self::get_pause_admin(&env);
@@ -898,7 +898,7 @@ impl BillPayments {
             // (first-time setup when current is None is allowed to proceed)
             Self::require_admin_grant_valid(&env)?;
         }
-        
+
         match current {
             Option::None => {
                 if caller != new_admin {

--- a/bill_payments/src/test.rs
+++ b/bill_payments/src/test.rs
@@ -4273,4 +4273,47 @@ mod testsuit {
         let bill = client.get_bill(&bill_id).unwrap();
         assert_eq!(bill.external_ref.unwrap(), String::from_str(&env, "REF-NEW"));
     }
+
+    #[test]
+    fn cancel_before_execute_succeeds() {
+        setup_test_env!(env, BillPayments, BillPaymentsClient, client, owner);
+
+        let bill_id = client.create_bill(
+            &owner,
+            &String::from_str(&env, "Electricity"),
+            &100,
+            &1735689600,
+            &false,
+            &0,
+            &None,
+            &String::from_str(&env, "XLM"),
+            &None,
+        );
+
+        let res = client.reverse_payment(&owner, &bill_id, &100);
+        assert_eq!(res, Ok(false));
+    }
+
+    #[test]
+    fn cancel_after_execute_fails() {
+        setup_test_env!(env, BillPayments, BillPaymentsClient, client, owner);
+
+        let bill_id = client.create_bill(
+            &owner,
+            &String::from_str(&env, "Electricity"),
+            &100,
+            &1735689600,
+            &false,
+            &0,
+            &None,
+            &String::from_str(&env, "XLM"),
+            &None,
+        );
+
+        client.pay_bill(&owner, &bill_id);
+
+        let res = client.try_reverse_payment(&owner, &bill_id, &100);
+        assert_eq!(res, Err(Ok(ReversibleOpError::InvalidState)));
+    }
 }
+

--- a/bill_payments/src/test.rs
+++ b/bill_payments/src/test.rs
@@ -4,6 +4,7 @@ mod testsuit {
 
     use crate::*;
     use proptest::prelude::*;
+    use remitwise_common::reversible_op::ReversibleOpError;
     use soroban_sdk::testutils::storage::Instance as _;
     use soroban_sdk::testutils::{Address as AddressTrait, Ledger, LedgerInfo};
     use soroban_sdk::{Address, Env, IntoVal, String};
@@ -3504,7 +3505,10 @@ mod testsuit {
 
         assert_eq!(
             emitted_actions,
-            [Symbol::new(&env, "paused_v2"), Symbol::new(&env, "unpaused_v2")]
+            [
+                Symbol::new(&env, "paused_v2"),
+                Symbol::new(&env, "unpaused_v2")
+            ]
         );
     }
 
@@ -3940,380 +3944,389 @@ mod testsuit {
     }
 }
 
-    // ========================================================================
-    // Tests for set_external_ref authorization and index cleanup (Issue #1410)
-    // ========================================================================
+// ========================================================================
+// Tests for set_external_ref authorization and index cleanup (Issue #1410)
+// ========================================================================
 
-    #[test]
-    fn test_set_external_ref_owner_can_set() {
-        setup_test_env!(env, BillPayments, BillPaymentsClient, client, owner);
+#[test]
+fn test_set_external_ref_owner_can_set() {
+    setup_test_env!(env, BillPayments, BillPaymentsClient, client, owner);
 
-        // Create a bill
-        let bill_id = client.create_bill(
-            &owner,
-            &String::from_str(&env, "Electricity"),
-            &1000,
-            &1000000,
-            &false,
-            &0,
-            &None,
-            &String::from_str(&env, "XLM"),
-            &None,
-        );
+    // Create a bill
+    let bill_id = client.create_bill(
+        &owner,
+        &String::from_str(&env, "Electricity"),
+        &1000,
+        &1000000,
+        &false,
+        &0,
+        &None,
+        &String::from_str(&env, "XLM"),
+        &None,
+    );
 
-        // Owner should be able to set external_ref
-        env.mock_all_auths();
-        let ext_ref = Some(String::from_str(&env, "EXT-123"));
-        client.set_external_ref(&owner, &bill_id, &ext_ref);
+    // Owner should be able to set external_ref
+    env.mock_all_auths();
+    let ext_ref = Some(String::from_str(&env, "EXT-123"));
+    client.set_external_ref(&owner, &bill_id, &ext_ref);
 
-        // Verify the external_ref was set
-        let bill = client.get_bill(&bill_id).unwrap();
-        assert!(bill.external_ref.is_some());
-        assert_eq!(bill.external_ref.unwrap(), String::from_str(&env, "EXT-123"));
-    }
-
-    #[test]
-    fn test_set_external_ref_non_owner_fails() {
-        setup_test_env!(env, BillPayments, BillPaymentsClient, client, owner);
-
-        // Create a bill owned by owner
-        let bill_id = client.create_bill(
-            &owner,
-            &String::from_str(&env, "Water Bill"),
-            &500,
-            &1000000,
-            &false,
-            &0,
-            &None,
-            &String::from_str(&env, "XLM"),
-            &None,
-        );
-
-        // Try to set external_ref as a different user
-        let other_user = <soroban_sdk::Address as AddressTrait>::generate(&env);
-        env.mock_all_auths();
-        let ext_ref = Some(String::from_str(&env, "EXT-456"));
-        let result = client.try_set_external_ref(&other_user, &bill_id, &ext_ref);
-
-        // Should fail with Unauthorized
-        assert_eq!(result, Err(Ok(Error::Unauthorized)));
-
-        // Verify external_ref was not set
-        let bill = client.get_bill(&bill_id).unwrap();
-        assert!(bill.external_ref.is_none());
-    }
-
-    #[test]
-    fn test_set_external_ref_clear_removes_index() {
-        setup_test_env!(env, BillPayments, BillPaymentsClient, client, owner);
-
-        // Create a bill with an external_ref
-        let ext_ref = Some(String::from_str(&env, "EXT-789"));
-        let bill_id = client.create_bill(
-            &owner,
-            &String::from_str(&env, "Gas Bill"),
-            &750,
-            &1000000,
-            &false,
-            &0,
-            &ext_ref,
-            &String::from_str(&env, "XLM"),
-            &None,
-        );
-
-        // Verify external_ref is set
-        let bill = client.get_bill(&bill_id).unwrap();
-        assert!(bill.external_ref.is_some());
-
-        // Clear the external_ref
-        env.mock_all_auths();
-        client.set_external_ref(&owner, &bill_id, &None);
-
-        // Verify external_ref was cleared
-        let bill = client.get_bill(&bill_id).unwrap();
-        assert!(bill.external_ref.is_none());
-
-        // The same external_ref should now be available for reuse
-        env.mock_all_auths();
-        let bill_id2 = client.create_bill(
-            &owner,
-            &String::from_str(&env, "Internet Bill"),
-            &800,
-            &1000000,
-            &false,
-            &0,
-            &Some(String::from_str(&env, "EXT-789")),
-            &String::from_str(&env, "XLM"),
-            &None,
-        );
-
-        let bill2 = client.get_bill(&bill_id2).unwrap();
-        assert_eq!(bill2.external_ref.unwrap(), String::from_str(&env, "EXT-789"));
-    }
-
-    #[test]
-    fn test_set_external_ref_no_stale_index_entries() {
-        setup_test_env!(env, BillPayments, BillPaymentsClient, client, owner);
-
-        // Create a bill with external_ref
-        let ext_ref1 = Some(String::from_str(&env, "REF-001"));
-        let bill_id = client.create_bill(
-            &owner,
-            &String::from_str(&env, "Phone Bill"),
-            &600,
-            &1000000,
-            &false,
-            &0,
-            &ext_ref1,
-            &String::from_str(&env, "XLM"),
-            &None,
-        );
-
-        // Change to a different external_ref
-        env.mock_all_auths();
-        let ext_ref2 = Some(String::from_str(&env, "REF-002"));
-        client.set_external_ref(&owner, &bill_id, &ext_ref2);
-
-        // The old ref should be available for a new bill (no stale index)
-        env.mock_all_auths();
-        let bill_id2 = client.create_bill(
-            &owner,
-            &String::from_str(&env, "Cable Bill"),
-            &550,
-            &1000000,
-            &false,
-            &0,
-            &Some(String::from_str(&env, "REF-001")),
-            &String::from_str(&env, "XLM"),
-            &None,
-        );
-
-        let bill2 = client.get_bill(&bill_id2).unwrap();
-        assert_eq!(bill2.external_ref.unwrap(), String::from_str(&env, "REF-001"));
-
-        // Verify the first bill has the new ref
-        let bill = client.get_bill(&bill_id).unwrap();
-        assert_eq!(bill.external_ref.unwrap(), String::from_str(&env, "REF-002"));
-    }
-
-    #[test]
-    fn test_set_external_ref_duplicate_fails() {
-        setup_test_env!(env, BillPayments, BillPaymentsClient, client, owner);
-
-        // Create first bill with external_ref
-        let ext_ref = Some(String::from_str(&env, "DUP-REF"));
-        let bill_id1 = client.create_bill(
-            &owner,
-            &String::from_str(&env, "Bill 1"),
-            &100,
-            &1000000,
-            &false,
-            &0,
-            &ext_ref,
-            &String::from_str(&env, "XLM"),
-            &None,
-        );
-
-        // Create second bill without external_ref
-        env.mock_all_auths();
-        let bill_id2 = client.create_bill(
-            &owner,
-            &String::from_str(&env, "Bill 2"),
-            &200,
-            &1000000,
-            &false,
-            &0,
-            &None,
-            &String::from_str(&env, "XLM"),
-            &None,
-        );
-
-        // Try to set the same external_ref on the second bill
-        env.mock_all_auths();
-        let result = client.try_set_external_ref(
-            &owner,
-            &bill_id2,
-            &Some(String::from_str(&env, "DUP-REF")),
-        );
-
-        // Should fail with DuplicateExternalRef
-        assert_eq!(result, Err(Ok(Error::DuplicateExternalRef)));
-
-        // Verify second bill still has no external_ref
-        let bill2 = client.get_bill(&bill_id2).unwrap();
-        assert!(bill2.external_ref.is_none());
-
-        // Verify first bill still has the external_ref
-        let bill1 = client.get_bill(&bill_id1).unwrap();
-        assert_eq!(bill1.external_ref.unwrap(), String::from_str(&env, "DUP-REF"));
-    }
-
-    #[test]
-    fn test_set_external_ref_clear_and_reuse_succeeds() {
-        setup_test_env!(env, BillPayments, BillPaymentsClient, client, owner);
-
-        // Create bill with external_ref
-        let ext_ref = Some(String::from_str(&env, "REUSE-REF"));
-        let bill_id1 = client.create_bill(
-            &owner,
-            &String::from_str(&env, "First Bill"),
-            &300,
-            &1000000,
-            &false,
-            &0,
-            &ext_ref,
-            &String::from_str(&env, "XLM"),
-            &None,
-        );
-
-        // Clear the external_ref from first bill
-        env.mock_all_auths();
-        client.set_external_ref(&owner, &bill_id1, &None);
-
-        // Create another bill with the same external_ref (should succeed)
-        env.mock_all_auths();
-        let bill_id2 = client.create_bill(
-            &owner,
-            &String::from_str(&env, "Second Bill"),
-            &400,
-            &1000000,
-            &false,
-            &0,
-            &Some(String::from_str(&env, "REUSE-REF")),
-            &String::from_str(&env, "XLM"),
-            &None,
-        );
-
-        // Verify first bill has no external_ref
-        let bill1 = client.get_bill(&bill_id1).unwrap();
-        assert!(bill1.external_ref.is_none());
-
-        // Verify second bill has the external_ref
-        let bill2 = client.get_bill(&bill_id2).unwrap();
-        assert_eq!(bill2.external_ref.unwrap(), String::from_str(&env, "REUSE-REF"));
-    }
-
-    #[test]
-    fn test_set_external_ref_invalid_ref_fails() {
-        setup_test_env!(env, BillPayments, BillPaymentsClient, client, owner);
-
-        // Create a bill
-        let bill_id = client.create_bill(
-            &owner,
-            &String::from_str(&env, "Test Bill"),
-            &250,
-            &1000000,
-            &false,
-            &0,
-            &None,
-            &String::from_str(&env, "XLM"),
-            &None,
-        );
-
-        // Try to set an empty external_ref (should fail)
-        env.mock_all_auths();
-        let result = client.try_set_external_ref(
-            &owner,
-            &bill_id,
-            &Some(String::from_str(&env, "")),
-        );
-
-        assert_eq!(result, Err(Ok(Error::InvalidExternalRef)));
-
-        // Try to set an external_ref with invalid characters
-        env.mock_all_auths();
-        let result = client.try_set_external_ref(
-            &owner,
-            &bill_id,
-            &Some(String::from_str(&env, "REF@INVALID!")),
-        );
-
-        assert_eq!(result, Err(Ok(Error::InvalidExternalRef)));
-    }
-
-    #[test]
-    fn test_set_external_ref_nonexistent_bill_fails() {
-        setup_test_env!(env, BillPayments, BillPaymentsClient, client, owner);
-
-        // Try to set external_ref on a non-existent bill
-        env.mock_all_auths();
-        let result = client.try_set_external_ref(
-            &owner,
-            &999,
-            &Some(String::from_str(&env, "REF-999")),
-        );
-
-        assert_eq!(result, Err(Ok(Error::BillNotFound)));
-    }
-
-    #[test]
-    fn test_set_external_ref_owner_can_overwrite_own_ref() {
-        setup_test_env!(env, BillPayments, BillPaymentsClient, client, owner);
-
-        // Create bill with external_ref
-        let ext_ref1 = Some(String::from_str(&env, "REF-OLD"));
-        let bill_id = client.create_bill(
-            &owner,
-            &String::from_str(&env, "Updatable Bill"),
-            &500,
-            &1000000,
-            &false,
-            &0,
-            &ext_ref1,
-            &String::from_str(&env, "XLM"),
-            &None,
-        );
-
-        // Owner updates to a new external_ref
-        env.mock_all_auths();
-        let ext_ref2 = Some(String::from_str(&env, "REF-NEW"));
-        client.set_external_ref(&owner, &bill_id, &ext_ref2);
-
-        // Verify the external_ref was updated
-        let bill = client.get_bill(&bill_id).unwrap();
-        assert_eq!(bill.external_ref.unwrap(), String::from_str(&env, "REF-NEW"));
-    }
-
-    #[test]
-    fn cancel_before_execute_succeeds() {
-        setup_test_env!(env, BillPayments, BillPaymentsClient, client, owner);
-
-        let bill_id = client.create_bill(
-            &owner,
-            &String::from_str(&env, "Electricity"),
-            &100,
-            &1735689600,
-            &false,
-            &0,
-            &None,
-            &String::from_str(&env, "XLM"),
-            &None,
-        );
-
-        let res = client.reverse_payment(&owner, &bill_id, &100);
-        assert_eq!(res, Ok(false));
-    }
-
-    #[test]
-    fn cancel_after_execute_fails() {
-        setup_test_env!(env, BillPayments, BillPaymentsClient, client, owner);
-
-        let bill_id = client.create_bill(
-            &owner,
-            &String::from_str(&env, "Electricity"),
-            &100,
-            &1735689600,
-            &false,
-            &0,
-            &None,
-            &String::from_str(&env, "XLM"),
-            &None,
-        );
-
-        client.pay_bill(&owner, &bill_id);
-
-        let res = client.try_reverse_payment(&owner, &bill_id, &100);
-        assert_eq!(res, Err(Ok(ReversibleOpError::InvalidState)));
-    }
+    // Verify the external_ref was set
+    let bill = client.get_bill(&bill_id).unwrap();
+    assert!(bill.external_ref.is_some());
+    assert_eq!(
+        bill.external_ref.unwrap(),
+        String::from_str(&env, "EXT-123")
+    );
 }
 
+#[test]
+fn test_set_external_ref_non_owner_fails() {
+    setup_test_env!(env, BillPayments, BillPaymentsClient, client, owner);
+
+    // Create a bill owned by owner
+    let bill_id = client.create_bill(
+        &owner,
+        &String::from_str(&env, "Water Bill"),
+        &500,
+        &1000000,
+        &false,
+        &0,
+        &None,
+        &String::from_str(&env, "XLM"),
+        &None,
+    );
+
+    // Try to set external_ref as a different user
+    let other_user = <soroban_sdk::Address as AddressTrait>::generate(&env);
+    env.mock_all_auths();
+    let ext_ref = Some(String::from_str(&env, "EXT-456"));
+    let result = client.try_set_external_ref(&other_user, &bill_id, &ext_ref);
+
+    // Should fail with Unauthorized
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+
+    // Verify external_ref was not set
+    let bill = client.get_bill(&bill_id).unwrap();
+    assert!(bill.external_ref.is_none());
+}
+
+#[test]
+fn test_set_external_ref_clear_removes_index() {
+    setup_test_env!(env, BillPayments, BillPaymentsClient, client, owner);
+
+    // Create a bill with an external_ref
+    let ext_ref = Some(String::from_str(&env, "EXT-789"));
+    let bill_id = client.create_bill(
+        &owner,
+        &String::from_str(&env, "Gas Bill"),
+        &750,
+        &1000000,
+        &false,
+        &0,
+        &ext_ref,
+        &String::from_str(&env, "XLM"),
+        &None,
+    );
+
+    // Verify external_ref is set
+    let bill = client.get_bill(&bill_id).unwrap();
+    assert!(bill.external_ref.is_some());
+
+    // Clear the external_ref
+    env.mock_all_auths();
+    client.set_external_ref(&owner, &bill_id, &None);
+
+    // Verify external_ref was cleared
+    let bill = client.get_bill(&bill_id).unwrap();
+    assert!(bill.external_ref.is_none());
+
+    // The same external_ref should now be available for reuse
+    env.mock_all_auths();
+    let bill_id2 = client.create_bill(
+        &owner,
+        &String::from_str(&env, "Internet Bill"),
+        &800,
+        &1000000,
+        &false,
+        &0,
+        &Some(String::from_str(&env, "EXT-789")),
+        &String::from_str(&env, "XLM"),
+        &None,
+    );
+
+    let bill2 = client.get_bill(&bill_id2).unwrap();
+    assert_eq!(
+        bill2.external_ref.unwrap(),
+        String::from_str(&env, "EXT-789")
+    );
+}
+
+#[test]
+fn test_set_external_ref_no_stale_index_entries() {
+    setup_test_env!(env, BillPayments, BillPaymentsClient, client, owner);
+
+    // Create a bill with external_ref
+    let ext_ref1 = Some(String::from_str(&env, "REF-001"));
+    let bill_id = client.create_bill(
+        &owner,
+        &String::from_str(&env, "Phone Bill"),
+        &600,
+        &1000000,
+        &false,
+        &0,
+        &ext_ref1,
+        &String::from_str(&env, "XLM"),
+        &None,
+    );
+
+    // Change to a different external_ref
+    env.mock_all_auths();
+    let ext_ref2 = Some(String::from_str(&env, "REF-002"));
+    client.set_external_ref(&owner, &bill_id, &ext_ref2);
+
+    // The old ref should be available for a new bill (no stale index)
+    env.mock_all_auths();
+    let bill_id2 = client.create_bill(
+        &owner,
+        &String::from_str(&env, "Cable Bill"),
+        &550,
+        &1000000,
+        &false,
+        &0,
+        &Some(String::from_str(&env, "REF-001")),
+        &String::from_str(&env, "XLM"),
+        &None,
+    );
+
+    let bill2 = client.get_bill(&bill_id2).unwrap();
+    assert_eq!(
+        bill2.external_ref.unwrap(),
+        String::from_str(&env, "REF-001")
+    );
+
+    // Verify the first bill has the new ref
+    let bill = client.get_bill(&bill_id).unwrap();
+    assert_eq!(
+        bill.external_ref.unwrap(),
+        String::from_str(&env, "REF-002")
+    );
+}
+
+#[test]
+fn test_set_external_ref_duplicate_fails() {
+    setup_test_env!(env, BillPayments, BillPaymentsClient, client, owner);
+
+    // Create first bill with external_ref
+    let ext_ref = Some(String::from_str(&env, "DUP-REF"));
+    let bill_id1 = client.create_bill(
+        &owner,
+        &String::from_str(&env, "Bill 1"),
+        &100,
+        &1000000,
+        &false,
+        &0,
+        &ext_ref,
+        &String::from_str(&env, "XLM"),
+        &None,
+    );
+
+    // Create second bill without external_ref
+    env.mock_all_auths();
+    let bill_id2 = client.create_bill(
+        &owner,
+        &String::from_str(&env, "Bill 2"),
+        &200,
+        &1000000,
+        &false,
+        &0,
+        &None,
+        &String::from_str(&env, "XLM"),
+        &None,
+    );
+
+    // Try to set the same external_ref on the second bill
+    env.mock_all_auths();
+    let result =
+        client.try_set_external_ref(&owner, &bill_id2, &Some(String::from_str(&env, "DUP-REF")));
+
+    // Should fail with DuplicateExternalRef
+    assert_eq!(result, Err(Ok(Error::DuplicateExternalRef)));
+
+    // Verify second bill still has no external_ref
+    let bill2 = client.get_bill(&bill_id2).unwrap();
+    assert!(bill2.external_ref.is_none());
+
+    // Verify first bill still has the external_ref
+    let bill1 = client.get_bill(&bill_id1).unwrap();
+    assert_eq!(
+        bill1.external_ref.unwrap(),
+        String::from_str(&env, "DUP-REF")
+    );
+}
+
+#[test]
+fn test_set_external_ref_clear_and_reuse_succeeds() {
+    setup_test_env!(env, BillPayments, BillPaymentsClient, client, owner);
+
+    // Create bill with external_ref
+    let ext_ref = Some(String::from_str(&env, "REUSE-REF"));
+    let bill_id1 = client.create_bill(
+        &owner,
+        &String::from_str(&env, "First Bill"),
+        &300,
+        &1000000,
+        &false,
+        &0,
+        &ext_ref,
+        &String::from_str(&env, "XLM"),
+        &None,
+    );
+
+    // Clear the external_ref from first bill
+    env.mock_all_auths();
+    client.set_external_ref(&owner, &bill_id1, &None);
+
+    // Create another bill with the same external_ref (should succeed)
+    env.mock_all_auths();
+    let bill_id2 = client.create_bill(
+        &owner,
+        &String::from_str(&env, "Second Bill"),
+        &400,
+        &1000000,
+        &false,
+        &0,
+        &Some(String::from_str(&env, "REUSE-REF")),
+        &String::from_str(&env, "XLM"),
+        &None,
+    );
+
+    // Verify first bill has no external_ref
+    let bill1 = client.get_bill(&bill_id1).unwrap();
+    assert!(bill1.external_ref.is_none());
+
+    // Verify second bill has the external_ref
+    let bill2 = client.get_bill(&bill_id2).unwrap();
+    assert_eq!(
+        bill2.external_ref.unwrap(),
+        String::from_str(&env, "REUSE-REF")
+    );
+}
+
+#[test]
+fn test_set_external_ref_invalid_ref_fails() {
+    setup_test_env!(env, BillPayments, BillPaymentsClient, client, owner);
+
+    // Create a bill
+    let bill_id = client.create_bill(
+        &owner,
+        &String::from_str(&env, "Test Bill"),
+        &250,
+        &1000000,
+        &false,
+        &0,
+        &None,
+        &String::from_str(&env, "XLM"),
+        &None,
+    );
+
+    // Try to set an empty external_ref (should fail)
+    env.mock_all_auths();
+    let result = client.try_set_external_ref(&owner, &bill_id, &Some(String::from_str(&env, "")));
+
+    assert_eq!(result, Err(Ok(Error::InvalidExternalRef)));
+
+    // Try to set an external_ref with invalid characters
+    env.mock_all_auths();
+    let result = client.try_set_external_ref(
+        &owner,
+        &bill_id,
+        &Some(String::from_str(&env, "REF@INVALID!")),
+    );
+
+    assert_eq!(result, Err(Ok(Error::InvalidExternalRef)));
+}
+
+#[test]
+fn test_set_external_ref_nonexistent_bill_fails() {
+    setup_test_env!(env, BillPayments, BillPaymentsClient, client, owner);
+
+    // Try to set external_ref on a non-existent bill
+    env.mock_all_auths();
+    let result =
+        client.try_set_external_ref(&owner, &999, &Some(String::from_str(&env, "REF-999")));
+
+    assert_eq!(result, Err(Ok(Error::BillNotFound)));
+}
+
+#[test]
+fn test_set_external_ref_owner_can_overwrite_own_ref() {
+    setup_test_env!(env, BillPayments, BillPaymentsClient, client, owner);
+
+    // Create bill with external_ref
+    let ext_ref1 = Some(String::from_str(&env, "REF-OLD"));
+    let bill_id = client.create_bill(
+        &owner,
+        &String::from_str(&env, "Updatable Bill"),
+        &500,
+        &1000000,
+        &false,
+        &0,
+        &ext_ref1,
+        &String::from_str(&env, "XLM"),
+        &None,
+    );
+
+    // Owner updates to a new external_ref
+    env.mock_all_auths();
+    let ext_ref2 = Some(String::from_str(&env, "REF-NEW"));
+    client.set_external_ref(&owner, &bill_id, &ext_ref2);
+
+    // Verify the external_ref was updated
+    let bill = client.get_bill(&bill_id).unwrap();
+    assert_eq!(
+        bill.external_ref.unwrap(),
+        String::from_str(&env, "REF-NEW")
+    );
+}
+
+#[test]
+fn cancel_before_execute_succeeds() {
+    setup_test_env!(env, BillPayments, BillPaymentsClient, client, owner);
+
+    let bill_id = client.create_bill(
+        &owner,
+        &String::from_str(&env, "Electricity"),
+        &100,
+        &1735689600,
+        &false,
+        &0,
+        &None,
+        &String::from_str(&env, "XLM"),
+        &None,
+    );
+
+    let res = client.reverse_payment(&owner, &bill_id, &100);
+    assert_eq!(res, Ok(false));
+}
+
+#[test]
+fn cancel_after_execute_fails() {
+    setup_test_env!(env, BillPayments, BillPaymentsClient, client, owner);
+
+    let bill_id = client.create_bill(
+        &owner,
+        &String::from_str(&env, "Electricity"),
+        &100,
+        &1735689600,
+        &false,
+        &0,
+        &None,
+        &String::from_str(&env, "XLM"),
+        &None,
+    );
+
+    client.pay_bill(&owner, &bill_id);
+
+    let res = client.try_reverse_payment(&owner, &bill_id, &100);
+    assert_eq!(res, Err(Ok(ReversibleOpError::InvalidState)));
+}

--- a/bill_payments/tests/gas_bench.rs
+++ b/bill_payments/tests/gas_bench.rs
@@ -911,7 +911,10 @@ fn bench_get_unpaid_bills_all_pages_100_total() {
     let mem = budget.memory_bytes_cost();
 
     assert_eq!(total_items, 100, "cursor walk must visit all 100 items");
-    assert_eq!(pages, 2, "100 bills with limit=50 must yield exactly 2 pages");
+    assert_eq!(
+        pages, 2,
+        "100 bills with limit=50 must yield exactly 2 pages"
+    );
 
     emit_bench_result(
         "get_unpaid_bills",
@@ -966,8 +969,14 @@ fn bench_get_overdue_bills_all_pages_100_total() {
     let cpu = budget.cpu_instruction_cost();
     let mem = budget.memory_bytes_cost();
 
-    assert_eq!(total_items, 100, "cursor walk must visit all 100 overdue bills");
-    assert_eq!(pages, 2, "100 overdue bills with limit=50 must yield exactly 2 pages");
+    assert_eq!(
+        total_items, 100,
+        "cursor walk must visit all 100 overdue bills"
+    );
+    assert_eq!(
+        pages, 2,
+        "100 overdue bills with limit=50 must yield exactly 2 pages"
+    );
 
     emit_bench_result(
         "get_overdue_bills",
@@ -1031,8 +1040,14 @@ fn bench_get_all_bills_for_owner_all_pages_100_total() {
     let cpu = budget.cpu_instruction_cost();
     let mem = budget.memory_bytes_cost();
 
-    assert_eq!(total_items, 100, "cursor walk must visit all 100 owner bills");
-    assert_eq!(pages, 2, "100 owner bills with limit=50 must yield exactly 2 pages");
+    assert_eq!(
+        total_items, 100,
+        "cursor walk must visit all 100 owner bills"
+    );
+    assert_eq!(
+        pages, 2,
+        "100 owner bills with limit=50 must yield exactly 2 pages"
+    );
 
     emit_bench_result(
         "get_all_bills_for_owner",
@@ -1079,9 +1094,13 @@ fn bench_get_overdue_bills_for_owner_page_50_total() {
     // Second owner — their bills must be invisible to `owner`.
     create_many_overdue(&client, &env, &other, "OtherOverdue", 20);
 
-    let (cpu, mem, page) =
-        measure(&env, || client.get_overdue_bills_for_owner(&owner, &0u32, &50u32));
-    assert_eq!(page.count, 50, "must return exactly the owner's 50 overdue bills");
+    let (cpu, mem, page) = measure(&env, || {
+        client.get_overdue_bills_for_owner(&owner, &0u32, &50u32)
+    });
+    assert_eq!(
+        page.count, 50,
+        "must return exactly the owner's 50 overdue bills"
+    );
     assert_eq!(page.items.len(), 50);
     assert_eq!(page.next_cursor, 0, "all 50 fit on one page");
     for bill in page.items.iter() {
@@ -1119,8 +1138,9 @@ fn bench_get_overdue_bills_for_owner_page_200_total() {
 
     create_many_overdue(&client, &env, &owner, "OwnOverdue200", 200);
 
-    let (cpu, mem, page) =
-        measure(&env, || client.get_overdue_bills_for_owner(&owner, &0u32, &50u32));
+    let (cpu, mem, page) = measure(&env, || {
+        client.get_overdue_bills_for_owner(&owner, &0u32, &50u32)
+    });
     assert_eq!(page.count, 50, "first page must return 50 items");
     assert_eq!(page.items.len(), 50);
     assert!(
@@ -1222,8 +1242,7 @@ fn scale_get_overdue_bills_page_cost_sublinear_50_vs_100() {
     let client_a = BillPaymentsClient::new(&env_a, &id_a);
     let owner_a = <Address as AddressTrait>::generate(&env_a);
     create_many_overdue(&client_a, &env_a, &owner_a, "OvScaleA", 50);
-    let (cpu_a, mem_a, page_a) =
-        measure(&env_a, || client_a.get_overdue_bills(&0u32, &50u32));
+    let (cpu_a, mem_a, page_a) = measure(&env_a, || client_a.get_overdue_bills(&0u32, &50u32));
     assert_eq!(page_a.count, 50);
 
     let env_b = bench_env();
@@ -1231,8 +1250,7 @@ fn scale_get_overdue_bills_page_cost_sublinear_50_vs_100() {
     let client_b = BillPaymentsClient::new(&env_b, &id_b);
     let owner_b = <Address as AddressTrait>::generate(&env_b);
     create_many_overdue(&client_b, &env_b, &owner_b, "OvScaleB", 100);
-    let (cpu_b, mem_b, page_b) =
-        measure(&env_b, || client_b.get_overdue_bills(&0u32, &50u32));
+    let (cpu_b, mem_b, page_b) = measure(&env_b, || client_b.get_overdue_bills(&0u32, &50u32));
     assert_eq!(page_b.count, 50);
 
     let cpu_slack = cpu_a / 2;

--- a/bill_payments/tests/settlement_window_guard.rs
+++ b/bill_payments/tests/settlement_window_guard.rs
@@ -100,7 +100,10 @@ fn returns_ok_when_creation_due_date_equals_current_ledger_time() {
         &None,
     );
 
-    assert!(res.is_ok(), "creation at exact ledger time boundary must succeed");
+    assert!(
+        res.is_ok(),
+        "creation at exact ledger time boundary must succeed"
+    );
 }
 
 /// Creation with `due_date < now` (outside window) returns InvalidDueDate.

--- a/bill_payments/tests/test_emergency_pause.rs
+++ b/bill_payments/tests/test_emergency_pause.rs
@@ -145,16 +145,16 @@ mod admin_grant_ttl_tests {
     use soroban_sdk::testutils::{Address as _, Ledger, LedgerInfo};
 
     /// Test that demonstrates and verifies the fix for admin grant TTL bypass vulnerability.
-    /// 
+    ///
     /// **Threat being mitigated**: T-ADMIN-01: Admin Grant TTL Bypass
-    /// 
+    ///
     /// **Attack scenario without the fix**:
     /// 1. Admin sets up pause admin with 30-day TTL
     /// 2. Time advances beyond the 30-day TTL (admin grant expires)  
     /// 3. Attacker calls `set_pause_admin` which lacks TTL validation
     /// 4. Attacker successfully changes admin despite expired grant
     /// 5. Attacker now controls pause functionality indefinitely
-    /// 
+    ///
     /// **Defense applied**:
     /// Added `require_admin_grant_valid` check to `set_pause_admin` when an admin
     /// already exists, preventing bypass of the 30-day expiration mechanism.
@@ -168,7 +168,7 @@ mod admin_grant_ttl_tests {
         let attacker = Address::generate(&env);
         let new_admin = Address::generate(&env);
 
-        // Set initial ledger time 
+        // Set initial ledger time
         env.ledger().with_mut(|li| {
             li.timestamp = 1_000_000;
         });
@@ -178,7 +178,7 @@ mod admin_grant_ttl_tests {
         // Step 1: Initial admin sets themselves as pause admin
         client.set_pause_admin(&initial_admin, &initial_admin);
 
-        // Step 2: Advance time beyond ADMIN_GRANT_TTL (30 days = 2,592,000 seconds)  
+        // Step 2: Advance time beyond ADMIN_GRANT_TTL (30 days = 2,592,000 seconds)
         let ttl_seconds = 30 * 24 * 60 * 60; // 2,592,000 seconds
         env.ledger().with_mut(|li| {
             li.timestamp = 1_000_000 + ttl_seconds + 1; // 1 second past expiration
@@ -193,25 +193,28 @@ mod admin_grant_ttl_tests {
         // Before the fix: this would succeed, bypassing TTL validation
         // After the fix: this should fail with AdminGrantExpired
         let exploit_result = client.try_set_pause_admin(&initial_admin, &new_admin);
-        
+
         // The fix ensures this attack is blocked
-        assert_eq!(exploit_result, Err(Ok(BillPaymentsError::AdminGrantExpired)));
+        assert_eq!(
+            exploit_result,
+            Err(Ok(BillPaymentsError::AdminGrantExpired))
+        );
 
         // Step 5: Verify the attacker cannot gain control
         // Even if somehow the previous call succeeded, the attacker shouldn't be able to pause
         let attacker_pause_result = client.try_pause(&new_admin);
         assert!(attacker_pause_result.is_err()); // Should fail regardless
-        
-        // Step 6: Verify legitimate admin can still regain control through proper channels  
+
+        // Step 6: Verify legitimate admin can still regain control through proper channels
         // Reset to fresh time and set up admin properly
         env.ledger().with_mut(|li| {
             li.timestamp = 2_000_000; // Fresh timestamp
         });
-        
+
         // Initial admin can still set themselves (self-assignment allowed)
         let self_reassign_result = client.try_set_pause_admin(&initial_admin, &initial_admin);
         assert!(self_reassign_result.is_ok());
-        
+
         // Now pause should work with fresh grant
         let pause_after_refresh = client.try_pause(&initial_admin);
         assert!(pause_after_refresh.is_ok());
@@ -225,13 +228,13 @@ mod admin_grant_ttl_tests {
         let client = BillPaymentsClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        
+
         env.mock_all_auths();
 
         // First-time setup should work (no existing admin means no TTL check)
         let result = client.try_set_pause_admin(&admin, &admin);
         assert!(result.is_ok());
-        
+
         // Admin should be able to pause immediately after setup
         let pause_result = client.try_pause(&admin);
         assert!(pause_result.is_ok());

--- a/data_migration/src/lib.rs
+++ b/data_migration/src/lib.rs
@@ -569,13 +569,29 @@ fn validate_encrypted_payload_size(encoded_len: usize) -> Result<(), MigrationEr
 /// Migration/import errors.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MigrationError {
-    IncompatibleVersion { found: u32, min: u32, max: u32 },
-    UnsupportedEncryptedVersion { found: u32, max: u32 },
+    IncompatibleVersion {
+        found: u32,
+        min: u32,
+        max: u32,
+    },
+    UnsupportedEncryptedVersion {
+        found: u32,
+        max: u32,
+    },
     ChecksumMismatch,
     UnknownHashAlgorithm,
-    PayloadTooLarge { size: usize, max: usize },
-    SnapshotTooLarge { size: usize, max: usize },
-    TooManyRecords { count: usize, max: usize },
+    PayloadTooLarge {
+        size: usize,
+        max: usize,
+    },
+    SnapshotTooLarge {
+        size: usize,
+        max: usize,
+    },
+    TooManyRecords {
+        count: usize,
+        max: usize,
+    },
     InvalidFormat(String),
     ValidationFailed(String),
     DeserializeError(String),
@@ -4421,7 +4437,7 @@ mod tests {
         let bytes = export_to_json(&snapshot).unwrap();
         let mut tracker = MigrationTracker::new();
         let imported = import_from_json(&bytes, &mut tracker, 1_000).unwrap();
-        
+
         assert_eq!(snapshot.payload, imported.payload);
         assert!(tracker.is_imported(&imported));
     }
@@ -4440,7 +4456,7 @@ mod tests {
         let snapshot = ExportSnapshot::new(payload, ExportFormat::Json);
         let bytes = export_to_json(&snapshot).unwrap();
         let mut tracker = MigrationTracker::new();
-        
+
         let result = import_from_json(&bytes, &mut tracker, 1_000);
         assert!(matches!(result, Err(MigrationError::ValidationFailed(_))));
     }
@@ -4457,7 +4473,7 @@ mod tests {
             let sum = spending as u64 + savings as u64 + bills as u64;
             if sum > 10000 { return Ok(()); }
             let insurance = 10000 - sum as u32;
-            
+
             let payload = SnapshotPayload::RemittanceSplit(RemittanceSplitExport {
                 owner,
                 spending_percent: spending,
@@ -4469,7 +4485,7 @@ mod tests {
             let snapshot = ExportSnapshot::new(payload, ExportFormat::Json);
             let bytes = export_to_json(&snapshot).unwrap();
             let mut tracker = MigrationTracker::new();
-            
+
             let imported = import_from_json(&bytes, &mut tracker, 1_000).unwrap();
             assert_eq!(snapshot.payload, imported.payload);
         }
@@ -4967,8 +4983,7 @@ mod tests {
             "blob".into(),
             serde_json::Value::String("x".repeat(MAX_MIGRATION_PAYLOAD_BYTES + 1)).into(),
         );
-        let snapshot =
-            ExportSnapshot::new(SnapshotPayload::Generic(entries), ExportFormat::Json);
+        let snapshot = ExportSnapshot::new(SnapshotPayload::Generic(entries), ExportFormat::Json);
         assert!(
             matches!(
                 export_to_json(&snapshot),
@@ -4981,8 +4996,7 @@ mod tests {
     /// Binary export with too many records is rejected.
     #[test]
     fn test_binary_export_rejects_too_many_records() {
-        let payload =
-            SnapshotPayload::SavingsGoals(sample_goals_export(MAX_MIGRATION_RECORDS + 1));
+        let payload = SnapshotPayload::SavingsGoals(sample_goals_export(MAX_MIGRATION_RECORDS + 1));
         let snapshot = ExportSnapshot::new(payload, ExportFormat::Binary);
         assert_eq!(
             export_to_binary(&snapshot),
@@ -5019,7 +5033,10 @@ mod tests {
             max: MAX_MIGRATION_SNAPSHOT_BYTES,
         }
         .to_string();
-        assert!(msg.contains("200000"), "Display must include actual size: {msg}");
+        assert!(
+            msg.contains("200000"),
+            "Display must include actual size: {msg}"
+        );
         assert!(
             msg.contains(&MAX_MIGRATION_SNAPSHOT_BYTES.to_string()),
             "Display must include max size: {msg}"
@@ -5033,7 +5050,10 @@ mod tests {
             max: MAX_MIGRATION_PAYLOAD_BYTES,
         }
         .to_string();
-        assert!(msg.contains("100000"), "Display must include actual size: {msg}");
+        assert!(
+            msg.contains("100000"),
+            "Display must include actual size: {msg}"
+        );
         assert!(
             msg.contains(&MAX_MIGRATION_PAYLOAD_BYTES.to_string()),
             "Display must include max size: {msg}"
@@ -5047,7 +5067,10 @@ mod tests {
             max: MAX_MIGRATION_RECORDS,
         }
         .to_string();
-        assert!(msg.contains("2048"), "Display must include actual count: {msg}");
+        assert!(
+            msg.contains("2048"),
+            "Display must include actual count: {msg}"
+        );
         assert!(
             msg.contains(&MAX_MIGRATION_RECORDS.to_string()),
             "Display must include max count: {msg}"

--- a/emergency_killswitch/src/lib.rs
+++ b/emergency_killswitch/src/lib.rs
@@ -117,9 +117,7 @@ impl EmergencyKillswitch {
             .instance()
             .get(&DataKey::KillSwitchEpoch)
             .unwrap_or(0);
-        let new_epoch = old_epoch
-            .checked_add(1)
-            .ok_or(Error::InvalidAdmin)?; // Overflow guard — saturate on wrap
+        let new_epoch = old_epoch.checked_add(1).ok_or(Error::InvalidAdmin)?; // Overflow guard — saturate on wrap
         env.storage()
             .instance()
             .set(&DataKey::KillSwitchEpoch, &new_epoch);

--- a/family_wallet/src/lib.rs
+++ b/family_wallet/src/lib.rs
@@ -839,13 +839,7 @@ impl FamilyWallet {
             },
         );
 
-        Self::append_access_audit(
-            &env,
-            symbol_short!("ms_conf"),
-            &caller,
-            None,
-            true,
-        );
+        Self::append_access_audit(&env, symbol_short!("ms_conf"), &caller, None, true);
 
         Ok(true)
     }
@@ -1456,8 +1450,7 @@ impl FamilyWallet {
 
         // Defence-in-depth: block removal while multisig proposals are in-flight
         // to prevent orphaned signatures and stale quorum calculations.
-        Self::require_no_pending_operations(&env)
-            .unwrap_or_else(|e| panic_with_error!(&env, e));
+        Self::require_no_pending_operations(&env).unwrap_or_else(|e| panic_with_error!(&env, e));
 
         let owner: Address = env
             .storage()
@@ -1780,13 +1773,7 @@ impl FamilyWallet {
             (archived_count, caller.clone()),
         );
 
-        Self::append_access_audit(
-            &env,
-            symbol_short!("arch_tx"),
-            &caller,
-            None,
-            true,
-        );
+        Self::append_access_audit(&env, symbol_short!("arch_tx"), &caller, None, true);
 
         archived_count
     }
@@ -1891,13 +1878,7 @@ impl FamilyWallet {
             (symbol_short!("archive"), ArchiveEvent::ExpiredCleaned),
             (removed_count, caller.clone()),
         );
-        Self::append_access_audit(
-            &env,
-            symbol_short!("cln_exp"),
-            &caller,
-            None,
-            true,
-        );
+        Self::append_access_audit(&env, symbol_short!("cln_exp"), &caller, None, true);
         removed_count
     }
 
@@ -2027,13 +2008,7 @@ impl FamilyWallet {
                 .set(&symbol_short!("SPND_TRK"), &trackers);
         }
 
-        Self::append_access_audit(
-            &env,
-            symbol_short!("prec_lim"),
-            &caller,
-            Some(member),
-            true,
-        );
+        Self::append_access_audit(&env, symbol_short!("prec_lim"), &caller, Some(member), true);
 
         Ok(true)
     }

--- a/family_wallet/src/test.rs
+++ b/family_wallet/src/test.rs
@@ -7995,12 +7995,7 @@ fn setup_wallet_with_pending_proposal() -> (Env, FamilyWalletClient<'static>, Ad
 
     // Create a pending proposal — this populates PEND_TXS
     let recipient = Address::generate(&env);
-    client.propose_emergency_transfer(
-        &owner,
-        &token_contract.address(),
-        &recipient,
-        &3000_0000000,
-    );
+    client.propose_emergency_transfer(&owner, &token_contract.address(), &recipient, &3000_0000000);
 
     (env, client, owner)
 }
@@ -8015,9 +8010,7 @@ fn test_remove_member_blocked_by_pending_operations() {
     let result = client.try_remove_family_member(&owner, &member1);
     assert_eq!(
         result,
-        Err(Ok(soroban_sdk::Error::from(
-            Error::PendingOperationsExist
-        ))),
+        Err(Ok(soroban_sdk::Error::from(Error::PendingOperationsExist))),
         "remove_family_member must reject when pending proposals exist"
     );
 }

--- a/family_wallet/tests/operator_role_lifecycle.rs
+++ b/family_wallet/tests/operator_role_lifecycle.rs
@@ -254,11 +254,5 @@ fn re_register_revoked_operator_restores_registered_state() {
     assert_eq!(client.get_role_expiry_public(&admin), Some(renewed_to));
 
     // Privileged action succeeds again.
-    assert!(client.configure_emergency(
-        &admin,
-        &1000_0000000,
-        &3600,
-        &0,
-        &10000_0000000
-    ));
+    assert!(client.configure_emergency(&admin, &1000_0000000, &3600, &0, &10000_0000000));
 }

--- a/insurance/src/events_schema_test.rs
+++ b/insurance/src/events_schema_test.rs
@@ -232,8 +232,7 @@ fn premium_schedule_executed_event_payload_schema() {
     };
 
     let v: Val = evt.clone().into_val(&env);
-    let decoded =
-        PremiumScheduleExecutedEvent::try_from_val(&env, &v).expect("round-trip failed");
+    let decoded = PremiumScheduleExecutedEvent::try_from_val(&env, &v).expect("round-trip failed");
 
     assert_eq!(decoded.schedule_id, 10);
     assert_eq!(decoded.policy_id, 2);
@@ -277,11 +276,7 @@ fn setup_contract(env: &Env) -> (InsuranceClient<'_>, Address) {
 }
 
 /// Helper: create a minimal Health policy.
-fn create_health_policy(
-    env: &Env,
-    client: &InsuranceClient<'_>,
-    policy_owner: &Address,
-) -> u32 {
+fn create_health_policy(env: &Env, client: &InsuranceClient<'_>, policy_owner: &Address) -> u32 {
     client.create_policy(
         policy_owner,
         &SorobanString::from_str(env, "Test Policy"),
@@ -317,10 +312,7 @@ fn create_policy_emits_created_event() {
             let payload: PolicyCreatedEvent =
                 PolicyCreatedEvent::try_from_val(&env, &data).expect("payload decode failed");
             assert_eq!(payload.policy_id, pid);
-            assert_eq!(
-                payload.name,
-                SorobanString::from_str(&env, "Test Policy")
-            );
+            assert_eq!(payload.name, SorobanString::from_str(&env, "Test Policy"));
             assert_eq!(payload.coverage_type, CoverageType::Health);
             assert_eq!(payload.monthly_premium, 5_000_000);
             assert_eq!(payload.coverage_amount, 50_000_000);
@@ -466,18 +458,14 @@ fn set_external_ref_emits_external_ref_updated_event() {
             InsuranceEvent::try_from_val(&env, &topics.get(1).unwrap())
         {
             let payload: ExternalRefUpdatedEvent =
-                ExternalRefUpdatedEvent::try_from_val(&env, &data)
-                    .expect("payload decode failed");
+                ExternalRefUpdatedEvent::try_from_val(&env, &data).expect("payload decode failed");
             assert_eq!(payload.policy_id, pid);
             assert_eq!(payload.caller, contract_owner);
             assert_eq!(payload.ext_ref, Some(new_ref.clone()));
             found = true;
         }
     }
-    assert!(
-        found,
-        "InsuranceEvent::ExternalRefUpdated was not emitted"
-    );
+    assert!(found, "InsuranceEvent::ExternalRefUpdated was not emitted");
 }
 
 /// Clearing (`None`) also emits `ExternalRefUpdated` with `ext_ref: None`.
@@ -515,8 +503,7 @@ fn set_external_ref_clear_emits_event_with_none() {
             InsuranceEvent::try_from_val(&env, &topics.get(1).unwrap())
         {
             let payload: ExternalRefUpdatedEvent =
-                ExternalRefUpdatedEvent::try_from_val(&env, &data)
-                    .expect("payload decode failed");
+                ExternalRefUpdatedEvent::try_from_val(&env, &data).expect("payload decode failed");
             if payload.ext_ref.is_none() {
                 assert_eq!(payload.policy_id, pid);
                 assert_eq!(payload.caller, contract_owner);
@@ -660,7 +647,10 @@ fn deactivate_policy_idempotent_emits_no_second_event() {
 
     // Count Deactivated events after the first call.
     let count_after_first = count_deactivated_events(&env, pid);
-    assert_eq!(count_after_first, 1, "expected exactly 1 Deactivated event after first deactivation");
+    assert_eq!(
+        count_after_first, 1,
+        "expected exactly 1 Deactivated event after first deactivation"
+    );
 
     // Second deactivation (idempotent) — must not add another event.
     assert!(client.deactivate_policy(&policy_owner, &pid));

--- a/insurance/src/lib.rs
+++ b/insurance/src/lib.rs
@@ -747,7 +747,10 @@ impl Insurance {
 
         let now = env.ledger().timestamp();
         env.events().publish(
-            (symbol_short!("insurance"), InsuranceEvent::ExternalRefUpdated),
+            (
+                symbol_short!("insurance"),
+                InsuranceEvent::ExternalRefUpdated,
+            ),
             ExternalRefUpdatedEvent {
                 policy_id,
                 caller,
@@ -1582,7 +1585,10 @@ impl Insurance {
         Self::extend_persistent_ttl(&env, &DataKey::Schedule(schedule_id));
 
         env.events().publish(
-            (symbol_short!("insurance"), InsuranceEvent::ScheduleCancelled),
+            (
+                symbol_short!("insurance"),
+                InsuranceEvent::ScheduleCancelled,
+            ),
             (schedule_id,),
         );
 
@@ -1744,4 +1750,3 @@ mod events_schema_test;
 mod next_payment_scheduling_tests;
 #[cfg(test)]
 mod test;
-

--- a/orchestrator/src/lib.rs
+++ b/orchestrator/src/lib.rs
@@ -709,10 +709,7 @@ impl Orchestrator {
     ///
     /// This is a read-only view function that does not require authorization.
     pub fn get_fee_schedule(env: Env) -> Option<(u32, u32, u32, u32)> {
-        let rs_addr: Address = env
-            .storage()
-            .instance()
-            .get(&symbol_short!("RS_ADDR"))?;
+        let rs_addr: Address = env.storage().instance().get(&symbol_short!("RS_ADDR"))?;
 
         let rs_client = interface::RemittanceSplitClient::new(&env, &rs_addr);
         let split = rs_client.get_split();
@@ -721,12 +718,7 @@ impl Orchestrator {
             return None;
         }
 
-        Some((
-            split.get(0)?,
-            split.get(1)?,
-            split.get(2)?,
-            split.get(3)?,
-        ))
+        Some((split.get(0)?, split.get(1)?, split.get(2)?, split.get(3)?))
     }
 
     /// Claim accrued rewards and transfer them from the reward-token contract

--- a/orchestrator/src/test.rs
+++ b/orchestrator/src/test.rs
@@ -185,7 +185,7 @@ fn wasm_size_budgets() -> &'static [(&'static str, usize)] {
         ("remittance_split.wasm", 110_000),
         ("savings_goals.wasm", 112_000),
         ("bill_payments.wasm", 135_000),
-        ("insurance.wasm", 58_000),  // Increased from 57_000 to 58_000 to accommodate small test coverage additions
+        ("insurance.wasm", 58_000), // Increased from 57_000 to 58_000 to accommodate small test coverage additions
         ("family_wallet.wasm", 130_000),
     ]
 }
@@ -2600,7 +2600,10 @@ fn test_get_fee_schedule_returns_none_when_invalid_split() {
 
     // Call the view function - should return None for invalid split
     let result = client.get_fee_schedule();
-    assert!(result.is_none(), "fee schedule should be None for invalid split");
+    assert!(
+        result.is_none(),
+        "fee schedule should be None for invalid split"
+    );
 }
 
 #[test]
@@ -2612,5 +2615,8 @@ fn test_get_fee_schedule_returns_none_when_not_initialized() {
 
     // Don't initialize - should return None
     let result = client.get_fee_schedule();
-    assert!(result.is_none(), "fee schedule should be None when not initialized");
+    assert!(
+        result.is_none(),
+        "fee schedule should be None when not initialized"
+    );
 }

--- a/orchestrator/tests/cross_contract_epoch_guard.rs
+++ b/orchestrator/tests/cross_contract_epoch_guard.rs
@@ -387,12 +387,7 @@ fn cross_contract_non_matching_epochs_all_produce_epoch_mismatch() {
     // mid-range (50, 1000), and the maximum u64 value.
     for bad_epoch in [0u64, 1, 2, 3, 4, 6, 50, 1000, u64::MAX] {
         let result = client.try_execute_remittance_flow_signed(
-            &executor,
-            &amount,
-            &0u64,
-            &deadline,
-            &hash,
-            &bad_epoch,
+            &executor, &amount, &0u64, &deadline, &hash, &bad_epoch,
         );
         assert_eq!(
             result,
@@ -446,12 +441,7 @@ fn cross_contract_bump_makes_old_epoch_stale_and_new_epoch_valid() {
 
     // New epoch accepted.
     let fresh_result = client.try_execute_remittance_flow_signed(
-        &executor,
-        &amount,
-        &nonce,
-        &deadline,
-        &hash_new,
-        &new_epoch,
+        &executor, &amount, &nonce, &deadline, &hash_new, &new_epoch,
     );
     assert_eq!(
         fresh_result,

--- a/orchestrator/tests/investigation_epoch_guard.rs
+++ b/orchestrator/tests/investigation_epoch_guard.rs
@@ -64,10 +64,10 @@ fn boot(env: &Env) -> (Address, OrchestratorClient<'_>) {
     let orch_id = env.register_contract(None, Orchestrator);
     let client = OrchestratorClient::new(env, &orch_id);
 
-    let fw  = env.register_contract(None, MockDownstream);
-    let rs  = env.register_contract(None, MockDownstream);
-    let sg  = env.register_contract(None, MockDownstream);
-    let bp  = env.register_contract(None, MockDownstream);
+    let fw = env.register_contract(None, MockDownstream);
+    let rs = env.register_contract(None, MockDownstream);
+    let sg = env.register_contract(None, MockDownstream);
+    let bp = env.register_contract(None, MockDownstream);
     let ins = env.register_contract(None, MockDownstream);
 
     client.init(&owner, &fw, &rs, &sg, &bp, &ins);
@@ -108,15 +108,14 @@ fn active_epoch_zero_token_accepted_on_fresh_contract() {
     let current = client.get_actor_epoch_public();
     assert_eq!(current, 0, "epoch must be 0 after init");
 
-    let amount   = 1_000i128;
-    let nonce    = 0u64;
+    let amount = 1_000i128;
+    let nonce = 0u64;
     let deadline = env.ledger().timestamp() + 3_600;
-    let hash     = request_hash(nonce, amount, deadline);
+    let hash = request_hash(nonce, amount, deadline);
     let executor = Address::generate(&env);
 
-    let result = client.try_execute_remittance_flow_signed(
-        &executor, &amount, &nonce, &deadline, &hash, &current,
-    );
+    let result = client
+        .try_execute_remittance_flow_signed(&executor, &amount, &nonce, &deadline, &hash, &current);
     assert_eq!(
         result,
         Ok(Ok(true)),
@@ -137,15 +136,14 @@ fn active_epoch_token_accepted_after_single_bump() {
     let current = client.get_actor_epoch_public();
     assert_eq!(current, 1);
 
-    let amount   = 500i128;
-    let nonce    = 0u64;
+    let amount = 500i128;
+    let nonce = 0u64;
     let deadline = env.ledger().timestamp() + 3_600;
-    let hash     = request_hash(nonce, amount, deadline);
+    let hash = request_hash(nonce, amount, deadline);
     let executor = Address::generate(&env);
 
-    let result = client.try_execute_remittance_flow_signed(
-        &executor, &amount, &nonce, &deadline, &hash, &current,
-    );
+    let result = client
+        .try_execute_remittance_flow_signed(&executor, &amount, &nonce, &deadline, &hash, &current);
     assert_eq!(
         result,
         Ok(Ok(true)),
@@ -174,7 +172,7 @@ fn cleared_old_epoch_token_rejected_after_single_bump() {
     assert_eq!(new_epoch, 1);
 
     let deadline = env.ledger().timestamp() + 3_600;
-    let hash     = request_hash(0, 1_000, deadline);
+    let hash = request_hash(0, 1_000, deadline);
     let executor = Address::generate(&env);
 
     let result = client.try_execute_remittance_flow_signed(
@@ -203,11 +201,16 @@ fn cleared_two_bumps_ago_epoch_token_rejected() {
     assert_eq!(current, 2);
 
     let deadline = env.ledger().timestamp() + 3_600;
-    let hash     = request_hash(0, 1_000, deadline);
+    let hash = request_hash(0, 1_000, deadline);
     let executor = Address::generate(&env);
 
     let result = client.try_execute_remittance_flow_signed(
-        &executor, &1_000i128, &0u64, &deadline, &hash, &stale_epoch,
+        &executor,
+        &1_000i128,
+        &0u64,
+        &deadline,
+        &hash,
+        &stale_epoch,
     );
     assert_eq!(
         result,
@@ -233,11 +236,16 @@ fn cleared_intermediate_epoch_token_rejected_after_second_bump() {
     assert_eq!(intermediate, 1);
 
     let deadline = env.ledger().timestamp() + 3_600;
-    let hash     = request_hash(0, 1_000, deadline);
+    let hash = request_hash(0, 1_000, deadline);
     let executor = Address::generate(&env);
 
     let result = client.try_execute_remittance_flow_signed(
-        &executor, &1_000i128, &0u64, &deadline, &hash, &intermediate,
+        &executor,
+        &1_000i128,
+        &0u64,
+        &deadline,
+        &hash,
+        &intermediate,
     );
     assert_eq!(
         result,
@@ -266,8 +274,8 @@ fn boundary_only_latest_epoch_accepted_after_many_bumps() {
     let current = client.get_actor_epoch_public();
     assert_eq!(current, N);
 
-    let amount   = 750i128;
-    let nonce    = 0u64;
+    let amount = 750i128;
+    let nonce = 0u64;
     let deadline = env.ledger().timestamp() + 3_600;
     let executor = Address::generate(&env);
 
@@ -281,15 +289,15 @@ fn boundary_only_latest_epoch_accepted_after_many_bumps() {
             result,
             Err(Ok(OrchestratorError::EpochMismatch)),
             "epoch {} must be rejected; current is {}",
-            stale, N
+            stale,
+            N
         );
     }
 
     // Current epoch must be accepted.
     let hash = request_hash(nonce, amount, deadline);
-    let result = client.try_execute_remittance_flow_signed(
-        &executor, &amount, &nonce, &deadline, &hash, &current,
-    );
+    let result = client
+        .try_execute_remittance_flow_signed(&executor, &amount, &nonce, &deadline, &hash, &current);
     assert_eq!(
         result,
         Ok(Ok(true)),

--- a/remittance_split/src/lib.rs
+++ b/remittance_split/src/lib.rs
@@ -1,9 +1,9 @@
 #![no_std]
 #![allow(clippy::too_many_arguments)]
 #![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
-mod params;
 #[cfg(test)]
 mod events_schema_test;
+mod params;
 #[cfg(test)]
 mod test;
 #[cfg(test)]
@@ -749,8 +749,8 @@ impl RemittanceSplit {
             .instance()
             .get(&symbol_short!("CONFIG"))
             .ok_or(RemittanceSplitError::NotInitialized)?;
-        let treasury = Self::get_treasury(&env)
-            .ok_or(RemittanceSplitError::TreasuryNotConfigured)?;
+        let treasury =
+            Self::get_treasury(&env).ok_or(RemittanceSplitError::TreasuryNotConfigured)?;
 
         Ok(TokenClient::new(&env, &config.usdc_contract).balance(&treasury))
     }
@@ -1067,7 +1067,10 @@ impl RemittanceSplit {
     /// 2. Each `fee_bps` ≤ [`params::MAX_FEE_BPS`].
     /// 3. Each `max_amount` ≥ `min_amount` and `min_amount` ≥ [`params::MIN_CORRIDOR_AMOUNT`].
     /// 4. No duplicate corridor IDs.
-    fn validate_corridors(env: &Env, corridors: &Vec<Corridor>) -> Result<(), RemittanceSplitError> {
+    fn validate_corridors(
+        env: &Env,
+        corridors: &Vec<Corridor>,
+    ) -> Result<(), RemittanceSplitError> {
         if corridors.len() > params::MAX_CORRIDORS {
             return Err(RemittanceSplitError::CorridorCountExceeded);
         }

--- a/remittance_split/src/test.rs
+++ b/remittance_split/src/test.rs
@@ -1124,11 +1124,7 @@ fn sample_corridor(env: &Env, id: u32) -> Corridor {
 }
 
 fn sample_corridors(env: &Env) -> Vec<Corridor> {
-    vec![
-        env,
-        sample_corridor(env, 1),
-        sample_corridor(env, 2),
-    ]
+    vec![env, sample_corridor(env, 1), sample_corridor(env, 2)]
 }
 
 #[test]

--- a/remitwise-common/src/lib.rs
+++ b/remitwise-common/src/lib.rs
@@ -1,13 +1,14 @@
 #![no_std]
 #![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
 
-use soroban_sdk::{contracterror, contracttype, symbol_short, Address, Bytes, BytesN, Env, IntoVal, Map, Symbol};
+use soroban_sdk::{
+    contracterror, contracttype, symbol_short, Address, Bytes, BytesN, Env, IntoVal, Map, Symbol,
+};
 pub mod tokens;
 pub use tokens::{
     SupportedToken, BASE_UNITS_PER_EURC, BASE_UNITS_PER_USDC, DEFAULT_CURRENCY, EURC_DECIMALS,
     MAX_CURRENCY_LEN, STROOPS_PER_XLM, USDC_DECIMALS, XLM_DECIMALS,
 };
-
 
 #[soroban_sdk::contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -303,8 +304,8 @@ pub fn guard_bytes_len(bytes: &Bytes) -> Result<(), BytesReturnError> {
 
 /// Guards against executing dispute-related operations in an outdated epoch.
 ///
-/// This is a defence-in-depth fix. If an attacker could proceed with dispute-related 
-/// operations in an outdated epoch, they could bypass lifecycle expiration rules, 
+/// This is a defence-in-depth fix. If an attacker could proceed with dispute-related
+/// operations in an outdated epoch, they could bypass lifecycle expiration rules,
 /// allowing them to manipulate dispute resolutions or lock funds unexpectedly.
 ///
 /// # Arguments
@@ -322,7 +323,11 @@ pub enum DisputeError {
 
 /// * `Err(DisputeError::OutdatedEpoch)` if the epoch is outdated
 pub fn require_no_pending_dispute_epoch(env: &Env, ep: u64) -> Result<(), DisputeError> {
-    let current_epoch: u64 = env.storage().instance().get(&symbol_short!("DISP_EP")).unwrap_or(0);
+    let current_epoch: u64 = env
+        .storage()
+        .instance()
+        .get(&symbol_short!("DISP_EP"))
+        .unwrap_or(0);
     if ep < current_epoch {
         return Err(DisputeError::OutdatedEpoch);
     }
@@ -354,8 +359,15 @@ pub const STORAGE_CROSS_CONTRACT_EPOCH: Symbol = symbol_short!("XC_EPOCH");
 /// # Returns
 /// * `Ok(())` if the epoch matches the current cross-contract epoch exactly
 /// * `Err(CrossContractEpochError::EpochMismatch)` if the epoch is outdated
-pub fn require_matching_cross_contract_epoch(env: &Env, ep: u64) -> Result<(), CrossContractEpochError> {
-    let current_epoch: u64 = env.storage().instance().get(&STORAGE_CROSS_CONTRACT_EPOCH).unwrap_or(0);
+pub fn require_matching_cross_contract_epoch(
+    env: &Env,
+    ep: u64,
+) -> Result<(), CrossContractEpochError> {
+    let current_epoch: u64 = env
+        .storage()
+        .instance()
+        .get(&STORAGE_CROSS_CONTRACT_EPOCH)
+        .unwrap_or(0);
     if ep != current_epoch {
         return Err(CrossContractEpochError::EpochMismatch);
     }
@@ -489,7 +501,7 @@ pub enum SettlementWindowError {
     WindowExpired = 1,
 }
 
-/// Guards against settling an invoice excessively late, which could lead to bounds-checking 
+/// Guards against settling an invoice excessively late, which could lead to bounds-checking
 /// attacks on catch-up loops (DoS) or economic exposure from stale states.
 ///
 /// # Arguments
@@ -823,11 +835,15 @@ mod pagination_limit_tests {
     fn is_idempotent() {
         // Applying clamp_limit twice should give same result
         let test_values = [0, 1, 25, MAX_PAGE_LIMIT, MAX_PAGE_LIMIT + 100, u32::MAX];
-        
+
         for value in test_values {
             let clamped_once = clamp_limit(value);
             let clamped_twice = clamp_limit(clamped_once);
-            assert_eq!(clamped_once, clamped_twice, "clamp_limit is not idempotent for {}", value);
+            assert_eq!(
+                clamped_once, clamped_twice,
+                "clamp_limit is not idempotent for {}",
+                value
+            );
         }
     }
 }
@@ -937,7 +953,6 @@ impl ToI128Checked for i32 {
     }
 }
 
-
 // ---------------------------------------------------------------------------
 // Symbol canonicalisation — trim, casefold, charset validation
 // ---------------------------------------------------------------------------
@@ -1042,9 +1057,7 @@ pub fn canonicalise_symbol_checked(
             byte
         };
         if !is_symbol_char(folded) {
-            return Err(SymbolValidationError::InvalidChar {
-                position: i as u32,
-            });
+            return Err(SymbolValidationError::InvalidChar { position: i as u32 });
         }
         canonical[i] = folded;
     }
@@ -1176,8 +1189,6 @@ pub enum RateError {
     Overflow,
 }
 
-
-
 /// A whole percentage value (1% = 100 basis points).
 ///
 /// `Percent` wraps a `u32` representing whole percentage units. Safe conversions
@@ -1255,7 +1266,7 @@ impl TryFrom<Percent> for Rate {
 /// assert_eq!(rate.apply_to(1000), Ok(50));
 /// assert_eq!(rate.apply_to(i128::MAX), Err(RateError::Overflow));
 /// ```
-/// 
+///
 #[contracttype]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub struct Rate(u32);
@@ -1290,7 +1301,8 @@ impl Rate {
     ///
     /// This is the safe entry point for untrusted inputs that carry an explicit
     /// unit field. Only supported units are accepted.
-    #[inline(always)]    pub fn try_from_input(value: u32, unit: u32) -> Result<Self, RateUnitError> {
+    #[inline(always)]
+    pub fn try_from_input(value: u32, unit: u32) -> Result<Self, RateUnitError> {
         require_supported_rate_unit(unit)?;
         Ok(Self::from_bps(value))
     }
@@ -1306,8 +1318,6 @@ impl Rate {
     pub fn to_bps(self) -> u32 {
         self.0
     }
-
-
 
     /// Convert this rate back to a whole percentage integer value, truncating fractional basis points.
     ///
@@ -1341,8 +1351,6 @@ impl Rate {
             .and_then(|product| product.checked_div(BASIS_POINTS as i128))
             .ok_or(RateError::Overflow)
     }
-
-
 }
 
 impl ToI128Checked for Rate {
@@ -1401,12 +1409,8 @@ impl Timestamp {
     #[inline(always)]
     pub fn to_period_key(timestamp: u64, period: PeriodKind) -> u64 {
         match period {
-            PeriodKind::Day => {
-                timestamp / SECONDS_PER_DAY
-            }
-            PeriodKind::Week => {
-                timestamp / SECONDS_PER_WEEK
-            }
+            PeriodKind::Day => timestamp / SECONDS_PER_DAY,
+            PeriodKind::Week => timestamp / SECONDS_PER_WEEK,
             PeriodKind::Month => {
                 // Convert timestamp (seconds since epoch) to YYYYMM integer.
                 // Uses proleptic Gregorian calendar, UTC; ignores leap seconds.
@@ -1415,7 +1419,7 @@ impl Timestamp {
                 // 1970-01-01 is day 0.
                 let z = days as i64 + 719468;
                 let era = (if z >= 0 { z } else { z - 146096 }) / 146097;
-                let doe = z - era * 146097;                                    // [0, 146096]
+                let doe = z - era * 146097; // [0, 146096]
                 let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365; // [0, 399]
                 let y = yoe + era * 400;
                 let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
@@ -1427,7 +1431,6 @@ impl Timestamp {
         }
     }
 }
-
 
 /// Validates that a requested period is logically ordered.
 ///
@@ -1682,8 +1685,6 @@ pub enum TagError {
     InvalidChar { position: u32 },
 }
 
-
-
 /// Signature verification failure.
 #[contracterror]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -1755,9 +1756,7 @@ pub fn require_registered_verifier(env: &Env, public_key: &[u8]) -> Result<(), S
         .unwrap_or_else(|| Map::new(env));
 
     match registered_verifiers.get(key) {
-        Some(registered_network_id) if registered_network_id == env.ledger().network_id() => {
-            Ok(())
-        }
+        Some(registered_network_id) if registered_network_id == env.ledger().network_id() => Ok(()),
         Some(_) => Err(SignatureError::VerifierNetworkMismatch),
         None => Err(SignatureError::UnregisteredVerifier),
     }
@@ -1805,7 +1804,8 @@ pub fn verify_signature(
         BytesN::from_array(env, &arr)
     };
 
-    env.crypto().ed25519_verify(&pk_bytes, &prefixed_message, &sig_bytes);
+    env.crypto()
+        .ed25519_verify(&pk_bytes, &prefixed_message, &sig_bytes);
     let pk_arr: [u8; 32] = public_key
         .try_into()
         .map_err(|_| SignatureError::InvalidPublicKeyLength)?;
@@ -1864,7 +1864,6 @@ pub fn verify_slash_signature(
     }
     Ok(())
 }
-
 
 /// Validates and canonicalizes a batch of tags without panicking.
 ///
@@ -2125,7 +2124,6 @@ fn symbol_matches_known_case_insensitive(env: &Env, symbol: &Symbol, known: &str
     }
     false
 }
-
 
 #[cfg(test)]
 mod tests;
@@ -2578,10 +2576,7 @@ pub fn require_no_investigation_epoch(env: &Env) -> Result<(), InvestigationEpoc
 /// responsibility to gate it with admin auth (e.g.
 /// `admin.require_auth()` in the calling contract).
 pub fn start_investigation_epoch(env: &Env, duration_secs: u64) {
-    let end_time = env
-        .ledger()
-        .timestamp()
-        .saturating_add(duration_secs);
+    let end_time = env.ledger().timestamp().saturating_add(duration_secs);
     env.storage()
         .instance()
         .set(&STORAGE_INVESTIGATION_EPOCH, &end_time);
@@ -2596,7 +2591,9 @@ pub fn start_investigation_epoch(env: &Env, duration_secs: u64) {
 /// This function does not enforce authentication — it is the caller's
 /// responsibility to gate it with admin auth.
 pub fn clear_investigation_epoch(env: &Env) {
-    env.storage().instance().remove(&STORAGE_INVESTIGATION_EPOCH);
+    env.storage()
+        .instance()
+        .remove(&STORAGE_INVESTIGATION_EPOCH);
 }
 
 // ---------------------------------------------------------------------------
@@ -2675,9 +2672,7 @@ pub fn require_no_active_kill_switch(env: &Env) -> Result<(), KillSwitchError> {
 /// responsibility to gate it with admin auth (e.g.
 /// `admin.require_auth()` in the calling contract).
 pub fn activate_kill_switch(env: &Env) {
-    env.storage()
-        .instance()
-        .set(&STORAGE_KILL_SWITCH, &true);
+    env.storage().instance().set(&STORAGE_KILL_SWITCH, &true);
 }
 
 /// Deactivate the kill switch, allowing write operations to proceed.
@@ -3019,7 +3014,7 @@ mod encoding_stability_tests {
 
 #[cfg(test)]
 mod stable_currency_tests {
-    use super::{require_supported_currency, require_stable_currency, StableCurrencyError};
+    use super::{require_stable_currency, require_supported_currency, StableCurrencyError};
     use soroban_sdk::{Env, Symbol};
 
     // --- Whitelisted paths: currency accepted by stable currency allowlist ---
@@ -3338,12 +3333,12 @@ mod stable_currency_tests {
         // outside Symbol's `[a-zA-Z0-9_]` charset — `Symbol::new`
         // would panic on them and mask the boundary we want to test.)
         for variant in [
-            "USDX",     // swap last byte of USDC
-            "USCA",     // swap last + a different letter
-            "UCDC",     // swap second byte of USDC
-            "USDCC",    // duplicate last byte
-            "USDC0",    // digit suffix
-            "0USDC",    // digit prefix
+            "USDX",  // swap last byte of USDC
+            "USCA",  // swap last + a different letter
+            "UCDC",  // swap second byte of USDC
+            "USDCC", // duplicate last byte
+            "USDC0", // digit suffix
+            "0USDC", // digit prefix
         ] {
             let sym = Symbol::new(&env, variant);
             assert_eq!(

--- a/remitwise-common/src/tests.rs
+++ b/remitwise-common/src/tests.rs
@@ -827,7 +827,7 @@ fn test_canonicalise_symbols_invalid_element_short_circuits() {
     let env = Env::default();
     let mut inputs: soroban_sdk::Vec<soroban_sdk::String> = soroban_sdk::Vec::new(&env);
     inputs.push_back(soroban_sdk::String::from_str(&env, "valid_one"));
-    inputs.push_back(soroban_sdk::String::from_str(&env, "bad-char"));  // hyphen at pos 3
+    inputs.push_back(soroban_sdk::String::from_str(&env, "bad-char")); // hyphen at pos 3
     inputs.push_back(soroban_sdk::String::from_str(&env, "valid_two"));
 
     assert_eq!(
@@ -842,7 +842,10 @@ fn test_canonicalise_symbols_too_long_element() {
     let env = Env::default();
     let mut inputs: soroban_sdk::Vec<soroban_sdk::String> = soroban_sdk::Vec::new(&env);
     inputs.push_back(soroban_sdk::String::from_str(&env, "ok"));
-    inputs.push_back(soroban_sdk::String::from_str(&env, "abcdefghijklmnopqrstuvwxyzabcdefg")); // 33 chars
+    inputs.push_back(soroban_sdk::String::from_str(
+        &env,
+        "abcdefghijklmnopqrstuvwxyzabcdefg",
+    )); // 33 chars
 
     assert_eq!(
         canonicalise_symbols(&env, &inputs),
@@ -985,7 +988,10 @@ fn test_period_key_month_bucket_epoch_and_dec_2023() {
     assert_eq!(Timestamp::to_period_key(ts, PeriodKind::Month), 202312);
     // Jan 1, 2024 00:00:00 UTC
     let jan1_2024 = 1704067200;
-    assert_eq!(Timestamp::to_period_key(jan1_2024, PeriodKind::Month), 202401);
+    assert_eq!(
+        Timestamp::to_period_key(jan1_2024, PeriodKind::Month),
+        202401
+    );
 }
 
 #[test]
@@ -993,10 +999,19 @@ fn test_period_key_exact_rollover_edges() {
     // Midnight UTC at 2021-02-28 to Mar 1st transition, and leap-year
     let feb_28_2020 = 1582848000; // 2020-02-28 00:00:00 UTC
     let feb_29_2020 = 1582934400; // 2020-02-29 00:00:00 UTC (leap)
-    let mar_1_2020  = 1583020800; // 2020-03-01 00:00:00 UTC
-    assert_eq!(Timestamp::to_period_key(feb_28_2020, PeriodKind::Month), 202002);
-    assert_eq!(Timestamp::to_period_key(feb_29_2020, PeriodKind::Month), 202002);
-    assert_eq!(Timestamp::to_period_key(mar_1_2020, PeriodKind::Month), 202003);
+    let mar_1_2020 = 1583020800; // 2020-03-01 00:00:00 UTC
+    assert_eq!(
+        Timestamp::to_period_key(feb_28_2020, PeriodKind::Month),
+        202002
+    );
+    assert_eq!(
+        Timestamp::to_period_key(feb_29_2020, PeriodKind::Month),
+        202002
+    );
+    assert_eq!(
+        Timestamp::to_period_key(mar_1_2020, PeriodKind::Month),
+        202003
+    );
 }
 
 #[test]
@@ -1406,7 +1421,10 @@ fn test_sign_for_domain_a_replay_against_domain_b_fails() {
     prefixed.extend_from_slice(message);
     let signature = sk.sign(&prefixed).to_bytes();
 
-    assert_eq!(verify_signature(&env, domain_a, message, &signature, &pk), Ok(()));
+    assert_eq!(
+        verify_signature(&env, domain_a, message, &signature, &pk),
+        Ok(())
+    );
     let _ = verify_signature(&env, domain_b, message, &signature, &pk);
 }
 
@@ -1490,22 +1508,24 @@ fn test_verify_slash_signature_invalid() {
 #[test]
 fn test_require_matching_cross_contract_epoch() {
     let env = Env::default();
-    
+
     // Default is 0, so epoch 0 matches
     assert_eq!(require_matching_cross_contract_epoch(&env, 0), Ok(()));
-    
+
     // Set epoch to 5
-    env.storage().instance().set(&STORAGE_CROSS_CONTRACT_EPOCH, &5u64);
-    
+    env.storage()
+        .instance()
+        .set(&STORAGE_CROSS_CONTRACT_EPOCH, &5u64);
+
     // Exact match is accepted
     assert_eq!(require_matching_cross_contract_epoch(&env, 5), Ok(()));
-    
+
     // Stale epoch (less than current) is rejected
     assert_eq!(
         require_matching_cross_contract_epoch(&env, 4),
         Err(CrossContractEpochError::EpochMismatch)
     );
-    
+
     // Future epoch (greater than current) is rejected
     assert_eq!(
         require_matching_cross_contract_epoch(&env, 6),
@@ -2187,4 +2207,3 @@ fn test_same_address_symmetric() {
     let b = soroban_sdk::Address::generate(&env);
     assert_eq!(crate::same_address(&a, &b), crate::same_address(&b, &a));
 }
-

--- a/reporting/src/tests_archived_pagination_bound.rs
+++ b/reporting/src/tests_archived_pagination_bound.rs
@@ -554,14 +554,20 @@ fn paged_reader_user_isolation_holds_under_bound() {
     let page_a = client.get_archived_reports_page(&user_a, &0u32, &DEFAULT_PAGE_LIMIT);
     assert_eq!(page_a.items.len(), DEFAULT_PAGE_LIMIT);
     for r in page_a.items.iter() {
-        assert!(same_address(&r.user, &user_a), "user_a must only see their own archive");
+        assert!(
+            same_address(&r.user, &user_a),
+            "user_a must only see their own archive"
+        );
     }
 
     // user_b sees only their own (smaller) archive.
     let page_b = client.get_archived_reports_page(&user_b, &0u32, &DEFAULT_PAGE_LIMIT);
     assert_eq!(page_b.items.len(), 3);
     for r in page_b.items.iter() {
-        assert!(same_address(&r.user, &user_b), "user_b must only see their own archive");
+        assert!(
+            same_address(&r.user, &user_b),
+            "user_b must only see their own archive"
+        );
     }
 
     // Walking user_a's archive never exposes user_b's stored rows.

--- a/savings_goals/src/test.rs
+++ b/savings_goals/src/test.rs
@@ -7285,4 +7285,3 @@ fn cancel_after_execute_fails() {
     let res = client.try_remove_from_goal(&user, &goal_id, &500);
     assert_eq!(res, Err(Ok(ReversibleOpError::InvalidState)));
 }
-

--- a/savings_goals/src/test.rs
+++ b/savings_goals/src/test.rs
@@ -7251,3 +7251,38 @@ fn test_paused_since_and_pause_state() {
     assert!(!unpaused_state.paused);
     assert_eq!(unpaused_state.paused_since, None);
 }
+
+#[test]
+fn cancel_before_execute_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, SavingsGoalContract);
+    let client = SavingsGoalContractClient::new(&env, &contract_id);
+    let user = Address::generate(&env);
+    client.init();
+
+    let name = String::from_str(&env, "Goal");
+    let goal_id = client.create_goal(&user, &name, &1000, &1735689600, &false);
+
+    let res = client.remove_from_goal(&user, &goal_id, &500);
+    assert_eq!(res, Ok(false));
+}
+
+#[test]
+fn cancel_after_execute_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, SavingsGoalContract);
+    let client = SavingsGoalContractClient::new(&env, &contract_id);
+    let user = Address::generate(&env);
+    client.init();
+
+    let name = String::from_str(&env, "Goal");
+    let goal_id = client.create_goal(&user, &name, &1000, &1735689600, &false);
+
+    client.add_to_goal(&user, &goal_id, &500);
+
+    let res = client.try_remove_from_goal(&user, &goal_id, &500);
+    assert_eq!(res, Err(Ok(ReversibleOpError::InvalidState)));
+}
+

--- a/savings_goals/tests/gas_bench.rs
+++ b/savings_goals/tests/gas_bench.rs
@@ -337,8 +337,9 @@ fn bench_get_archived_goals_page_first_n50() {
 
     setup_archived_goals(&client, &owner, 50);
 
-    let (cpu, mem, page) =
-        measure(&env, || client.get_archived_goals_page(&owner, &0, &MAX_PAGE_LIMIT));
+    let (cpu, mem, page) = measure(&env, || {
+        client.get_archived_goals_page(&owner, &0, &MAX_PAGE_LIMIT)
+    });
     assert_eq!(page.count, MAX_PAGE_LIMIT);
 
     println!(
@@ -357,8 +358,9 @@ fn bench_get_archived_goals_page_first_n200() {
 
     setup_archived_goals(&client, &owner, 200);
 
-    let (cpu, mem, page) =
-        measure(&env, || client.get_archived_goals_page(&owner, &0, &MAX_PAGE_LIMIT));
+    let (cpu, mem, page) = measure(&env, || {
+        client.get_archived_goals_page(&owner, &0, &MAX_PAGE_LIMIT)
+    });
     assert_eq!(page.count, MAX_PAGE_LIMIT);
 
     println!(
@@ -377,8 +379,9 @@ fn bench_get_archived_goals_page_first_n1000() {
 
     setup_archived_goals(&client, &owner, 1000);
 
-    let (cpu, mem, page) =
-        measure(&env, || client.get_archived_goals_page(&owner, &0, &MAX_PAGE_LIMIT));
+    let (cpu, mem, page) = measure(&env, || {
+        client.get_archived_goals_page(&owner, &0, &MAX_PAGE_LIMIT)
+    });
     assert_eq!(page.count, MAX_PAGE_LIMIT);
 
     println!(
@@ -403,8 +406,9 @@ fn bench_get_archived_goals_page_last_n50() {
         cursor = last_page.next_cursor;
         last_page = client.get_archived_goals_page(&owner, &cursor, &MAX_PAGE_LIMIT);
     }
-    let (cpu, mem, page) =
-        measure(&env, || client.get_archived_goals_page(&owner, &cursor, &MAX_PAGE_LIMIT));
+    let (cpu, mem, page) = measure(&env, || {
+        client.get_archived_goals_page(&owner, &cursor, &MAX_PAGE_LIMIT)
+    });
     assert!(page.count > 0);
 
     println!(
@@ -429,8 +433,9 @@ fn bench_get_archived_goals_page_last_n200() {
         cursor = last_page.next_cursor;
         last_page = client.get_archived_goals_page(&owner, &cursor, &MAX_PAGE_LIMIT);
     }
-    let (cpu, mem, page) =
-        measure(&env, || client.get_archived_goals_page(&owner, &cursor, &MAX_PAGE_LIMIT));
+    let (cpu, mem, page) = measure(&env, || {
+        client.get_archived_goals_page(&owner, &cursor, &MAX_PAGE_LIMIT)
+    });
     assert!(page.count > 0);
 
     println!(
@@ -455,8 +460,9 @@ fn bench_get_archived_goals_page_last_n1000() {
         cursor = last_page.next_cursor;
         last_page = client.get_archived_goals_page(&owner, &cursor, &MAX_PAGE_LIMIT);
     }
-    let (cpu, mem, page) =
-        measure(&env, || client.get_archived_goals_page(&owner, &cursor, &MAX_PAGE_LIMIT));
+    let (cpu, mem, page) = measure(&env, || {
+        client.get_archived_goals_page(&owner, &cursor, &MAX_PAGE_LIMIT)
+    });
     assert!(page.count > 0);
 
     println!(

--- a/testutils/tests/no_panic_in_view_fn_test.rs
+++ b/testutils/tests/no_panic_in_view_fn_test.rs
@@ -83,7 +83,9 @@ pub fn require_no_panic_in_view_fn(source: &str) -> Vec<PanicViolation> {
             cursor = fn_kw_start + 7;
             continue;
         };
-        let fn_name = source[name_start..name_start + rel_paren].trim().to_string();
+        let fn_name = source[name_start..name_start + rel_paren]
+            .trim()
+            .to_string();
 
         // Only inspect view functions.
         if !fn_name.starts_with("get_") && !fn_name.starts_with("is_") {

--- a/testutils/tests/storage_key_source_scan_test.rs
+++ b/testutils/tests/storage_key_source_scan_test.rs
@@ -244,7 +244,10 @@ fn scanned_storage_keys_within_max_length() {
 fn scanned_storage_keys_are_uppercase_with_underscores() {
     let violations: Vec<String> = scan_all_crates()
         .into_iter()
-        .filter(|(_, key)| !key.chars().all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_'))
+        .filter(|(_, key)| {
+            !key.chars()
+                .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_')
+        })
         .map(|(krate, key)| format!("❌ {krate}: '{key}' is not UPPERCASE_WITH_UNDERSCORES"))
         .collect();
 
@@ -262,7 +265,9 @@ fn scanned_storage_keys_are_uppercase_with_underscores() {
 fn scanned_storage_keys_have_no_leading_trailing_or_double_underscores() {
     let violations: Vec<String> = scan_all_crates()
         .into_iter()
-        .filter(|(_, key)| key.starts_with('_') || key.ends_with('_') || key.contains("__") || key.is_empty())
+        .filter(|(_, key)| {
+            key.starts_with('_') || key.ends_with('_') || key.contains("__") || key.is_empty()
+        })
         .map(|(krate, key)| format!("❌ {krate}: '{key}' has an underscore placement violation"))
         .collect();
 

--- a/testutils/tests/view_fn_readonly_test.rs
+++ b/testutils/tests/view_fn_readonly_test.rs
@@ -412,10 +412,7 @@ fn detect_panics_in_view_fns(source: &str) -> (bool, Vec<String>) {
     while let Some(fn_idx) = source[current_idx..].find("pub fn ") {
         let abs_idx = current_idx + fn_idx;
         let start_of_name = abs_idx + 7; // skip "pub fn "
-        let end_of_name = source[start_of_name..]
-            .find('(')
-            .unwrap_or(0)
-            + start_of_name;
+        let end_of_name = source[start_of_name..].find('(').unwrap_or(0) + start_of_name;
         let fn_name = source[start_of_name..end_of_name].trim();
 
         if fn_name.starts_with("get_") || fn_name.starts_with("is_") {
@@ -459,8 +456,7 @@ fn detect_panics_in_view_fns(source: &str) -> (bool, Vec<String>) {
                 };
 
                 let has_expect = body.contains(".expect(");
-                let has_panic = body.contains("panic!(")
-                    || body.contains("panic_with_error!(");
+                let has_panic = body.contains("panic!(") || body.contains("panic_with_error!(");
 
                 if has_bare_unwrap || has_expect || has_panic {
                     let reason = if has_bare_unwrap {
@@ -689,10 +685,7 @@ impl Bad {
 }
 "#;
     let (found, violations) = detect_panics_in_view_fns(source);
-    assert!(
-        found,
-        "bare .unwrap() in an is_* fn must be flagged"
-    );
+    assert!(found, "bare .unwrap() in an is_* fn must be flagged");
     assert!(
         violations.iter().any(|v| v.contains("is_initialized")),
         "violation must name 'is_initialized', got:\n{}",


### PR DESCRIPTION


***

## Description
Locks in the `cancel-before-execute` and `cancel-after-execute` invariants for `ReversibleOp` trait implementors (`SavingsGoalsReversible` and `BillPaymentsReversible`).

## Added Unit Tests
- **`cancel_before_execute_succeeds`**: Verifies that invoking reversal/cancellation before execution returns `Ok(false)` (idempotent no-op).
- **`cancel_after_execute_fails`**: Verifies post-execution cancellation behavior against the typed `ReversibleOpError` taxonomy.

## Files Touched
- [savings_goals/src/test.rs](file:///c:/Users/HP/Desktop/drips/12/Remitwise-Contracts/savings_goals/src/test.rs)
- [bill_payments/src/test.rs](file:///c:/Users/HP/Desktop/drips/12/Remitwise-Contracts/bill_payments/src/test.rs)

Closes #1111 