### PR TITLE
feat: surface the WASM size delta on every build (#1559)

### DIFF
--- a/benchmarks/wasm_size_baseline.json
+++ b/benchmarks/wasm_size_baseline.json
@@ -1,0 +1,1 @@
+{"remittance_split":108005,"savings_goals":110307,"bill_payments":127963,"insurance":66695,"family_wallet":121202,"orchestrator":60683,"data_migration":0,"emergency_killswitch":35943,"reporting":99050}

--- a/check_ci.sh
+++ b/check_ci.sh
@@ -21,6 +21,9 @@ python3 scripts/validate_lockfile.py
 echo "Building WASM..."
 cargo build --release --target wasm32-unknown-unknown
 
+echo "WASM size delta (issue #1559)..."
+bash scripts/wasm_size_delta.sh
+
 echo "Running tests..."
 cargo test --all-features
 

--- a/scripts/wasm_size_delta.sh
+++ b/scripts/wasm_size_delta.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Issue #1559 – surface the WASM size delta on every build.
+#
+# Compares each contract's current WASM byte size (via collect_wasm_sizes.sh)
+# against the committed baseline and prints a per-contract delta table, so a
+# size regression is visible in the build output the moment it happens rather
+# than at deploy time.
+#
+# Usage:
+#   ./scripts/wasm_size_delta.sh            # print the delta table
+#   ./scripts/wasm_size_delta.sh --update   # rewrite the baseline from current sizes
+#
+# This is a DX surface, not a gate: it always exits 0 (except on missing
+# tooling), mirroring how compare_gas_results.sh reports gas movement.
+# Refresh the baseline deliberately — in the same PR that changes a
+# contract's size — with --update, mirroring update_baseline.sh.
+set -euo pipefail
+
+BASELINE="benchmarks/wasm_size_baseline.json"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+current=$("$SCRIPT_DIR/collect_wasm_sizes.sh")
+
+if [ "${1:-}" = "--update" ]; then
+    printf '%s\n' "$current" > "$BASELINE"
+    echo "✅ WASM size baseline updated at $BASELINE"
+    exit 0
+fi
+
+if [ ! -f "$BASELINE" ]; then
+    echo "⚠️  No baseline at $BASELINE — run './scripts/wasm_size_delta.sh --update' after a clean build"
+    exit 0
+fi
+
+python3 - "$BASELINE" <<PYEOF
+import json, sys
+baseline = json.load(open(sys.argv[1]))
+current = json.loads('''$current''')
+
+print()
+print("WASM size delta vs benchmarks/wasm_size_baseline.json")
+print(f"{'contract':<22} {'baseline':>10} {'current':>10} {'delta':>9} {'pct':>8}")
+print("-" * 64)
+total_b = total_c = 0
+for name in sorted(set(baseline) | set(current)):
+    b = baseline.get(name, 0)
+    c = current.get(name, 0)
+    total_b += b; total_c += c
+    if b == 0 and c == 0:
+        print(f"{name:<22} {'-':>10} {'-':>10} {'-':>9} {'-':>8}")
+        continue
+    delta = c - b
+    pct = f"{100*delta/b:+.2f}%" if b else "new"
+    marker = "" if delta == 0 else ("  ▲" if delta > 0 else "  ▼")
+    print(f"{name:<22} {b:>10} {c:>10} {delta:>+9} {pct:>8}{marker}")
+print("-" * 64)
+tdelta = total_c - total_b
+tpct = f"{100*tdelta/total_b:+.2f}%" if total_b else "n/a"
+print(f"{'TOTAL':<22} {total_b:>10} {total_c:>10} {tdelta:>+9} {tpct:>8}")
+print()
+PYEOF


### PR DESCRIPTION
## Summary

Closes #1559 — every build now prints a per-contract WASM size delta table against a committed baseline, so size regressions surface in build output the moment they happen instead of at deploy time.

## Design — deliberately in this repo's existing idiom

The repo already has the pieces of a measurement culture: `collect_wasm_sizes.sh` (sizes as JSON) and the gas tooling's baseline/compare/update trio. This PR completes the same trio for size:

- **`scripts/wasm_size_delta.sh`** — reuses `collect_wasm_sizes.sh` for current sizes, compares against `benchmarks/wasm_size_baseline.json`, prints per-contract `baseline / current / delta / %` with ▲▼ direction markers and a workspace total.
- **`benchmarks/wasm_size_baseline.json`** — seeded from a clean build of all nine contracts on current main (729,848 bytes total; `data_migration` produces no wasm and reports as `-` without noise).
- **`--update`** rewrites the baseline deliberately — mirroring `update_baseline.sh` — so growth lands visibly in the PR that causes it.
- **`check_ci.sh`** invokes it right after the WASM build step: the delta appears on every CI build.

It is a **DX surface, not a gate** (always exits 0), matching how `compare_gas_results.sh` reports gas movement — a budget gate can be layered on later if wanted.

## Verified

- Zero-delta run on pristine artifacts prints all `+0 / +0.00%`.
- Synthetic baseline perturbation correctly reports growth (`reporting +1234 / +1.26% ▲`) and shrinkage (`insurance −500 / −0.74% ▼`) and the total.
- Shellcheck-clean; no workflow files touched, so no CI-permission surface changes.

Happy path + failure mode per acceptance criteria: the table itself (zero and non-zero deltas) plus the missing-baseline case, which prints a clear instruction instead of erroring.