### PR TITLE
test: add kill-switch guard, epoch guard tests and recovery doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ To run an example, use `cargo run --example <example_name>`:
 - [Epoch Model](docs/EPOCH_MODEL.md) - How epoch counters bump, what they invalidate, and the stale-authorization replay threat they mitigate in the emergency killswitch and orchestrator contracts
 - [Dispute Epoch Model](docs/DISPUTE_EPOCH_MODEL.md) - Semantics + when dispute epochs bump
 - [Killswitch Trust Model](docs/killswitch-trust-model.md) - Who can trigger, who can clear, what state is preserved in the emergency killswitch
+- [Kill-Switch Recovery Runbook](docs/KILL_SWITCH_RECOVERY.md) - Operator runbook: how to engage the kill switch, verify the freeze, and safely resume operations after an incident
 - [Ledger Monotonicity](docs/LEDGER_MONOTONICITY.md) - Where and why contract code relies on ledger sequence and timestamp monotonicity
 - [Timestamp Conventions](docs/TIMESTAMP_CONVENTIONS.md) - How timestamps are represented, stored, and compared across all contracts
 - [Tagging Feature](TAGGING_FEATURE.md) - Tag-based organization system

--- a/docs/KILL_SWITCH_RECOVERY.md
+++ b/docs/KILL_SWITCH_RECOVERY.md
@@ -1,0 +1,282 @@
+# Kill-Switch Recovery Runbook
+
+**Audience:** Contract operators and on-call engineers.
+
+This document covers the complete lifecycle of a kill-switch event: how to engage
+the kill switch, what happens while it is active, and how to safely resume
+operations after the incident is resolved.
+
+---
+
+## Overview
+
+RemitWise contracts have two complementary write-freeze mechanisms:
+
+| Mechanism | Type | How it clears |
+|---|---|---|
+| **Kill switch** (`KILL_SW`) | Binary toggle — stays active until cleared | Explicit `deactivate_kill_switch` call |
+| **Investigation epoch** (`INV_EPOCH`) | Time-bounded — has an end timestamp | Expires automatically; can be cleared early |
+
+Both mechanisms are implemented in `remitwise-common/src/lib.rs` and are called
+at the top of every write entry point across all contracts.  When either one is
+active, write entry points return a typed error (`KillSwitchError::WriteBlocked`
+or `InvestigationEpochError::WriteBlocked`) without executing any mutations.
+
+Read-only entry points are **not** affected — queries, balance checks, and audit
+log reads continue to work during a freeze.
+
+---
+
+## 1. Engaging the Kill Switch
+
+### When to use it
+
+Activate the binary kill switch when you need an **immediate, indefinite freeze**
+— for example:
+
+* A confirmed exploit or vulnerability that requires triage before any further
+  mutations are allowed.
+* A regulatory or legal hold instruction.
+* An emergency maintenance window where all write paths must be closed.
+
+If you need to freeze writes for a **bounded investigation window** (hours or
+days) and want automatic expiry, use the investigation epoch instead (§ 4).
+
+### How to activate
+
+Call `activate_kill_switch` on the relevant contract.  This sets a `bool` flag
+in instance storage (`KILL_SW = true`).  No arguments are required.  Every
+write entry point that calls `require_no_active_kill_switch` will immediately
+start returning `KillSwitchError::WriteBlocked`.
+
+```bash
+# Example: activate via soroban CLI
+soroban contract invoke \
+  --id <CONTRACT_ID> \
+  --source <ADMIN_KEY> \
+  --network testnet \
+  -- activate_kill_switch
+```
+
+> **Auth note:** `activate_kill_switch` and `deactivate_kill_switch` in
+> `remitwise-common` do **not** enforce their own authentication — the calling
+> contract's entry point is responsible for gating with `admin.require_auth()`.
+> Never expose these helpers via an unauthenticated public entry point.
+
+### What is frozen
+
+Once the kill switch is active, every entry point that calls
+`require_no_active_kill_switch` will reject mutations.  As of the current
+implementation this covers **all write entry points** across:
+
+* `bill_payments`
+* `insurance`
+* `remittance_split`
+* `family_wallet`
+* `savings_goals`
+* `orchestrator`
+* `reporting`
+
+Read-only entry points (`get_*`, `is_*`, `list_*`) continue to work.
+
+---
+
+## 2. Verifying the Kill Switch is Active
+
+```bash
+# Check via soroban CLI
+soroban contract invoke \
+  --id <CONTRACT_ID> \
+  --source <ANY_KEY> \
+  --network testnet \
+  -- is_kill_switch_active
+# Returns: true
+```
+
+Attempt any write to confirm it is blocked:
+
+```bash
+soroban contract invoke \
+  --id <CONTRACT_ID> \
+  --source <USER_KEY> \
+  --network testnet \
+  -- pay_bill --caller <ADDR> --bill_id 1 --amount 1000
+# Error: KillSwitchError::WriteBlocked (contract error code 1)
+```
+
+---
+
+## 3. Clearing the Kill Switch (Recovery)
+
+When the incident is resolved:
+
+1. **Confirm the fix is deployed** (patched WASM uploaded and instance storage
+   migrated if needed).
+2. **Obtain admin authorization** for the deactivation call.
+3. **Call `deactivate_kill_switch`.**
+
+```bash
+soroban contract invoke \
+  --id <CONTRACT_ID> \
+  --source <ADMIN_KEY> \
+  --network testnet \
+  -- deactivate_kill_switch
+```
+
+This removes the `KILL_SW` flag from instance storage.  From this point forward,
+`require_no_active_kill_switch` returns `Ok(())` and write operations resume.
+
+4. **Verify recovery:**
+
+```bash
+soroban contract invoke \
+  --id <CONTRACT_ID> \
+  --source <ANY_KEY> \
+  --network testnet \
+  -- is_kill_switch_active
+# Returns: false
+```
+
+5. **Perform a smoke-test write** (e.g., a test bill payment on testnet) to
+   confirm the entry point is unblocked end-to-end.
+
+### Idempotency guarantee
+
+`deactivate_kill_switch` is a safe no-op when the kill switch is already
+inactive.  Calling it twice or calling it on a never-activated contract will not
+cause any errors or unexpected side effects.
+
+---
+
+## 4. Investigation Epoch (Time-Bounded Alternative)
+
+The investigation epoch (`INV_EPOCH`) is a time-bounded write freeze.  It is
+appropriate when you know in advance how long the freeze should last and want it
+to expire automatically without a manual deactivation step.
+
+### Starting an investigation epoch
+
+```bash
+# Freeze writes for 4 hours (14400 seconds)
+soroban contract invoke \
+  --id <CONTRACT_ID> \
+  --source <ADMIN_KEY> \
+  --network testnet \
+  -- start_investigation_epoch --duration_secs 14400
+```
+
+The contract stores `epoch_end = ledger_timestamp + duration_secs`.  Every write
+entry point that calls `require_no_investigation_epoch` will return
+`InvestigationEpochError::WriteBlocked` until the ledger timestamp reaches
+`epoch_end`.
+
+### Automatic expiry
+
+No action is needed to clear the epoch after `epoch_end` — the next write attempt
+will succeed automatically.
+
+### Early clearance
+
+If the investigation resolves before the epoch expires:
+
+```bash
+soroban contract invoke \
+  --id <CONTRACT_ID> \
+  --source <ADMIN_KEY> \
+  --network testnet \
+  -- clear_investigation_epoch
+```
+
+This removes the `INV_EPOCH` key from instance storage.  `clear_investigation_epoch`
+is also a safe no-op when called on a contract with no active epoch.
+
+---
+
+## 5. Kill-Switch Epoch Guard (emergency_killswitch)
+
+The `emergency_killswitch` contract uses a separate **kill-switch epoch** counter
+(`DataKey::KillSwitchEpoch`) to prevent replay of stale `transfer_admin`
+authorizations.  Every call to `transfer_admin` must supply the current epoch;
+if the epoch does not match exactly, the call is rejected with
+`Error::EpochMismatch`.
+
+### When to bump the epoch
+
+Bump the epoch whenever you need to **invalidate all prior authorizations** —
+for example after a signing key rotation, after a suspected leak of an admin
+authorization payload, or as a precautionary measure after an incident.
+
+```bash
+soroban contract invoke \
+  --id <CONTRACT_ID> \
+  --source <ADMIN_KEY> \
+  --network testnet \
+  -- bump_kill_switch_epoch --caller <ADMIN_ADDR>
+# Returns: new_epoch (u64)
+```
+
+After the bump, any `transfer_admin` call that was authorized at the previous
+epoch will be rejected.  Authorized callers must re-acquire a fresh authorization
+that references the new epoch value.
+
+### Reading the current epoch
+
+```bash
+soroban contract invoke \
+  --id <CONTRACT_ID> \
+  --source <ANY_KEY> \
+  --network testnet \
+  -- get_kill_switch_epoch
+# Returns: current epoch (u64, starts at 0 after initialize)
+```
+
+---
+
+## 6. Checklist
+
+Use this checklist for every kill-switch event:
+
+```
+Engagement
+[ ] Confirmed the incident type warrants a kill switch
+[ ] Admin key secured and available
+[ ] Kill switch activated (or investigation epoch started) on all affected contracts
+[ ] Verified is_kill_switch_active == true (or epoch active) on each contract
+
+During freeze
+[ ] Read-only paths confirmed still operational
+[ ] Incident investigation in progress
+[ ] Patch reviewed and approved
+[ ] Patched WASM built and verified (cargo build --target wasm32-unknown-unknown --release)
+[ ] Patched WASM uploaded to chain
+
+Recovery
+[ ] Deactivation call executed on all contracts (or epoch cleared early)
+[ ] is_kill_switch_active == false confirmed on each contract
+[ ] Smoke-test write executed and succeeded on each contract
+[ ] Kill-switch epoch bumped (if signing key rotation was involved)
+[ ] Incident post-mortem drafted
+```
+
+---
+
+## 7. Related Documentation
+
+* [Killswitch Trust Model](killswitch-trust-model.md) — who can trigger, who
+  can clear, what state is preserved
+* [Pause Playbook](PAUSE_PLAYBOOK.md) — granular pause controls (module/function
+  level) managed by the `emergency_killswitch` contract
+* [Epoch Model](EPOCH_MODEL.md) — how epoch counters bump, what they invalidate,
+  and the stale-authorization replay threat
+* [Cross-Contract Invariants](CROSS_CONTRACT_INVARIANTS.md) — kill switch as a
+  cross-contract invariant in the reviewer checklist
+* [Migration Flags](MIGRATION_FLAGS.md) — investigation-epoch write freezes
+  during data migration
+
+---
+
+## 8. Emergency Contacts
+
+This document intentionally does not list specific engineer contacts (they
+change frequently).  Consult your team's on-call rotation and escalation policy
+for the current contact list.

--- a/emergency_killswitch/src/lib.rs
+++ b/emergency_killswitch/src/lib.rs
@@ -785,3 +785,273 @@ mod tests {
         assert_eq!(res, Err(Ok(Error::Unauthorized)));
     }
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Expanded kill-switch-epoch guard tests (#1293)
+//
+// Covers: same epoch, off-by-one (too low, too high), ancient epoch,
+// consecutive bumps, replay with stale epoch, epoch boundary semantics,
+// and error discriminant stability.
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod kill_switch_epoch_guard_comprehensive_tests {
+    use super::*;
+    use soroban_sdk::testutils::Address as _;
+
+    fn setup() -> (Env, EmergencyKillswitchClient<'static>, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, EmergencyKillswitch);
+        let client = EmergencyKillswitchClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+        (env, client, admin)
+    }
+
+    // ── Happy path: exact epoch match ─────────────────────────────────────
+
+    /// `require_killswitch_epoch` passes when the caller supplies the correct
+    /// epoch (0 immediately after initialization).
+    #[test]
+    fn correct_epoch_zero_passes_after_init() {
+        let (_env, client, _admin) = setup();
+        let res = client.try_require_killswitch_epoch(&0u64);
+        assert_eq!(res, Ok(Ok(())));
+    }
+
+    /// After one bump the epoch is 1; supplying 1 must pass.
+    #[test]
+    fn correct_epoch_one_passes_after_single_bump() {
+        let (_env, client, admin) = setup();
+        client.bump_kill_switch_epoch(&admin);
+        let res = client.try_require_killswitch_epoch(&1u64);
+        assert_eq!(res, Ok(Ok(())));
+    }
+
+    /// After multiple consecutive bumps, supplying the resulting epoch passes.
+    #[test]
+    fn correct_epoch_passes_after_five_consecutive_bumps() {
+        let (_env, client, admin) = setup();
+        let mut last = 0u64;
+        for _ in 0..5 {
+            last = client.bump_kill_switch_epoch(&admin);
+        }
+        assert_eq!(last, 5);
+        let res = client.try_require_killswitch_epoch(&5u64);
+        assert_eq!(res, Ok(Ok(())));
+    }
+
+    // ── Off-by-one: one below current epoch ───────────────────────────────
+
+    /// Supplying epoch = current - 1 (one below) is rejected with EpochMismatch.
+    /// This is the classic "stale authorization" off-by-one.
+    #[test]
+    fn one_below_current_epoch_rejected_off_by_one() {
+        let (_env, client, admin) = setup();
+        client.bump_kill_switch_epoch(&admin); // epoch is now 1
+
+        // Supply 0 (one below current 1) — must fail.
+        let res = client.try_require_killswitch_epoch(&0u64);
+        assert_eq!(res, Err(Ok(Error::EpochMismatch)));
+    }
+
+    /// Supplying epoch = current + 1 (one above) is also rejected — the guard
+    /// requires an exact match, not just >= or <=.
+    #[test]
+    fn one_above_current_epoch_rejected_off_by_one() {
+        let (_env, client, _admin) = setup();
+        // Epoch is 0 after init; supply 1 (one above).
+        let res = client.try_require_killswitch_epoch(&1u64);
+        assert_eq!(res, Err(Ok(Error::EpochMismatch)));
+    }
+
+    // ── Ancient epoch ─────────────────────────────────────────────────────
+
+    /// An ancient epoch (many bumps ago) is rejected. Pins that the guard does
+    /// not compare with >= (which would allow old epochs after bumps).
+    #[test]
+    fn ancient_epoch_rejected_after_many_bumps() {
+        let (_env, client, admin) = setup();
+        // Bump 10 times — current epoch is now 10.
+        for _ in 0..10 {
+            client.bump_kill_switch_epoch(&admin);
+        }
+
+        // Epoch 0 (the initial value, now 10 bumps stale) must be rejected.
+        let res = client.try_require_killswitch_epoch(&0u64);
+        assert_eq!(res, Err(Ok(Error::EpochMismatch)));
+
+        // Epoch 5 (half-stale) must also be rejected.
+        let res = client.try_require_killswitch_epoch(&5u64);
+        assert_eq!(res, Err(Ok(Error::EpochMismatch)));
+    }
+
+    // ── Replay attack simulation ──────────────────────────────────────────
+
+    /// Simulate a replay attack: obtain a valid authorization at epoch N,
+    /// bump the epoch to N+1, then try to replay the old authorization.
+    /// The replay must fail with EpochMismatch.
+    #[test]
+    fn stale_authorization_replay_rejected_after_epoch_bump() {
+        let (env, client, admin) = setup();
+        let new_admin = Address::generate(&env);
+
+        // Capture current epoch (0) — represents a "signed" transfer_admin call.
+        let captured_epoch = client.get_kill_switch_epoch();
+        assert_eq!(captured_epoch, 0);
+
+        // Transfer to new_admin using epoch 0 (valid at capture time).
+        let res = client.try_transfer_admin(&new_admin, &captured_epoch);
+        assert_eq!(res, Ok(Ok(())));
+
+        // New admin bumps the epoch to invalidate any further epoch-0 auths.
+        let new_epoch = client.bump_kill_switch_epoch(&new_admin);
+        assert_eq!(new_epoch, 1);
+
+        // A second address tries to replay the old epoch-0 authorization.
+        let another_admin = Address::generate(&env);
+        let replay = client.try_transfer_admin(&another_admin, &captured_epoch);
+        assert_eq!(
+            replay,
+            Err(Ok(Error::EpochMismatch)),
+            "replay with stale epoch must be rejected after bump"
+        );
+    }
+
+    // ── Consecutive bump semantics ────────────────────────────────────────
+
+    /// Every bump increments by exactly one and returns the new epoch.
+    #[test]
+    fn consecutive_bumps_increment_by_one_and_return_new_epoch() {
+        let (_env, client, admin) = setup();
+        for expected_new in 1u64..=10 {
+            let returned = client.bump_kill_switch_epoch(&admin);
+            assert_eq!(
+                returned, expected_new,
+                "bump must return the new epoch (expected {expected_new})"
+            );
+            let stored = client.get_kill_switch_epoch();
+            assert_eq!(
+                stored, expected_new,
+                "stored epoch must equal returned epoch after bump {expected_new}"
+            );
+        }
+    }
+
+    /// After each bump, the previous epoch is immediately rejected.
+    #[test]
+    fn previous_epoch_rejected_immediately_after_each_bump() {
+        let (_env, client, admin) = setup();
+        for bump_count in 1u64..=5 {
+            client.bump_kill_switch_epoch(&admin);
+            // The epoch that was valid before this bump is now stale.
+            let stale_epoch = bump_count - 1;
+            let res = client.try_require_killswitch_epoch(&stale_epoch);
+            assert_eq!(
+                res,
+                Err(Ok(Error::EpochMismatch)),
+                "epoch {stale_epoch} must be rejected immediately after bump to {bump_count}"
+            );
+        }
+    }
+
+    // ── Epoch at boundary: u64::MAX - 1 ──────────────────────────────────
+
+    /// The overflow guard in `bump_kill_switch_epoch` uses `checked_add`, which
+    /// returns an error (mapped to `Error::InvalidAdmin`) when the epoch would
+    /// wrap past u64::MAX.  This test bumps to u64::MAX - 1 via storage
+    /// manipulation to verify the overflow guard fires on the next bump.
+    ///
+    /// We write the epoch directly to instance storage to avoid the prohibitive
+    /// cost of calling `bump_kill_switch_epoch` u64::MAX - 1 times.
+    #[test]
+    fn overflow_guard_fires_at_u64_max() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, EmergencyKillswitch);
+        let client = EmergencyKillswitchClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        // Inject u64::MAX directly into instance storage — the contract's
+        // bump function uses checked_add so the next bump must overflow.
+        env.as_contract(&contract_id, || {
+            env.storage()
+                .instance()
+                .set(&DataKey::KillSwitchEpoch, &u64::MAX);
+        });
+
+        assert_eq!(client.get_kill_switch_epoch(), u64::MAX);
+
+        // The next bump would overflow u64 — must return an error.
+        let res = client.try_bump_kill_switch_epoch(&admin);
+        // bump_kill_switch_epoch maps checked_add None to Error::InvalidAdmin
+        assert_eq!(res, Err(Ok(Error::InvalidAdmin)));
+    }
+
+    // ── Error discriminant stability ──────────────────────────────────────
+
+    /// The EpochMismatch discriminant must be 7 (ABI contract — pinned for
+    /// encoding stability across contract versions and downstream integrators).
+    #[test]
+    fn epoch_mismatch_error_discriminant_is_seven() {
+        assert_eq!(
+            Error::EpochMismatch as u32,
+            7u32,
+            "Error::EpochMismatch discriminant must be 7 (ABI contract)"
+        );
+    }
+
+    // ── get_kill_switch_epoch — observable without auth ───────────────────
+
+    /// `get_kill_switch_epoch` always reflects the current epoch and its
+    /// return value matches what `bump_kill_switch_epoch` reports.
+    #[test]
+    fn get_kill_switch_epoch_reflects_current_epoch_after_bumps() {
+        let (_env, client, admin) = setup();
+
+        // Before any bump: epoch must be 0.
+        assert_eq!(client.get_kill_switch_epoch(), 0);
+
+        // After first bump: epoch must be 1.
+        client.bump_kill_switch_epoch(&admin);
+        assert_eq!(client.get_kill_switch_epoch(), 1);
+
+        // After second bump: epoch must be 2.
+        client.bump_kill_switch_epoch(&admin);
+        assert_eq!(
+            client.get_kill_switch_epoch(),
+            2,
+            "get_kill_switch_epoch must return 2 after two bumps"
+        );
+    }
+
+    // ── transfer_admin epoch binding ──────────────────────────────────────
+
+    /// `transfer_admin` requires the caller to supply the current epoch. A
+    /// call with a future epoch (one not yet reached) must also fail, preventing
+    /// pre-authorization for a future epoch.
+    #[test]
+    fn transfer_admin_with_future_epoch_rejected() {
+        let (env, client, _admin) = setup();
+        let new_admin = Address::generate(&env);
+        // Current epoch is 0; supply 99 (future, never bumped to).
+        let res = client.try_transfer_admin(&new_admin, &99u64);
+        assert_eq!(
+            res,
+            Err(Ok(Error::EpochMismatch)),
+            "transfer_admin with future epoch must be rejected"
+        );
+    }
+
+    /// `transfer_admin` with epoch 0 at initialization succeeds, confirming
+    /// the default epoch from `initialize` is 0 and is the only valid value.
+    #[test]
+    fn transfer_admin_with_correct_epoch_zero_succeeds() {
+        let (env, client, _admin) = setup();
+        let new_admin = Address::generate(&env);
+        let res = client.try_transfer_admin(&new_admin, &0u64);
+        assert_eq!(res, Ok(Ok(())));
+    }
+}

--- a/remitwise-common/src/tests.rs
+++ b/remitwise-common/src/tests.rs
@@ -2260,3 +2260,672 @@ fn test_require_registered_operator_fails_if_missing() {
     let result = require_registered_operator(&env, &caller);
     assert_eq!(result, Err(OperatorError::NotRegistered));
 }
+
+// ============================================================================
+// Kill-switch guard comprehensive tests (#1290)
+// ============================================================================
+//
+// These tests lock in every observable behaviour of the kill-switch guard:
+//  - Default state (no flag set → inactive, writes allowed)
+//  - Activation makes `is_kill_switch_active` return true
+//  - `require_no_active_kill_switch` returns WriteBlocked when active
+//  - Deactivation clears the flag and restores write permission
+//  - Idempotent activation (double-activate remains blocked)
+//  - Idempotent deactivation (double-deactivate remains clear)
+//  - Multiple activate/deactivate cycles (toggle durability)
+//  - Storage isolation: independent envs do not share kill-switch state
+//  - Error discriminant is stable at 1 (ABI contract pinned)
+//  - Error round-trips through Val encoding
+//  - `require_no_active_kill_switch` is the single canonical guard call-sites
+//    must use — callers may not bypass it by checking `is_kill_switch_active`
+//    directly and inverting the result (both are tested to be equivalent)
+
+#[cfg(test)]
+mod kill_switch_guard_comprehensive_tests {
+    use crate::{
+        activate_kill_switch, deactivate_kill_switch, is_kill_switch_active,
+        require_no_active_kill_switch, KillSwitchError,
+    };
+    use soroban_sdk::Env;
+
+    // ── Happy-path (inactive) ─────────────────────────────────────────────
+
+    /// The kill switch is inactive by default: no storage has been set.
+    /// `is_kill_switch_active` must return false and `require_no_active_kill_switch`
+    /// must return Ok(()).
+    #[test]
+    fn inactive_by_default_allows_writes() {
+        let env = Env::default();
+        assert!(
+            !is_kill_switch_active(&env),
+            "kill switch must be inactive when no flag is stored"
+        );
+        assert_eq!(
+            require_no_active_kill_switch(&env),
+            Ok(()),
+            "guard must pass when kill switch has never been activated"
+        );
+    }
+
+    /// After deactivation on a fresh environment (never activated), the state
+    /// remains inactive — deactivate is a safe no-op.
+    #[test]
+    fn deactivate_on_pristine_env_is_safe_noop() {
+        let env = Env::default();
+        deactivate_kill_switch(&env);
+        assert!(
+            !is_kill_switch_active(&env),
+            "deactivating a never-activated kill switch must leave it inactive"
+        );
+        assert_eq!(
+            require_no_active_kill_switch(&env),
+            Ok(()),
+            "guard must pass after deactivating a never-activated kill switch"
+        );
+    }
+
+    // ── Sad-path (active) ─────────────────────────────────────────────────
+
+    /// Activating the kill switch must make `is_kill_switch_active` return true
+    /// and `require_no_active_kill_switch` return `Err(WriteBlocked)`.
+    #[test]
+    fn activate_blocks_writes_with_typed_error() {
+        let env = Env::default();
+        activate_kill_switch(&env);
+
+        assert!(
+            is_kill_switch_active(&env),
+            "is_kill_switch_active must return true immediately after activation"
+        );
+        assert_eq!(
+            require_no_active_kill_switch(&env),
+            Err(KillSwitchError::WriteBlocked),
+            "guard must return WriteBlocked after activation"
+        );
+    }
+
+    /// The typed error discriminant must be 1 (pinned for ABI stability across
+    /// contract versions and downstream integrators).
+    #[test]
+    fn write_blocked_error_discriminant_is_one() {
+        assert_eq!(
+            KillSwitchError::WriteBlocked as u32,
+            1u32,
+            "KillSwitchError::WriteBlocked discriminant must be 1 (ABI contract)"
+        );
+    }
+
+    /// The error round-trips through Val encoding (encoding stability guard).
+    #[test]
+    fn write_blocked_error_round_trips_through_val_encoding() {
+        use soroban_sdk::{IntoVal, TryFromVal};
+        let env = Env::default();
+        let val: soroban_sdk::Val = KillSwitchError::WriteBlocked.into_val(&env);
+        let decoded: KillSwitchError =
+            KillSwitchError::try_from_val(&env, &val).expect("KillSwitchError must round-trip");
+        assert_eq!(
+            decoded,
+            KillSwitchError::WriteBlocked,
+            "round-trip must preserve WriteBlocked"
+        );
+    }
+
+    // ── Recovery (deactivation) ───────────────────────────────────────────
+
+    /// After activation and then deactivation, writes are allowed again.
+    #[test]
+    fn deactivate_after_activate_allows_writes_again() {
+        let env = Env::default();
+        activate_kill_switch(&env);
+        assert!(is_kill_switch_active(&env));
+
+        deactivate_kill_switch(&env);
+
+        assert!(
+            !is_kill_switch_active(&env),
+            "is_kill_switch_active must return false after deactivation"
+        );
+        assert_eq!(
+            require_no_active_kill_switch(&env),
+            Ok(()),
+            "guard must pass after deactivation"
+        );
+    }
+
+    // ── Idempotency ───────────────────────────────────────────────────────
+
+    /// Double-activation: activating twice in a row must leave the kill switch active.
+    #[test]
+    fn double_activate_remains_blocked() {
+        let env = Env::default();
+        activate_kill_switch(&env);
+        activate_kill_switch(&env); // second call must not clear the flag
+
+        assert!(
+            is_kill_switch_active(&env),
+            "double-activate must keep kill switch active"
+        );
+        assert_eq!(
+            require_no_active_kill_switch(&env),
+            Err(KillSwitchError::WriteBlocked),
+            "guard must remain blocked after double-activate"
+        );
+    }
+
+    /// Double-deactivation: deactivating twice must keep the kill switch inactive.
+    #[test]
+    fn double_deactivate_remains_clear() {
+        let env = Env::default();
+        activate_kill_switch(&env);
+        deactivate_kill_switch(&env);
+        deactivate_kill_switch(&env); // second deactivate must not re-arm
+
+        assert!(
+            !is_kill_switch_active(&env),
+            "double-deactivate must keep kill switch inactive"
+        );
+        assert_eq!(
+            require_no_active_kill_switch(&env),
+            Ok(()),
+            "guard must pass after double-deactivate"
+        );
+    }
+
+    // ── Toggle durability ─────────────────────────────────────────────────
+
+    /// Three full activate/deactivate cycles must each independently produce
+    /// the expected state, proving the flag is written and removed correctly
+    /// across repeated operations.
+    #[test]
+    fn three_full_toggle_cycles_produce_correct_state() {
+        let env = Env::default();
+
+        for cycle in 1u32..=3 {
+            // Activate
+            activate_kill_switch(&env);
+            assert!(
+                is_kill_switch_active(&env),
+                "cycle {cycle}: expected active after activate"
+            );
+            assert_eq!(
+                require_no_active_kill_switch(&env),
+                Err(KillSwitchError::WriteBlocked),
+                "cycle {cycle}: guard must block after activate"
+            );
+
+            // Deactivate
+            deactivate_kill_switch(&env);
+            assert!(
+                !is_kill_switch_active(&env),
+                "cycle {cycle}: expected inactive after deactivate"
+            );
+            assert_eq!(
+                require_no_active_kill_switch(&env),
+                Ok(()),
+                "cycle {cycle}: guard must pass after deactivate"
+            );
+        }
+    }
+
+    // ── Storage isolation ─────────────────────────────────────────────────
+
+    /// Two independent `Env` instances must not share kill-switch state.
+    /// Activating in one must not affect the other.
+    #[test]
+    fn kill_switch_state_is_isolated_per_env() {
+        let env_a = Env::default();
+        let env_b = Env::default();
+
+        activate_kill_switch(&env_a);
+
+        assert!(
+            is_kill_switch_active(&env_a),
+            "env_a kill switch must be active"
+        );
+        assert!(
+            !is_kill_switch_active(&env_b),
+            "env_b kill switch must remain inactive when only env_a was activated"
+        );
+        assert_eq!(
+            require_no_active_kill_switch(&env_b),
+            Ok(()),
+            "guard on env_b must pass when env_a was activated"
+        );
+    }
+
+    // ── Guard equivalence ─────────────────────────────────────────────────
+
+    /// `require_no_active_kill_switch` and `!is_kill_switch_active` must agree
+    /// in every state. This pins the contract that the guard is the canonical
+    /// call-site and is not just a thin wrapper that could silently diverge.
+    #[test]
+    fn guard_result_matches_negated_is_active_in_all_states() {
+        let env = Env::default();
+
+        // Inactive
+        assert_eq!(
+            require_no_active_kill_switch(&env).is_ok(),
+            !is_kill_switch_active(&env),
+            "inactive: guard result must equal !is_kill_switch_active"
+        );
+
+        // Active
+        activate_kill_switch(&env);
+        assert_eq!(
+            require_no_active_kill_switch(&env).is_ok(),
+            !is_kill_switch_active(&env),
+            "active: guard result must equal !is_kill_switch_active"
+        );
+
+        // Deactivated again
+        deactivate_kill_switch(&env);
+        assert_eq!(
+            require_no_active_kill_switch(&env).is_ok(),
+            !is_kill_switch_active(&env),
+            "deactivated: guard result must equal !is_kill_switch_active"
+        );
+    }
+
+    // ── Boundary: simulate a write entry-point being guarded ─────────────
+
+    /// Simulates the pattern used in every write entry point:
+    /// `require_no_active_kill_switch` is called first; if it returns Err the
+    /// entry point must propagate the error without executing any mutations.
+    ///
+    /// This test pins both the "before kill-switch" and "after kill-switch"
+    /// paths of a typical guarded write entry point.
+    #[test]
+    fn guarded_write_entrypoint_simulation_passes_and_fails_correctly() {
+        let env = Env::default();
+        let mut mutated = false;
+
+        // Happy path: guard passes, mutation proceeds.
+        let result: Result<(), KillSwitchError> = (|| {
+            require_no_active_kill_switch(&env)?;
+            mutated = true;
+            Ok(())
+        })();
+        assert_eq!(result, Ok(()));
+        assert!(mutated, "mutation must occur when kill switch is inactive");
+
+        // Sad path: guard blocks, mutation must NOT occur.
+        mutated = false;
+        activate_kill_switch(&env);
+
+        let result: Result<(), KillSwitchError> = (|| {
+            require_no_active_kill_switch(&env)?;
+            mutated = true; // must not be reached
+            Ok(())
+        })();
+        assert_eq!(result, Err(KillSwitchError::WriteBlocked));
+        assert!(
+            !mutated,
+            "mutation must NOT occur when kill switch is active"
+        );
+
+        // Recovery: deactivate and verify mutation proceeds again.
+        mutated = false;
+        deactivate_kill_switch(&env);
+
+        let result: Result<(), KillSwitchError> = (|| {
+            require_no_active_kill_switch(&env)?;
+            mutated = true;
+            Ok(())
+        })();
+        assert_eq!(result, Ok(()));
+        assert!(
+            mutated,
+            "mutation must resume after kill switch is deactivated"
+        );
+    }
+}
+
+// ============================================================================
+// Investigation epoch guard comprehensive tests (#1293 — common-lib side)
+// ============================================================================
+//
+// `investigation_epoch` is the time-bounded sibling of the binary kill switch.
+// These tests lock in:
+//  - Default state: no epoch active → writes allowed
+//  - Starting an epoch blocks writes for its duration
+//  - After the epoch expires, writes are allowed again
+//  - Clearing an active epoch immediately restores writes
+//  - Clearing an already-expired/nonexistent epoch is a safe no-op
+//  - Off-by-one: ledger timestamp exactly at epoch_end is NOT active
+//    (the guard uses strict >, so epoch_end is the first allowed timestamp)
+//  - Back-to-back epochs (new epoch started before old one expires)
+//  - Epoch error discriminant is stable
+
+#[cfg(test)]
+mod investigation_epoch_guard_comprehensive_tests {
+    use crate::{
+        clear_investigation_epoch, is_investigation_epoch_active, require_no_investigation_epoch,
+        start_investigation_epoch, InvestigationEpochError,
+    };
+    use soroban_sdk::testutils::{Ledger, LedgerInfo};
+    use soroban_sdk::Env;
+
+    /// Set the ledger timestamp, preserving all other ledger state.
+    fn set_ts(env: &Env, timestamp: u64) {
+        let proto = env.ledger().protocol_version();
+        let seq = env.ledger().sequence();
+        env.ledger().set(LedgerInfo {
+            protocol_version: proto,
+            sequence_number: seq,
+            timestamp,
+            network_id: [0; 32],
+            base_reserve: 10,
+            min_temp_entry_ttl: 1,
+            min_persistent_entry_ttl: 1,
+            max_entry_ttl: 3_000_000,
+        });
+    }
+
+    const T0: u64 = 1_000_000; // baseline timestamp
+    const DURATION: u64 = 3_600; // 1 hour
+
+    // ── Happy path (no epoch active) ──────────────────────────────────────
+
+    /// No epoch stored: writes are allowed by default.
+    #[test]
+    fn no_epoch_set_allows_writes() {
+        let env = Env::default();
+        set_ts(&env, T0);
+
+        assert!(
+            !is_investigation_epoch_active(&env),
+            "no epoch active by default"
+        );
+        assert_eq!(
+            require_no_investigation_epoch(&env),
+            Ok(()),
+            "guard must pass when no epoch is set"
+        );
+    }
+
+    // ── Sad path (epoch active) ───────────────────────────────────────────
+
+    /// Starting an epoch immediately blocks writes.
+    #[test]
+    fn active_epoch_blocks_writes() {
+        let env = Env::default();
+        set_ts(&env, T0);
+
+        start_investigation_epoch(&env, DURATION);
+
+        assert!(
+            is_investigation_epoch_active(&env),
+            "epoch must be active immediately after start"
+        );
+        assert_eq!(
+            require_no_investigation_epoch(&env),
+            Err(InvestigationEpochError::WriteBlocked),
+            "guard must return WriteBlocked during active epoch"
+        );
+    }
+
+    // ── Expiry ────────────────────────────────────────────────────────────
+
+    /// After the epoch duration has elapsed, writes are allowed again without
+    /// any explicit `clear` call — expiry is automatic.
+    #[test]
+    fn epoch_expires_automatically_after_duration() {
+        let env = Env::default();
+        set_ts(&env, T0);
+        start_investigation_epoch(&env, DURATION);
+
+        // Advance past the epoch end
+        set_ts(&env, T0 + DURATION + 1);
+
+        assert!(
+            !is_investigation_epoch_active(&env),
+            "epoch must be inactive after its duration has elapsed"
+        );
+        assert_eq!(
+            require_no_investigation_epoch(&env),
+            Ok(()),
+            "guard must pass after epoch expires"
+        );
+    }
+
+    // ── Off-by-one: strict boundary ───────────────────────────────────────
+
+    /// At exactly `epoch_end` the epoch is NOT active (the guard uses `>`, so
+    /// `epoch_end == timestamp` means the epoch has just expired).
+    #[test]
+    fn epoch_inactive_at_exact_end_timestamp() {
+        let env = Env::default();
+        set_ts(&env, T0);
+        start_investigation_epoch(&env, DURATION);
+
+        let epoch_end = T0 + DURATION;
+        set_ts(&env, epoch_end);
+
+        assert!(
+            !is_investigation_epoch_active(&env),
+            "epoch must be inactive at the exact epoch_end timestamp (guard uses strict >)"
+        );
+        assert_eq!(
+            require_no_investigation_epoch(&env),
+            Ok(()),
+            "guard must pass at exact epoch_end"
+        );
+    }
+
+    /// One second BEFORE epoch_end the epoch is still active.
+    #[test]
+    fn epoch_still_active_one_second_before_end() {
+        let env = Env::default();
+        set_ts(&env, T0);
+        start_investigation_epoch(&env, DURATION);
+
+        let one_before_end = T0 + DURATION - 1;
+        set_ts(&env, one_before_end);
+
+        assert!(
+            is_investigation_epoch_active(&env),
+            "epoch must still be active one second before epoch_end"
+        );
+        assert_eq!(
+            require_no_investigation_epoch(&env),
+            Err(InvestigationEpochError::WriteBlocked),
+            "guard must block one second before epoch_end"
+        );
+    }
+
+    // ── Immediate clear ───────────────────────────────────────────────────
+
+    /// Clearing an active epoch immediately restores writes (before expiry).
+    #[test]
+    fn clear_active_epoch_immediately_allows_writes() {
+        let env = Env::default();
+        set_ts(&env, T0);
+        start_investigation_epoch(&env, DURATION);
+
+        assert!(is_investigation_epoch_active(&env));
+
+        clear_investigation_epoch(&env);
+
+        assert!(
+            !is_investigation_epoch_active(&env),
+            "epoch must be inactive immediately after clear"
+        );
+        assert_eq!(
+            require_no_investigation_epoch(&env),
+            Ok(()),
+            "guard must pass immediately after clear"
+        );
+    }
+
+    /// Clearing when no epoch is active is a safe no-op.
+    #[test]
+    fn clear_nonexistent_epoch_is_safe_noop() {
+        let env = Env::default();
+        set_ts(&env, T0);
+
+        // Must not panic
+        clear_investigation_epoch(&env);
+
+        assert!(
+            !is_investigation_epoch_active(&env),
+            "state must remain inactive after no-op clear"
+        );
+        assert_eq!(
+            require_no_investigation_epoch(&env),
+            Ok(()),
+            "guard must still pass after no-op clear"
+        );
+    }
+
+    /// Clearing an already-expired epoch is also a safe no-op.
+    #[test]
+    fn clear_expired_epoch_is_safe_noop() {
+        let env = Env::default();
+        set_ts(&env, T0);
+        start_investigation_epoch(&env, DURATION);
+
+        // Let it expire
+        set_ts(&env, T0 + DURATION + 1);
+        assert!(!is_investigation_epoch_active(&env));
+
+        // Explicitly clear — must not panic or re-arm the epoch
+        clear_investigation_epoch(&env);
+
+        assert!(
+            !is_investigation_epoch_active(&env),
+            "epoch must remain inactive after clearing an expired epoch"
+        );
+    }
+
+    // ── Back-to-back epochs ───────────────────────────────────────────────
+
+    /// Starting a new epoch while one is still active replaces (extends) it.
+    #[test]
+    fn new_epoch_while_active_extends_block() {
+        let env = Env::default();
+        set_ts(&env, T0);
+        start_investigation_epoch(&env, DURATION);
+
+        // Advance to 1 second before the first epoch ends, then start a new one
+        let mid = T0 + DURATION - 1;
+        set_ts(&env, mid);
+        start_investigation_epoch(&env, DURATION); // new end = mid + DURATION
+
+        // Original epoch_end (T0 + DURATION) has passed but new one is active
+        let new_epoch_end = mid + DURATION;
+        set_ts(&env, T0 + DURATION + 1); // past original, still in new
+
+        assert!(
+            is_investigation_epoch_active(&env),
+            "new epoch must still be active after original epoch_end"
+        );
+
+        // Jump to exactly new_epoch_end — must be inactive
+        set_ts(&env, new_epoch_end);
+        assert!(
+            !is_investigation_epoch_active(&env),
+            "new epoch must expire at its own epoch_end"
+        );
+    }
+
+    /// Starting an epoch after a previous one expired resets the guard.
+    #[test]
+    fn new_epoch_after_expiry_reinstates_block() {
+        let env = Env::default();
+        set_ts(&env, T0);
+        start_investigation_epoch(&env, DURATION);
+
+        // Let the first epoch expire
+        set_ts(&env, T0 + DURATION + 1);
+        assert!(!is_investigation_epoch_active(&env));
+
+        // Start a fresh epoch at the current time
+        let t1 = T0 + DURATION + 1;
+        set_ts(&env, t1);
+        start_investigation_epoch(&env, DURATION);
+
+        // Immediately: must be active
+        assert!(
+            is_investigation_epoch_active(&env),
+            "fresh epoch must block immediately after starting"
+        );
+        assert_eq!(
+            require_no_investigation_epoch(&env),
+            Err(InvestigationEpochError::WriteBlocked),
+            "guard must block after fresh epoch starts"
+        );
+
+        // Expire the second epoch
+        set_ts(&env, t1 + DURATION + 1);
+        assert!(
+            !is_investigation_epoch_active(&env),
+            "second epoch must expire after its duration"
+        );
+    }
+
+    // ── Error discriminant stability ──────────────────────────────────────
+
+    /// The `WriteBlocked` discriminant must be 1 (ABI contract — pinned for
+    /// encoding stability across contract upgrades and downstream integrators).
+    #[test]
+    fn write_blocked_discriminant_is_one() {
+        assert_eq!(
+            InvestigationEpochError::WriteBlocked as u32,
+            1u32,
+            "InvestigationEpochError::WriteBlocked discriminant must be 1 (ABI contract)"
+        );
+    }
+
+    /// The error round-trips through Val encoding.
+    #[test]
+    fn write_blocked_error_round_trips_through_val() {
+        use soroban_sdk::{IntoVal, TryFromVal};
+        let env = Env::default();
+        let val: soroban_sdk::Val = InvestigationEpochError::WriteBlocked.into_val(&env);
+        let decoded = InvestigationEpochError::try_from_val(&env, &val)
+            .expect("InvestigationEpochError must round-trip through Val");
+        assert_eq!(decoded, InvestigationEpochError::WriteBlocked);
+    }
+
+    // ── Zero-duration epoch ───────────────────────────────────────────────
+
+    /// A zero-duration epoch expires immediately (epoch_end == T0 and the
+    /// guard checks `epoch_end > timestamp`, so it is never active).
+    #[test]
+    fn zero_duration_epoch_is_never_active() {
+        let env = Env::default();
+        set_ts(&env, T0);
+        start_investigation_epoch(&env, 0);
+
+        assert!(
+            !is_investigation_epoch_active(&env),
+            "zero-duration epoch must never be active (epoch_end == now, guard uses strict >)"
+        );
+        assert_eq!(
+            require_no_investigation_epoch(&env),
+            Ok(()),
+            "guard must pass for zero-duration epoch"
+        );
+    }
+
+    // ── u64 saturation boundary ───────────────────────────────────────────
+
+    /// `start_investigation_epoch` uses `saturating_add` for the end time.
+    /// At `u64::MAX` ledger time + any duration, the epoch_end saturates at
+    /// `u64::MAX`. The guard compares `epoch_end > timestamp`; at exactly
+    /// `u64::MAX` they are equal, so the guard passes (epoch not active).
+    #[test]
+    fn saturation_at_u64_max_does_not_panic() {
+        let env = Env::default();
+        set_ts(&env, u64::MAX);
+        // Must not panic even though saturating_add overflows conceptually
+        start_investigation_epoch(&env, u64::MAX);
+
+        // epoch_end == u64::MAX::saturating_add(u64::MAX) == u64::MAX
+        // timestamp == u64::MAX → epoch_end == timestamp → NOT active
+        assert!(
+            !is_investigation_epoch_active(&env),
+            "saturated epoch_end == timestamp must not be considered active"
+        );
+    }
+}


### PR DESCRIPTION
Closes #1290 Closes #1291 Closes #1293

remitwise-common/src/tests.rs
- Add kill_switch_guard_comprehensive_tests (12 tests): default inactive state, activation/deactivation, idempotency, three-cycle toggle durability, env isolation, guard-vs-flag equivalence, error discriminant stability, Val round-trip, entry-point simulation.
- Add investigation_epoch_guard_comprehensive_tests (13 tests): default inactive, active epoch blocks, automatic expiry, off-by-one at exact epoch_end, early clear, no-op clear, back-to-back epochs, error discriminant stability, Val round-trip, zero-duration, u64::MAX saturation.

emergency_killswitch/src/lib.rs
- Add kill_switch_epoch_guard_comprehensive_tests (13 tests): correct epoch passes, off-by-one below and above current epoch, ancient epoch rejected after many bumps, replay attack simulation, consecutive bumps increment by 1, previous epoch rejected immediately after each bump, overflow guard at u64::MAX, EpochMismatch discriminant == 7, future epoch pre-authorization rejected, transfer_admin happy path.

docs/KILL_SWITCH_RECOVERY.md (new)
- Operator runbook: engaging the binary kill switch, verifying the freeze, clearing it, using the time-bounded investigation epoch, bumping the kill-switch epoch to invalidate stale authorizations, operator checklist, and cross-links to related docs.

README.md
- Link docs/KILL_SWITCH_RECOVERY.md alongside the Killswitch Trust Model entry.
closes #1290 
closes #1291 
closes #1293 