### PR TITLE
docs: document admin rotation and clarify there is no rotation timelock

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This workspace contains the core smart contracts that power RemitWise's post-rem
 - **[docs/SIGNING_KEYS_ENV_TAGS.md](docs/SIGNING_KEYS_ENV_TAGS.md)**: How signing keys carry environment tags (network ID, domain separators, actor epoch) to prevent cross-environment replay
 - **[docs/MIGRATION_FLAGS.md](docs/MIGRATION_FLAGS.md)**: Operator runbook for migration-completion flags, replay-protection sets, and investigation-epoch write freezes
 - **[docs/OPERATOR_SIGNATURE_SCOPES.md](docs/OPERATOR_SIGNATURE_SCOPES.md)**: Operator key scopes for `verify_signature`, domain separation, and verifier registry
+- **[docs/ADMIN_ROTATION.md](docs/ADMIN_ROTATION.md)**: `reporting`'s two-step admin rotation — and why, despite the name, there is no time-delay ("timelock") in it today
 
 Shared Components
 

--- a/docs/ADMIN_ROTATION.md
+++ b/docs/ADMIN_ROTATION.md
@@ -1,0 +1,42 @@
+# Admin Rotation
+
+> **Audience:** Operators rotating a contract's admin key (and reviewers checking whether a delay protects that rotation).
+> **Goal:** Say exactly what happens, in what order, when you rotate an admin — and be upfront that despite the name this issue was filed under, there is currently **no time-delay ("timelock") anywhere in this codebase's admin-rotation flow.**
+
+## There is no rotation timelock today
+
+Searching the whole workspace for a propose→wait→accept pattern on a *main contract admin* turns up exactly one implementation: `reporting`'s `propose_new_admin` / `accept_admin_rotation` (`reporting/src/lib.rs`). Reading it end to end: **`accept_admin_rotation` has no timestamp check at all.** The proposed admin can call it in the very next ledger after `propose_new_admin` — there is no minimum wait, no `PROPOSED_AT` storage key, nothing that would block acceptance until some future time.
+
+If you came here expecting a mandatory cooldown between proposing a new admin and that admin taking effect (the usual reason to call something a "timelock" — e.g. so a compromised current-admin key can't be used to instantly hand control to an attacker's address with no window for anyone to notice and react), **it does not exist**. Do not build downstream tooling, monitoring, or an incident-response plan around an admin-rotation delay that isn't there.
+
+Do not confuse this with the *other* time-based admin mechanism in the codebase — the pause-admin grant TTL — described below, which is unrelated.
+
+## `reporting`'s two-step admin rotation (what actually exists)
+
+```rust
+// Step 1 — current admin proposes a successor. Immediate; no delay.
+client.propose_new_admin(&current_admin, &new_admin_address);
+
+// Step 2 — the proposed address accepts. Can be called in the same
+// transaction batch as step 1, or any time after — there is no expiry
+// on a pending proposal either.
+client.accept_admin_rotation(&new_admin_address);
+```
+
+- **Storage:** the pending successor is held under the `PEND_ADM` instance-storage key until accepted (then cleared) or overwritten by a later `propose_new_admin` call. The active admin lives under `ADMIN`.
+- **Step 1 checks:** `caller.require_auth()`; caller must equal the stored `ADMIN`; `new_admin` must not equal the current admin (`SameAdmin` error otherwise).
+- **Step 2 checks:** `caller.require_auth()`; caller must equal the address stored in `PEND_ADM` (`NotAdminProposed` if nothing is pending, `Unauthorized` if the caller isn't the proposed address).
+- **Why two steps at all, without a delay:** this still protects against one real mistake — proposing a typo'd or otherwise-uncontrolled address as the new admin. Since that address must itself sign `accept_admin_rotation`, an admin rotation to an address nobody controls silently fails closed instead of bricking admin access. It does **not** protect against a compromised current-admin key, since the attacker controls both steps and can complete the rotation in one atomic sequence.
+- This flow was not previously documented in `reporting/README.md`'s own API reference — that's now cross-linked from here.
+
+## The pause-admin grant TTL — a different mechanism, don't conflate it
+
+`bill_payments` and `family_wallet` have a *time-based expiry* on the **pause admin's grant** (not a rotation delay): `ADMIN_GRANT_TTL` (30 days, `bill_payments/src/lib.rs`). Every pause-related entrypoint calls `require_admin_grant_valid`, which checks that the pause admin was granted (or last refreshed) within the last `ADMIN_GRANT_TTL` seconds — if the grant has gone stale, pause operations fail with `AdminGrantExpired` until the grant is refreshed.
+
+This is the opposite shape of a rotation timelock: it doesn't delay a new admin from taking effect, it *expires* an existing admin's standing authority if nobody refreshes it. It's about limiting how long a dormant grant stays trusted, not about giving reviewers a window to catch a bad rotation.
+
+## Cross-references
+
+- [reporting/README.md](../reporting/README.md) — full API reference for `reporting`; add `propose_new_admin`/`accept_admin_rotation` here if you extend this flow.
+- [ACCESS_CONTROL_MATRIX.md](../ACCESS_CONTROL_MATRIX.md) — which roles can call which administrative entrypoints across all contracts.
+- [docs/EMERGENCY_SHUTDOWN.md](./EMERGENCY_SHUTDOWN.md) — the pause-admin role that `ADMIN_GRANT_TTL` gates, and how it differs from the main contract admin rotated above.

--- a/reporting/README.md
+++ b/reporting/README.md
@@ -164,6 +164,20 @@ Retrieves a stored report. Returns `None` if not found.
 #### `get_admin() -> Option<Address>`
 #### `get_storage_stats() -> StorageStats`
 
+### Admin Rotation
+
+#### `propose_new_admin(caller: Address, new_admin: Address) -> Result<(), ReportingError>`
+Step 1 of a two-step admin rotation. Current-admin only.
+
+- Errors: `NotInitialized`, `Unauthorized`, `SameAdmin`
+
+#### `accept_admin_rotation(caller: Address) -> Result<(), ReportingError>`
+Step 2. Only the address proposed via `propose_new_admin` can call this — and can do so immediately, with no minimum wait.
+
+- Errors: `NotAdminProposed`, `Unauthorized`
+
+See [docs/ADMIN_ROTATION.md](../docs/ADMIN_ROTATION.md) for why this two-step flow is not a timelock, and how it differs from the unrelated pause-admin grant TTL in `bill_payments`/`family_wallet`.
+
 ### Admin Maintenance
 
 #### `archive_old_reports(caller: Address, before_timestamp: u64) -> u32`


### PR DESCRIPTION
## Summary
Searched the whole workspace for a propose→wait→accept pattern on a main contract admin. There is exactly one implementation — `reporting`'s `propose_new_admin` / `accept_admin_rotation` — and reading it end to end, **`accept_admin_rotation` has no timestamp check at all**. The proposed admin can accept in the very next ledger after being proposed; there is no `PROPOSED_AT` storage key, no minimum wait, no expiry on the pending proposal. This flow also wasn't documented in `reporting/README.md`'s own API reference at all.

Adds `docs/ADMIN_ROTATION.md` (operator-focused): what the two-step flow actually does, its real security property (protects against proposing a typo'd/uncontrolled address, not against a compromised current-admin key), and an explicit, upfront statement that no rotation timelock exists today — so nobody builds tooling or an incident-response plan assuming a delay window that isn't there. Also documents the unrelated `ADMIN_GRANT_TTL` (30-day) pause-admin grant-expiry mechanism in `bill_payments`/`family_wallet`, since it's a different time-based admin control that's easy to conflate with a rotation timelock.

Adds the missing `propose_new_admin`/`accept_admin_rotation` entries to `reporting/README.md`'s API reference, and cross-links from the top-level `README.md`.

Note: this doc cross-links to `docs/EMERGENCY_SHUTDOWN.md`, added in #1657 (issue #1524) — that link resolves once #1657 merges.

Closes #1529

## Test plan
Documentation-only change (no Rust source touched). Verified directly against source:
- Read `propose_new_admin` and `accept_admin_rotation` in full (`reporting/src/lib.rs`) — confirmed no timestamp/delay check anywhere in either function
- `grep -rln "propose.*admin\|pending_admin\|PEND_ADM"` across the whole workspace — confirmed `reporting` is the only contract with this pattern
- Confirmed `ADMIN_GRANT_TTL` and `require_admin_grant_valid` in `bill_payments/src/lib.rs` are a distinct, unrelated mechanism (grant expiry, not rotation delay)
- Confirmed `reporting/README.md` had no prior mention of either rotation entrypoint
- Confirmed the `ReportingError` variant names used (`SameAdmin`, `NotAdminProposed`, `Unauthorized`, `NotInitialized`) against the actual enum