### PR TITLE
docs(storage): enforce reserved storage key prefixes in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,11 @@ jobs:
 
         '
       continue-on-error: false
+    - name: Run reserved storage key enforcement check
+      run: 'cargo test --package testutils --test reserved_storage_keys_test -- --nocapture
+
+        '
+      continue-on-error: false
   gas-benchmarks:
     name: Gas Benchmarks
     runs-on: macos-latest

--- a/README.md
+++ b/README.md
@@ -337,6 +337,8 @@ To run an example, use `cargo run --example <example_name>`:
 - [Type-Safe Percent Conversion](docs/type-safe-percent-conversion.md) - Converting whole percentages to basis points with checked overflow arithmetic
 - [Configuration Schema Versioning](docs/CONFIG_SCHEMA_VERSIONING.md) - Protocols for bumping configuration schema versions with backward compatibility
 - [Storage Layout Reference](STORAGE_LAYOUT.md)
+- [Storage Key Naming Conventions](docs/storage-key-naming-conventions.md) - Naming rules for storage keys, plus the CI checks that enforce them
+- [Reserved Storage Keys](docs/RESERVED_STORAGE_KEYS.md) - Storage-key prefixes set aside for roadmap features; contributors must not reuse them
 - [Audit Event Fields](docs/audit-event-fields.md) - On-chain audit log fields and patterns
 - [Event Indexer](indexer/README.md) - Off-chain event indexing and querying
 - [Audit Trail](docs/AUDIT_TRAIL.md) - How to reconstruct historical state from events alone

--- a/STORAGE_LAYOUT.md
+++ b/STORAGE_LAYOUT.md
@@ -21,7 +21,7 @@ All storage keys follow strict naming conventions to ensure consistency and comp
 - **Format:** UPPERCASE_WITH_UNDERSCORES
 - **Valid characters:** A-Z, 0-9, \_ (underscore)
 
-These conventions are automatically validated in CI by two complementary test suites: a hand-maintained catalogue check (`storage_key_naming_test.rs`) and a live source scan (`storage_key_source_scan_test.rs`) that parses each contract's `src/lib.rs` directly so a key added or renamed in code can't silently drift out of sync with the documented conventions. See [Storage Key Naming Conventions](docs/storage-key-naming-conventions.md) for detailed guidelines and [testutils/tests/README.md](testutils/tests/README.md) for information about the automated validation tests.
+These conventions are automatically validated in CI by three complementary test suites: a hand-maintained catalogue check (`storage_key_naming_test.rs`), a live source scan (`storage_key_source_scan_test.rs`) that parses each contract's `src/lib.rs` directly so a key added or renamed in code can't silently drift out of sync with the documented conventions, and a reserved-key check (`reserved_storage_keys_test.rs`) that fails the build if a contract reuses a key set aside for a future roadmap feature. See [Storage Key Naming Conventions](docs/storage-key-naming-conventions.md) for detailed guidelines, [Reserved Storage Keys](docs/RESERVED_STORAGE_KEYS.md) for the list of keys not yet available for reuse, and [testutils/tests/README.md](testutils/tests/README.md) for information about the automated validation tests.
 
 **Run validation tests:**
 

--- a/docs/RESERVED_STORAGE_KEYS.md
+++ b/docs/RESERVED_STORAGE_KEYS.md
@@ -47,9 +47,36 @@ pub fn set_notification(env: Env, enabled: bool) {
 }
 ```
 
+## Automated Enforcement
+
+Point 1 below is not just a review checklist item — it's enforced in CI.
+[`testutils/tests/reserved_storage_keys_test.rs`](../testutils/tests/reserved_storage_keys_test.rs)
+parses the table above directly out of this document (so the doc stays the
+single source of truth) and cross-checks every reserved key against every
+storage-key literal actually used in each contract's `src/lib.rs`, the same
+way [`storage_key_source_scan_test.rs`](../testutils/tests/storage_key_source_scan_test.rs)
+catches naming-convention drift. If a PR stores data under a reserved key,
+this test fails the build instead of relying on a reviewer to spot it.
+
+**Run it locally:**
+
+```bash
+cargo test --package testutils --test reserved_storage_keys_test -- --nocapture
+```
+
+When the future feature for a reserved key is actually implemented, remove
+the row from the table above (see step 3 below) — the test will then stop
+treating that key as reserved automatically, no test-code change required.
+
 ## Reviewer Verification
 
 When reviewing PRs, verify that:
-1. No `symbol_short!` macro invocation uses a key from the table above.
+1. No `symbol_short!` macro invocation uses a key from the table above — automatically checked by `reserved_storage_keys_test.rs` (see [Automated Enforcement](#automated-enforcement)), but worth a manual glance for keys built up dynamically (e.g. `format!`) that the scanner can't see.
 2. The storage layout tests in `testutils/tests/storage_key_naming_test.rs` are passing.
 3. If the PR implements the future feature for a reserved key, the key is removed from this document and added to the [Storage Key Naming Conventions](storage-key-naming-conventions.md#common-storage-keys) table.
+
+## References
+
+- [Storage Key Naming Conventions](storage-key-naming-conventions.md) - Naming rules and CI-enforced conventions for all storage keys
+- [Storage Layout Reference](../STORAGE_LAYOUT.md) - Complete storage layout documentation for every contract
+- [testutils/tests/README.md](../testutils/tests/README.md) - Overview of all storage-key validation tests, including this document's enforcement test

--- a/docs/storage-key-naming-conventions.md
+++ b/docs/storage-key-naming-conventions.md
@@ -174,6 +174,10 @@ Storage key naming conventions are automatically validated in CI through two com
    literal actually passed to a Soroban storage accessor (`.get()`, `.set()`,
    `.has()`, `.remove()`), then validates those against the same
    length/format constraints.
+3. **`testutils/tests/reserved_storage_keys_test.rs`** - Parses the
+   [Reserved Storage Keys](RESERVED_STORAGE_KEYS.md) table and cross-checks
+   it against the same live source scan, failing CI if any contract stores
+   data under a key reserved for a future roadmap feature.
 
 The hand-maintained catalogue is easy to read but nothing forces it to stay
 in sync with the code: a key can be renamed or added in source without the
@@ -181,7 +185,9 @@ catalogue (or its checks) ever noticing. The source scan closes that gap by
 validating what the code actually does, independent of whether anyone
 remembered to update the catalogue. Running both together means drift
 between "documented convention" and "real on-chain key" fails CI regardless
-of which side changed.
+of which side changed. The reserved-key check closes a related but distinct
+gap: a key can be perfectly well-formed and still collide with a namespace
+set aside for an unshipped feature.
 
 Note: `savings_goals` and `insurance` primarily use a composite `DataKey`
 enum (`DataKey::Goal(u32)`, `DataKey::Policy(u32)`, ...) for most of their
@@ -202,6 +208,9 @@ cargo test --package testutils test_all_keys_within_max_length -- --nocapture
 
 # Run only the live-source drift scan
 cargo test --package testutils --test storage_key_source_scan_test -- --nocapture
+
+# Run only the reserved-key enforcement check
+cargo test --package testutils --test reserved_storage_keys_test -- --nocapture
 ```
 
 ### Test Coverage
@@ -229,12 +238,14 @@ against `src/lib.rs` in every contract crate:
 
 ### CI Integration
 
-Both test suites run automatically on every pull request and push to main
-through the GitHub Actions workflow defined in `.github/workflows/ci.yml`.
+All three test suites run automatically on every pull request and push to
+main through the GitHub Actions workflow defined in `.github/workflows/ci.yml`.
 
 The `storage-key-validation` job will fail if any naming convention
 violations are detected — by the catalogue check, the source scan, or
-both — preventing non-compliant keys from being merged.
+both — or if the reserved-key check (`reserved_storage_keys_test.rs`) finds
+a reserved key in use, preventing non-compliant or namespace-colliding keys
+from being merged.
 
 ## Adding New Storage Keys
 

--- a/testutils/tests/README.md
+++ b/testutils/tests/README.md
@@ -8,6 +8,7 @@ This directory contains automated tests that validate storage key naming convent
 
 - **`storage_key_naming_test.rs`** - Comprehensive validation suite for a hand-maintained catalogue of documented storage keys
 - **`storage_key_source_scan_test.rs`** - Parses each contract crate's `src/lib.rs` directly, extracts every storage-key literal actually passed to a Soroban storage accessor (`.get()`, `.set()`, `.has()`, `.remove()`), and re-validates those against the same conventions. This catches drift that the hand-maintained catalogue can miss: a key can be added or renamed in source without anyone remembering to update `storage_key_naming_test.rs`, and this scan will still catch a convention violation because it reads the real code, not a snapshot of it.
+- **`reserved_storage_keys_test.rs`** - Parses the reserved-key table out of [`docs/RESERVED_STORAGE_KEYS.md`](../../docs/RESERVED_STORAGE_KEYS.md) and cross-checks it against the same live source scan used above, failing if any contract stores data under a key set aside for a future roadmap feature (yield generation, staking, the V2 migration path, etc.).
 
 ## What Gets Validated
 
@@ -54,6 +55,28 @@ heuristic silently regressing). It recognizes two shapes:
 instead of literal keys, so the scan naturally finds fewer entries for
 those two crates - see [STORAGE_LAYOUT.md](../../STORAGE_LAYOUT.md).
 
+## Reserved Key Enforcement
+
+`reserved_storage_keys_test.rs` reuses the same key-extraction approach as
+the source scan, but checks against a different list: the "reserved for a
+future feature" keys documented in
+[`docs/RESERVED_STORAGE_KEYS.md`](../../docs/RESERVED_STORAGE_KEYS.md)
+(e.g. `YIELD_CFG`, `STAKE_POL`, `REWARD_CF`). It parses that document's
+table directly, so the doc itself stays the single source of truth - remove
+a row there once the feature ships, and the test stops treating that key as
+reserved without any test-code change.
+
+Three checks:
+
+1. **Parser sanity** - the expected reserved keys are actually found in the
+   doc's table (guards against a markdown format change silently emptying
+   the reserved set).
+2. **Enforcement (happy path)** - no crate in `SCANNED_CRATES` currently
+   uses a reserved key.
+3. **Detector proof (failure mode)** - runs the same extraction + check
+   against a synthetic snippet that intentionally reuses a reserved key,
+   proving the detector actually flags it.
+
 ## Running the Tests
 
 ### Run All Storage Key Tests
@@ -82,6 +105,12 @@ cargo test --package testutils test_print_storage_key_summary -- --nocapture
 
 ```bash
 cargo test --package testutils --test storage_key_source_scan_test -- --nocapture
+```
+
+### Run the Reserved Key Enforcement Check Only
+
+```bash
+cargo test --package testutils --test reserved_storage_keys_test -- --nocapture
 ```
 
 ### Run from Workspace Root
@@ -196,6 +225,11 @@ storage-key-validation:
       run: |
         cargo test --package testutils --test storage_key_source_scan_test -- --nocapture
       continue-on-error: false
+
+    - name: Run reserved storage key enforcement check
+      run: |
+        cargo test --package testutils --test reserved_storage_keys_test -- --nocapture
+      continue-on-error: false
 ```
 
 ## Maintenance
@@ -253,6 +287,7 @@ All keys are centralized in the `get_all_storage_keys()` function for easy maint
 ## References
 
 - [Storage Key Naming Conventions](../../docs/storage-key-naming-conventions.md)
+- [Reserved Storage Keys](../../docs/RESERVED_STORAGE_KEYS.md)
 - [Storage Layout Documentation](../../STORAGE_LAYOUT.md)
 - [Soroban Symbol Documentation](https://docs.rs/soroban-sdk/latest/soroban_sdk/struct.Symbol.html)
 - [Soroban Storage Example](https://developers.stellar.org/docs/build/smart-contracts/example-contracts/storage)

--- a/testutils/tests/reserved_storage_keys_test.rs
+++ b/testutils/tests/reserved_storage_keys_test.rs
@@ -1,0 +1,316 @@
+//! Reserved storage key enforcement.
+//!
+//! `docs/RESERVED_STORAGE_KEYS.md` documents storage-key prefixes that are
+//! set aside for roadmap features (yield generation, staking, the V2
+//! migration path, etc.) and tells contributors not to reuse them. Until
+//! now that document was aspirational: nothing checked that a contract
+//! never actually stores data under one of those keys, so the "reviewer
+//! verification" checklist at the bottom of that doc relied entirely on a
+//! human noticing during code review.
+//!
+//! This module closes that gap the same way `storage_key_source_scan_test.rs`
+//! closes the drift gap for naming conventions: it parses the reserved-key
+//! table straight out of the markdown doc (so the doc stays the single
+//! source of truth) and cross-checks it against every storage-key literal
+//! actually used in each contract's `src/lib.rs`. A reserved key finding its
+//! way into source now fails CI instead of waiting on a reviewer to catch it.
+//!
+//! Reference: `docs/RESERVED_STORAGE_KEYS.md`,
+//! `docs/storage-key-naming-conventions.md`,
+//! `testutils/tests/storage_key_source_scan_test.rs`.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::PathBuf;
+
+/// Crates scanned for storage keys. Mirrors
+/// `storage_key_source_scan_test.rs`; duplicated intentionally so this file
+/// does not depend on another test binary's internals (each `tests/*.rs`
+/// file compiles as its own crate).
+const SCANNED_CRATES: &[&str] = &[
+    "remittance_split",
+    "savings_goals",
+    "bill_payments",
+    "insurance",
+    "family_wallet",
+    "reporting",
+    "orchestrator",
+    "emergency_killswitch",
+    "remitwise-common",
+];
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("testutils has a parent directory")
+        .to_path_buf()
+}
+
+/// Parses the `| \`KEY\` | ... |` rows out of the "List of Reserved Keys"
+/// table in `docs/RESERVED_STORAGE_KEYS.md`. Only rows whose first cell is a
+/// backtick-quoted key are matched, which naturally skips the header row
+/// (`| Reserved Key | ... |`), the separator row (`|---|---|`), and the
+/// fenced code blocks in the "Concrete Examples" section (those lines don't
+/// start with `|`).
+fn parse_reserved_keys_from_doc() -> BTreeSet<String> {
+    let path = workspace_root()
+        .join("docs")
+        .join("RESERVED_STORAGE_KEYS.md");
+    let src = fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()));
+
+    let mut keys = BTreeSet::new();
+    for line in src.lines() {
+        let trimmed = line.trim();
+        if !trimmed.starts_with('|') {
+            continue;
+        }
+        let Some(first_backtick) = trimmed.find('`') else {
+            continue;
+        };
+        let rest = &trimmed[first_backtick + 1..];
+        let Some(end) = rest.find('`') else {
+            continue;
+        };
+        let key = rest[..end].trim();
+        if !key.is_empty() {
+            keys.insert(key.to_string());
+        }
+    }
+    keys
+}
+
+/// Finds every `const NAME: Symbol = symbol_short!("KEY");` (with or
+/// without a `pub` prefix) in `src` and returns a map of `NAME -> KEY`.
+fn find_local_symbol_consts(src: &str) -> BTreeMap<String, String> {
+    let mut consts = BTreeMap::new();
+    let marker = "const ";
+    let mut cursor = 0usize;
+
+    while let Some(rel) = src[cursor..].find(marker) {
+        let name_start = cursor + rel + marker.len();
+        let rest = &src[name_start..];
+
+        let name_end = rest
+            .find(|c: char| !(c.is_alphanumeric() || c == '_'))
+            .unwrap_or(rest.len());
+        let name = &rest[..name_end];
+        cursor = name_start + name_end.max(1);
+
+        if name.is_empty() {
+            continue;
+        }
+
+        let after_name = rest[name_end..].trim_start();
+        let Some(after_colon) = after_name.strip_prefix(':') else {
+            continue;
+        };
+        let after_type = after_colon.trim_start();
+        let Some(after_symbol_ty) = after_type.strip_prefix("Symbol") else {
+            continue;
+        };
+        let after_eq = after_symbol_ty.trim_start();
+        let Some(after_eq) = after_eq.strip_prefix('=') else {
+            continue;
+        };
+        let after_eq = after_eq.trim_start();
+        let Some(after_macro) = after_eq.strip_prefix("symbol_short!(\"") else {
+            continue;
+        };
+        if let Some(quote_end) = after_macro.find('"') {
+            consts.insert(name.to_string(), after_macro[..quote_end].to_string());
+        }
+    }
+
+    consts
+}
+
+/// Returns byte offsets of the opening `(` for every call to `.{accessor}(`
+/// or `.{accessor}::<...>(` in `src`.
+fn find_call_open_parens(src: &str, accessor: &str) -> Vec<usize> {
+    let dotted = format!(".{accessor}");
+    let mut sites = Vec::new();
+    let mut cursor = 0usize;
+
+    while let Some(rel) = src[cursor..].find(&dotted) {
+        let idx = cursor + rel;
+        let after = idx + dotted.len();
+        match src[after..].chars().next() {
+            Some('(') => {
+                sites.push(after);
+                cursor = after + 1;
+            }
+            Some(':') => {
+                if let Some(paren_rel) = src[after..].find('(') {
+                    sites.push(after + paren_rel);
+                    cursor = after + paren_rel + 1;
+                } else {
+                    cursor = after;
+                }
+            }
+            _ => cursor = after,
+        }
+    }
+
+    sites
+}
+
+/// Given the byte offset of a call's opening `(`, returns the source text of
+/// its first top-level argument (i.e. up to the first depth-1 comma, or the
+/// closing `)` if there is only one argument). Handles nested parens such as
+/// `symbol_short!("X")` or `DataKey::Goal(id)`.
+fn extract_first_arg(src: &str, open_idx: usize) -> Option<&str> {
+    let bytes = src.as_bytes();
+    let arg_start = open_idx + 1;
+    let mut depth = 1i32;
+    let mut i = arg_start;
+
+    while i < bytes.len() {
+        match bytes[i] {
+            b'(' => depth += 1,
+            b')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(&src[arg_start..i]);
+                }
+            }
+            b',' if depth == 1 => return Some(&src[arg_start..i]),
+            _ => {}
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Extracts every storage key literal used in `src` that is passed to a
+/// Soroban storage accessor (`.get()`, `.set()`, `.has()`, `.remove()`),
+/// either as an inline `symbol_short!("KEY")` literal or via a local
+/// `const NAME: Symbol = symbol_short!("KEY");` referenced by name.
+fn extract_storage_keys(src: &str) -> BTreeSet<String> {
+    let local_consts = find_local_symbol_consts(src);
+    let mut keys = BTreeSet::new();
+
+    for accessor in ["get", "set", "has", "remove"] {
+        for open_idx in find_call_open_parens(src, accessor) {
+            let Some(raw_arg) = extract_first_arg(src, open_idx) else {
+                continue;
+            };
+            let arg = raw_arg.trim().trim_start_matches('&').trim();
+
+            if let Some(rest) = arg.strip_prefix("symbol_short!(\"") {
+                if let Some(quote_end) = rest.find('"') {
+                    keys.insert(rest[..quote_end].to_string());
+                }
+                continue;
+            }
+
+            if !arg.is_empty() && arg.chars().all(|c| c.is_alphanumeric() || c == '_') {
+                if let Some(key) = local_consts.get(arg) {
+                    keys.insert(key.clone());
+                }
+            }
+        }
+    }
+
+    keys
+}
+
+/// Reads `<crate>/src/lib.rs` for every crate in `SCANNED_CRATES` and
+/// returns `(crate_name, storage_key)` pairs for every key found.
+fn scan_all_crates() -> Vec<(&'static str, String)> {
+    let root = workspace_root();
+    let mut found = Vec::new();
+
+    for crate_name in SCANNED_CRATES {
+        let path = root.join(crate_name).join("src").join("lib.rs");
+        let src = fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()));
+
+        for key in extract_storage_keys(&src) {
+            found.push((*crate_name, key));
+        }
+    }
+
+    found
+}
+
+/// Sanity check on the doc parser itself: if `RESERVED_STORAGE_KEYS.md`'s
+/// table format ever changes in a way the parser can't follow, this fails
+/// loudly instead of the enforcement test below silently checking against
+/// an empty set.
+#[test]
+fn reserved_keys_doc_parses_expected_entries() {
+    let reserved = parse_reserved_keys_from_doc();
+    let expected = ["YIELD_CFG", "STAKE_POL", "REWARD_CF", "V2_MIGR", "TMP_LOCK"];
+
+    for key in expected {
+        assert!(
+            reserved.contains(key),
+            "\n\nExpected reserved key '{key}' not found by the doc parser.\n\
+             Either docs/RESERVED_STORAGE_KEYS.md's table format changed \
+             (update parse_reserved_keys_from_doc to match) or the key was \
+             genuinely removed from the table (update this test's expectations).\n"
+        );
+    }
+}
+
+/// The main enforcement check (happy path): no contract in the workspace may
+/// currently store data under a key reserved for a future feature.
+#[test]
+fn no_scanned_crate_uses_a_reserved_storage_key() {
+    let reserved = parse_reserved_keys_from_doc();
+    assert!(
+        !reserved.is_empty(),
+        "reserved-key doc parser returned no keys; see reserved_keys_doc_parses_expected_entries"
+    );
+
+    let violations: Vec<String> = scan_all_crates()
+        .into_iter()
+        .filter(|(_, key)| reserved.contains(key))
+        .map(|(krate, key)| {
+            format!("❌ {krate}: uses '{key}', which is reserved for a future feature")
+        })
+        .collect();
+
+    assert!(
+        violations.is_empty(),
+        "\n\nReserved storage key violations found in live source:\n{}\n\n\
+         A contract stores data under a key reserved for a future roadmap \
+         feature. See docs/RESERVED_STORAGE_KEYS.md for the reserved list \
+         and why it exists, and pick a different, non-reserved key.\n",
+        violations.join("\n")
+    );
+}
+
+/// Explicit failure mode: proves the detector actually flags reuse of a
+/// reserved key. Runs the same extraction + reserved-set check used above
+/// against a synthetic `lib.rs`-shaped snippet rather than mutating real
+/// contract source, so this test documents the failure behavior without
+/// requiring a second, throwaway crate to intentionally break the build.
+#[test]
+fn detector_flags_reserved_key_reuse_in_synthetic_source() {
+    let reserved = parse_reserved_keys_from_doc();
+    assert!(reserved.contains("REWARD_CF"));
+
+    let synthetic_src = r#"
+        use soroban_sdk::{symbol_short, Env, Symbol};
+
+        const KEY_REWARD: Symbol = symbol_short!("REWARD_CF");
+
+        pub fn set_notification(env: Env, enabled: bool) {
+            env.storage().instance().set(&KEY_REWARD, &enabled);
+        }
+    "#;
+
+    let used_keys = extract_storage_keys(synthetic_src);
+    assert!(
+        used_keys.contains("REWARD_CF"),
+        "extractor failed to find the synthetic REWARD_CF usage at all"
+    );
+
+    let violations: Vec<&String> = used_keys.iter().filter(|k| reserved.contains(*k)).collect();
+    assert!(
+        !violations.is_empty(),
+        "detector failed to flag a reserved key ('REWARD_CF') reused in synthetic source"
+    );
+}


### PR DESCRIPTION
docs/RESERVED_STORAGE_KEYS.md documented storage-key prefixes reserved for roadmap features (yield generation, staking, the V2 migration path, etc.) but nothing enforced it - a reviewer had to manually check every PR for reuse of a reserved key.

Add testutils/tests/reserved_storage_keys_test.rs, which parses the reserved-key table directly out of that doc (so the doc stays the single source of truth) and cross-checks it against every storage-key literal actually used in each contract's src/lib.rs, the same way storage_key_source_scan_test.rs already catches naming-convention drift. Wire it into the storage-key-validation CI job.

Also cross-link the reserved-keys doc from README.md and STORAGE_LAYOUT.md, where it was previously orphaned.

Closes #1564