### PR TITLE
test: pin the authorized-signer cap at its exact boundary (#1615)

### DIFF
--- a/family_wallet/src/test.rs
+++ b/family_wallet/src/test.rs
@@ -3525,7 +3525,8 @@ fn test_too_many_signers_rejected() {
 
     let owner = Address::generate(&env);
 
-    // Create 101 members (exceeds MAX_SIGNERS = 100)
+    // Create 101 members — far beyond MAX_SIGNERS (= 20; the boundary
+    // itself is pinned by test_signer_cap_boundary_* below).
     let mut members = Vec::new(&env);
     let mut signers = Vec::new(&env);
     for _ in 0..101 {
@@ -8079,4 +8080,64 @@ fn test_archive_integrity_rejects_mismatched_tx_id() {
     // Archive with a cutoff well after executed_at so the corrupted entry
     // would be eligible for archiving — triggering the integrity check.
     client.archive_old_transactions(&owner, &10_000);
+}
+
+// ─── Issue #1615 – pin the signer cap at its exact boundary ──────────────────
+
+/// Exactly MAX_SIGNERS (20) signers is permitted: the cap is inclusive.
+#[test]
+fn test_signer_cap_boundary_at_max_accepted() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, FamilyWallet);
+    let client = FamilyWalletClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let mut members = Vec::new(&env);
+    let mut signers = Vec::new(&env);
+    for _ in 0..20 {
+        let addr = Address::generate(&env);
+        members.push_back(addr.clone());
+        signers.push_back(addr);
+    }
+    client.init(&owner, &members);
+
+    let result = client.try_configure_multisig(
+        &owner,
+        &TransactionType::LargeWithdrawal,
+        &2,
+        &signers,
+        &1000_0000000,
+    );
+    assert_eq!(result, Ok(Ok(true)), "exactly MAX_SIGNERS must be accepted");
+}
+
+/// MAX_SIGNERS + 1 (21) signers is rejected with the typed `TooManySigners`
+/// error — the explicit failure mode one past the boundary, not just the
+/// far-past case covered by `test_too_many_signers_rejected`.
+#[test]
+fn test_signer_cap_boundary_one_over_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, FamilyWallet);
+    let client = FamilyWalletClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let mut members = Vec::new(&env);
+    let mut signers = Vec::new(&env);
+    for _ in 0..21 {
+        let addr = Address::generate(&env);
+        members.push_back(addr.clone());
+        signers.push_back(addr);
+    }
+    client.init(&owner, &members);
+
+    let result = client.try_configure_multisig(
+        &owner,
+        &TransactionType::LargeWithdrawal,
+        &2,
+        &signers,
+        &1000_0000000,
+    );
+    assert_eq!(result, Err(Ok(Error::TooManySigners)));
 }


### PR DESCRIPTION
## Summary

Closes #1615 — hardens the authorized-signer cap by **pinning it at its exact boundary with tests**, after an audit showed the cap itself already exists.

## Audit (what an attacker gets without this)

Per the issue's hint, I threat-modelled before writing: every proposal execution iterates the signer list during signature verification, so an unbounded signer set lets a careless or compromised admin bloat the instance storage entry and push execution toward resource exhaustion — a self-DoS on the wallet's own funds.

Auditing **every** signer-set write path in the workspace: `configure_multisig` is the only one, and it already enforces `MAX_SIGNERS` with the typed `TooManySigners` error, plus membership, uniqueness, and threshold-bound checks. So the check exists — but it was **not load-bearing**:

- The sole existing test drives **101 signers at a cap of 20** — any regression that loosened the cap to, say, 50 would pass unnoticed.
- That test's comment claims `MAX_SIGNERS = 100` — evidence the constant was changed without the test following, exactly how boundary regressions slip in.

## Changes

- `test_signer_cap_boundary_at_max_accepted` — exactly `MAX_SIGNERS` (20) is permitted; the cap is inclusive (happy path).
- `test_signer_cap_boundary_one_over_rejected` — 21 signers fails with the **typed** `TooManySigners` error (explicit failure mode, one past the boundary where regressions actually appear).
- Corrected the stale comment on the existing far-past-cap test.

No production-code change was needed — and shipping a redundant second check would have been noise; the tests are what make the existing check trustworthy.

## Test-suite note

The crate has **35 pre-existing failures on pristine main** (unrelated setup breakage). This PR adds none — the failure list is verified identical before/after — and adds 2 passing tests. Clippy clean, fmt applied.