### PR TITLE
feat(reporting): reject the contract's own address as a proposed admin

### DIFF
--- a/reporting/src/lib.rs
+++ b/reporting/src/lib.rs
@@ -267,6 +267,11 @@ pub enum ReportingError {
     SameAdmin = 10,
     /// The requested top-N size exceeds the global cap.
     TopNTooLarge = 11,
+    /// Proposed new admin is this contract's own address — accepting it would
+    /// brick admin control, since the contract cannot sign `require_auth()`
+    /// for itself as an external caller. Mirrors `emergency_killswitch`'s
+    /// `InvalidAdmin` guard on `transfer_admin`.
+    InvalidAdmin = 12,
 }
 
 #[contracttype]
@@ -694,6 +699,7 @@ impl ReportingContract {
     /// # Errors
     /// * `NotInitialized` - If contract has not been initialized
     /// * `Unauthorized` - If caller is not the current admin
+    /// * `InvalidAdmin` - If `new_admin` is this contract's own address
     /// * `SameAdmin` - If `new_admin` is the same as the current admin
     pub fn propose_new_admin(
         env: Env,
@@ -710,6 +716,14 @@ impl ReportingContract {
 
         if caller != admin {
             return Err(ReportingError::Unauthorized);
+        }
+
+        // Rejecting the contract's own address prevents an unrecoverable brick:
+        // this contract can never produce a `require_auth()` signature for
+        // itself as an external caller, so `accept_admin_rotation` could never
+        // be completed and admin control would be permanently lost.
+        if new_admin == env.current_contract_address() {
+            return Err(ReportingError::InvalidAdmin);
         }
 
         if new_admin == admin {

--- a/reporting/src/tests_auth_acl.rs
+++ b/reporting/src/tests_auth_acl.rs
@@ -560,6 +560,30 @@ fn test_admin_rotation_reject_propose_current_admin() {
     );
 }
 
+/// Proposing the contract's own address as the new admin must be rejected —
+/// accepting it would brick admin control forever, since the contract can
+/// never produce a `require_auth()` signature for itself as an external
+/// caller to complete `accept_admin_rotation`.
+#[test]
+fn test_admin_rotation_reject_propose_self_contract_as_admin() {
+    let env = create_test_env();
+    let (client, admin) = setup_reporting(&env);
+
+    assert_eq!(
+        client.try_propose_new_admin(&admin, &client.address),
+        Err(Ok(ReportingError::InvalidAdmin)),
+        "proposing the contract's own address must be rejected"
+    );
+
+    // Admin is unchanged, no pending proposal exists.
+    assert_eq!(client.get_admin(), Some(admin.clone()));
+    assert_eq!(
+        client.try_accept_admin_rotation(&admin),
+        Err(Ok(ReportingError::NotAdminProposed)),
+        "no pending proposal after rejected self-contract proposal"
+    );
+}
+
 /// Aggregate invariant: NO rejected path changes the admin. After exercising
 /// every negative path in sequence, the admin is still the original, and a
 /// legitimate rotation still succeeds afterwards (the state machine is intact).


### PR DESCRIPTION
## Summary
This issue was filed as "assert admin != zero-address on rotate" — an EVM idiom (Solidity's `require(newAdmin != address(0))`). Soroban's `Address` type has no such thing: it isn't nullable the way an EVM address is, and this codebase already uses `Option<Address>` for "no admin set yet" everywhere (`reporting/README.md` says so explicitly: *"Soroban/Stellar contract IDs are not an EVM-style 'zero address'"*). Asserting `!= address(0)` doesn't translate.

## Threat model
The real Soroban-native equivalent of "don't let admin become an unusable address" is: **don't let admin become this contract's own address.** A contract can never produce a `require_auth()` signature for itself as an external caller through the normal invocation path, so if `new_admin` were ever set to the contract's own address, whatever role that admin gates would be permanently unrecoverable — an unrecoverable brick, exactly the failure `address(0)` checks exist to prevent in Solidity.

This exact pattern is already precedented in this codebase: `emergency_killswitch::transfer_admin` and `initialize` both reject `new_admin == env.current_contract_address()` with `Error::InvalidAdmin`. Searching for the same guard on `reporting`'s admin-rotation flow (`propose_new_admin`, documented in #1659 / `docs/ADMIN_ROTATION.md`) found it missing — `reporting` checks `NotInitialized`, `Unauthorized`, and `SameAdmin`, but never checks against the contract's own address.

## Change
- Added `ReportingError::InvalidAdmin = 12`, matching `emergency_killswitch`'s naming for the same failure mode.
- `propose_new_admin` now rejects `new_admin == env.current_contract_address()` before the existing `SameAdmin` check.

Closes #1535

## Test plan
- New test `test_admin_rotation_reject_propose_self_contract_as_admin` in `reporting/src/tests_auth_acl.rs` (added right next to the existing `test_admin_rotation_reject_propose_current_admin`, same style): asserts `propose_new_admin(admin, client.address)` returns `InvalidAdmin`, the admin is unchanged, and there's no pending proposal to accept afterward. This test targets code that did not exist before this PR (`ReportingError::InvalidAdmin` and the guard itself) — it fails to compile/pass on `main` and passes with this diff, satisfying the "fails today, passes after" requirement.
- `cargo test -p reporting` — full suite: 171 lib unit tests + gas benchmarks + integration tests, 0 failed
- `cargo build --release --target wasm32-unknown-unknown -p reporting` — clean build
- `cargo clippy -p reporting --all-targets --all-features` — no new warnings in the changed files
- `cargo fmt -p reporting -- --check` — clean, no diff