### PR TITLE
fix(remittance_split): bound corridor validation work

### DIFF
--- a/remittance_split/src/lib.rs
+++ b/remittance_split/src/lib.rs
@@ -1073,10 +1073,15 @@ impl RemittanceSplit {
         env: &Env,
         corridors: &Vec<Corridor>,
     ) -> Result<(), RemittanceSplitError> {
-        if corridors.len() > params::MAX_CORRIDORS {
+        let corridor_count = corridors.len();
+        if corridor_count > params::MAX_CORRIDORS {
             return Err(RemittanceSplitError::CorridorCountExceeded);
         }
-        for i in 0..corridors.len() {
+
+        // Keep validation work linear within the checked caller-controlled bound.
+        // Pairwise duplicate checks made the maximum accepted input quadratic.
+        let mut seen_ids: Map<u32, bool> = Map::new(env);
+        for i in 0..corridor_count {
             if let Some(c) = corridors.get(i) {
                 if c.fee_bps > params::MAX_FEE_BPS {
                     return Err(RemittanceSplitError::CorridorFeeTooHigh);
@@ -1093,13 +1098,10 @@ impl RemittanceSplit {
                 if c.max_amount < c.min_amount || c.min_amount < params::MIN_CORRIDOR_AMOUNT {
                     return Err(RemittanceSplitError::InvalidCorridorAmountRange);
                 }
-                for j in (i + 1)..corridors.len() {
-                    if let Some(other) = corridors.get(j) {
-                        if c.id == other.id {
-                            return Err(RemittanceSplitError::DuplicateCorridorId);
-                        }
-                    }
+                if seen_ids.contains_key(c.id) {
+                    return Err(RemittanceSplitError::DuplicateCorridorId);
                 }
+                seen_ids.set(c.id, true);
             }
         }
         Ok(())

--- a/remittance_split/src/test.rs
+++ b/remittance_split/src/test.rs
@@ -1151,7 +1151,7 @@ fn test_corridor_below_min_deposit_is_rejected() {
     );
 }
 
-fn sample_corridor(env: &Env, id: u32) -> Corridor {
+fn sample_corridor(_env: &Env, id: u32) -> Corridor {
     Corridor {
         id,
         source_currency: symbol_short!("USD"),
@@ -1164,6 +1164,38 @@ fn sample_corridor(env: &Env, id: u32) -> Corridor {
 
 fn sample_corridors(env: &Env) -> Vec<Corridor> {
     vec![env, sample_corridor(env, 1), sample_corridor(env, 2)]
+}
+
+#[test]
+fn test_validate_corridors_accepts_exact_loop_bound() {
+    let env = Env::default();
+    let mut corridors = vec![&env];
+
+    for id in 0..params::MAX_CORRIDORS {
+        let mut corridor = sample_corridor(&env, id);
+        corridor.fee_bps = 100;
+        corridors.push_back(corridor);
+    }
+
+    assert_eq!(
+        RemittanceSplit::validate_corridors(&env, &corridors),
+        Ok(())
+    );
+}
+
+#[test]
+fn test_validate_corridors_rejects_input_above_loop_bound() {
+    let env = Env::default();
+    let mut corridors = vec![&env];
+
+    for id in 0..=params::MAX_CORRIDORS {
+        corridors.push_back(sample_corridor(&env, id));
+    }
+
+    assert_eq!(
+        RemittanceSplit::validate_corridors(&env, &corridors),
+        Err(RemittanceSplitError::CorridorCountExceeded)
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- reject corridor lists above `params::MAX_CORRIDORS` before validation work
- replace pairwise duplicate-ID scanning with one bounded pass backed by a typed Soroban map
- cover the exact accepted boundary and the first rejected boundary

## Threat model

`init_corridors` accepts a caller-controlled vector. Although the vector count was rejected above `MAX_CORRIDORS`, duplicate validation still compared every accepted element with every later element. At the current maximum of 100 corridors, an authorized caller could force 4,950 pairwise comparisons before storage mutation, amplifying contract CPU use and making the accepted boundary a resource-exhaustion surface.

The validator now captures and checks the input count before iteration, then performs at most one validation pass over the accepted input. Duplicate IDs continue to return the existing typed `DuplicateCorridorId` error, while an oversized vector returns `CorridorCountExceeded` before iteration or state mutation.

## Validation

- `cargo fmt -p remittance_split -- --check`
- `cargo test -p remittance_split test_validate_corridors_ -- --nocapture` — 2 passed
- `cargo clippy -p remittance_split --lib --no-deps -- -D warnings`
- `cargo build -p remittance_split --target wasm32-unknown-unknown --release`

The repository-wide checks are currently blocked on unrelated `main` failures:

- `cargo test -p remittance_split` reaches 61 passed / 49 failed; the failures occur in pre-existing token initialization and percentage-validation paths, before this validator is reached.
- `cargo clippy --workspace --all-targets -- -D warnings` stops in pre-existing `testutils` and `remitwise-common` warnings/errors.

Closes #1626
