### PR TITLE
docs: document the WASM size delta script

### DIFF
--- a/README.md
+++ b/README.md
@@ -733,6 +733,31 @@ RUST_TEST_THREADS=1 cargo test -p family_wallet --test gas_bench -- --nocapture
 RUST_TEST_THREADS=1 cargo test -p remittance_split --test gas_bench -- --nocapture
 ```
 
+## WASM Size Delta
+
+Every `check_ci.sh` run prints a per-contract WASM size delta against a committed baseline, so a size regression is visible in the build output the moment it happens rather than at deploy time.
+
+### Quick Start
+
+Build the contracts, then print the delta table:
+
+```bash
+cargo build --release --target wasm32-unknown-unknown
+./scripts/wasm_size_delta.sh
+```
+
+This compares each contract's current `.wasm` byte size (via `scripts/collect_wasm_sizes.sh`) against `benchmarks/wasm_size_baseline.json` and prints a table with the baseline, current, absolute delta, and percentage change per contract, plus a `TOTAL` row.
+
+This is a DX surface, not a gate — unlike gas-benchmark regression checks, it always exits `0` and never fails a build on its own.
+
+### Update Baseline
+
+After a deliberate size change, refresh the baseline in the same PR:
+
+```bash
+./scripts/wasm_size_delta.sh --update
+```
+
 ## Deployment
 
 ### Automated Bootstrap Deployment


### PR DESCRIPTION
## Summary
The WASM-size-delta DX surface this issue asks for already exists — `scripts/wasm_size_delta.sh`, `benchmarks/wasm_size_baseline.json`, and the `check_ci.sh` wiring were added under issue #1559. What was still missing was the piece this issue's own implementation hints call for: "The improvement should be visible in the local README or CONTRIBUTING" — there was no mention of it anywhere in `README.md`.

Adds a "WASM Size Delta" section to `README.md` (mirroring the existing "Gas Benchmarks" section's structure): quick-start commands, what the table shows, and the `--update` baseline-refresh flow.

Closes #1531

## Test plan
Documentation-only change. Verified every command in the new section actually works as described:
- `cargo build --release --target wasm32-unknown-unknown` — clean build (pre-existing warnings only, unrelated to this change)
- `./scripts/wasm_size_delta.sh` — prints the per-contract delta table against `benchmarks/wasm_size_baseline.json` as documented