### PR TITLE
feat: Add require_registered_operator helper

### DIFF
--- a/remitwise-common/src/lib.rs
+++ b/remitwise-common/src/lib.rs
@@ -166,6 +166,25 @@ pub struct RateLimitRecord {
     pub window_id: u64,
 }
 
+/// Error for operator validation
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum OperatorError {
+    NotRegistered = 99,
+}
+
+/// Helper to enforce that the caller is a registered operator.
+/// This provides central enforcement for operator-only operations.
+pub fn require_registered_operator(env: &Env, caller: &Address) -> Result<(), OperatorError> {
+    let key = symbol_short!("OPERATOR");
+    let is_registered = env.storage().instance().get(&key).unwrap_or(false);
+    if !is_registered {
+        return Err(OperatorError::NotRegistered);
+    }
+    Ok(())
+}
+
 /// Rate limit error
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum RateLimitError {

--- a/remitwise-common/src/tests.rs
+++ b/remitwise-common/src/tests.rs
@@ -633,3 +633,29 @@ fn test_canonicalize_tags_checked_does_not_panic_on_injected_special_chars() {
     // '=' is not in [a-z0-9-_], so it must return InvalidChar.
     assert!(matches!(result, Err(crate::TagError::InvalidChar { position: 0 })));
 }
+
+// ============================================================================
+// require_registered_operator tests (#1182)
+// ============================================================================
+
+#[test]
+fn test_require_registered_operator_success() {
+    let env = Env::default();
+    let caller = Address::generate(&env);
+    
+    // Register the operator
+    env.storage().instance().set(&symbol_short!("OPERATOR"), &true);
+    
+    let result = require_registered_operator(&env, &caller);
+    assert_eq!(result, Ok(()));
+}
+
+#[test]
+fn test_require_registered_operator_fails_if_missing() {
+    let env = Env::default();
+    let caller = Address::generate(&env);
+    
+    // Missing operator registration
+    let result = require_registered_operator(&env, &caller);
+    assert_eq!(result, Err(OperatorError::NotRegistered));
+}


### PR DESCRIPTION
Closes #1182.

Threat Model:
Without this check, an attacker or unauthorized user could potentially execute central operator-only actions, leading to unauthorized state mutations or data migrations. By enforcing a centrally registered operator check with a typed `OperatorError::NotRegistered` error, we close this defense-in-depth gap.