### PR TITLE
DX: auto-regenerate `bindings/` on build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,11 +5,13 @@ Cargo.lock
 .env
 *.log
 
+# Generated client bindings (regenerate with `make bindings`)
+/bindings/
+
 # Local testing scripts
 ci-test.ps1
 test-ci-local.ps1
 test-ci-local.sh
-Makefile
 
 # Documentation files
 *.md

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+CONTRACTS := remittance_split savings_goals bill_payments insurance
+WASM_DIR := target/wasm32-unknown-unknown/release
+BINDINGS_DIR := bindings
+
+.PHONY: wasm bindings build
+
+# Builds every contract's release WASM in one command, matching what CI's
+# "Build workspace (WASM)" step does -- see .github/workflows/ci.yml.
+wasm:
+	cargo build --release --target wasm32-unknown-unknown
+	@echo "WASM output: $(WASM_DIR)/*.wasm"
+
+# Regenerates the TypeScript client bindings for every contract from its
+# just-built WASM. Depends on `wasm` so bindings are always regenerated
+# from current source rather than read from a stale WASM file left over
+# from a previous build.
+bindings: wasm
+	@for contract in $(CONTRACTS); do \
+		echo "Generating bindings for $$contract..."; \
+		stellar contract bindings typescript \
+			--wasm $(WASM_DIR)/$$contract.wasm \
+			--output-dir $(BINDINGS_DIR)/$$contract \
+			--overwrite; \
+	done
+
+# One-command build: WASM plus its bindings, so bindings/ can't drift out
+# of sync with the contracts it was generated from.
+build: bindings


### PR DESCRIPTION
## Summary
Adds `make bindings` and `make build` (`wasm` -> `bindings`) to the Makefile: regenerates each contract's TypeScript client bindings (via `stellar contract bindings typescript`) straight from its just-built WASM, so `bindings/` can never drift out of sync with a stale build. `bindings/` is generated output -- added to `.gitignore` rather than committed, same treatment as `target/`.

Note: this PR's `Makefile`/`.gitignore` changes overlap with #1641 (`make wasm`) since both are independent branches off `main` adding the same new file -- expected to need a rebase against whichever merges first.

## Testing
- `make bindings` -- ran for real: builds all four contracts' WASM, then generates working TypeScript bindings for each into `bindings/<contract>/` (verified `bindings/remittance_split/src/index.ts` etc. were produced)
- `cargo test --workspace`

Closes #1613