### PR TITLE
feat(family-wallet): add a paused_at() view

### DIFF
--- a/family_wallet/src/lib.rs
+++ b/family_wallet/src/lib.rs
@@ -2134,6 +2134,9 @@ impl FamilyWallet {
         env.storage()
             .instance()
             .set(&symbol_short!("PAUSED"), &true);
+        env.storage()
+            .instance()
+            .set(&symbol_short!("PAUSED_AT"), &env.ledger().timestamp());
         env.events()
             .publish((symbol_short!("wallet"), symbol_short!("paused")), ());
         Self::append_access_audit(&env, symbol_short!("pause"), &caller, None, true);
@@ -2160,6 +2163,7 @@ impl FamilyWallet {
         env.storage()
             .instance()
             .set(&symbol_short!("PAUSED"), &false);
+        env.storage().instance().remove(&symbol_short!("PAUSED_AT"));
         env.events()
             .publish((symbol_short!("wallet"), symbol_short!("unpaused")), ());
         Self::append_access_audit(&env, symbol_short!("unpause"), &caller, None, true);
@@ -2187,6 +2191,12 @@ impl FamilyWallet {
 
     pub fn is_paused(env: Env) -> bool {
         Self::get_global_paused(&env)
+    }
+
+    /// Ledger timestamp the wallet was paused at, or `None` if it isn't
+    /// currently paused. Cleared by `unpause`.
+    pub fn paused_at(env: Env) -> Option<u64> {
+        env.storage().instance().get(&symbol_short!("PAUSED_AT"))
     }
 
     pub fn get_version(env: Env) -> u32 {

--- a/family_wallet/src/test.rs
+++ b/family_wallet/src/test.rs
@@ -4176,6 +4176,53 @@ fn test_expired_admin_cannot_unpause() {
 }
 
 #[test]
+fn test_paused_at_is_none_before_first_pause() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, FamilyWallet);
+    let client = FamilyWalletClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    client.init(&owner, &vec![&env]);
+
+    assert_eq!(client.paused_at(), None);
+}
+
+#[test]
+fn test_paused_at_reports_the_pause_timestamp() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000);
+    let contract_id = env.register_contract(None, FamilyWallet);
+    let client = FamilyWalletClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    client.init(&owner, &vec![&env]);
+
+    client.pause(&owner);
+
+    assert_eq!(client.paused_at(), Some(1_000));
+}
+
+#[test]
+fn test_paused_at_clears_on_unpause() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000);
+    let contract_id = env.register_contract(None, FamilyWallet);
+    let client = FamilyWalletClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    client.init(&owner, &vec![&env]);
+
+    client.pause(&owner);
+    assert_eq!(client.paused_at(), Some(1_000));
+
+    client.unpause(&owner);
+    assert_eq!(client.paused_at(), None);
+}
+
+#[test]
 fn test_expired_admin_cannot_archive_transactions() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
## Summary

\`family_wallet\`'s \`pause()\`/\`unpause()\` only tracked a \`PAUSED\` bool -- unlike \`emergency_killswitch\`'s \`get_paused_since()\`, there was no way to query *when* a pause took effect.

- Adds a \`PAUSED_AT\` instance-storage key: set to \`env.ledger().timestamp()\` on \`pause()\`, removed on \`unpause()\`.
- Adds \`paused_at(env: Env) -> Option<u64>\` returning it.

**Not touched:** the pre-upgrade snapshot (\`PreUpgradeSnapshot\`) captures \`paused: bool\` but not this new timestamp, so a restored snapshot loses \`paused_at\` even though it correctly restores the paused flag itself. Extending the snapshot schema is versioned (\`SNAPSHOT_VERSION\`) and felt out of scope for a small, focused PR -- flagging it rather than leaving it a silent gap.

## Testing

Added three tests: \`paused_at\` is \`None\` before any pause, \`Some(timestamp)\` immediately after \`pause()\`, and back to \`None\` after \`unpause()\`.

- \`cargo test -p family_wallet\` — 178 passed (3 new). Note: 35 tests fail on this crate independent of this change -- confirmed identical failures on a clean checkout of \`main\` before making any edits, so these are pre-existing and unrelated.
- \`cargo check -p family_wallet\` — clean (only 2 pre-existing warnings, unchanged)
- \`cargo clippy -p family_wallet\` — no new warnings on the changed code
- \`cargo fmt -p family_wallet -- --check\` — no formatting issues in the changed lines (this crate has pre-existing formatting drift elsewhere, untouched)

Closes #1586