### PR TITLE
ci: add a stable + MSRV (1.88.0) build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,3 +202,50 @@ jobs:
           \ > 10 ? '\u26A0\uFE0F' : memChange < -5 ? '\u2728' : '\u2705';\n      \n      comment += `- **${curr.contract}::${curr.method}**: CPU ${cpuIcon} ${cpuChange > 0 ? '+' : ''}${cpuChange}%, Memory\
           \ ${memIcon} ${memChange > 0 ? '+' : ''}${memChange}%\\n`;\n    }\n  });\n}\n\ngithub.rest.issues.createComment({\n  issue_number: context.issue.number,\n  owner: context.repo.owner,\n  repo:\
           \ context.repo.repo,\n  body: comment\n});\n"
+  msrv:
+    name: MSRV Check (Rust ${{ matrix.rust }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        rust:
+        - stable
+        - '1.88.0'
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+    - name: Install Rust ${{ matrix.rust }}
+      uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
+      with:
+        toolchain: ${{ matrix.rust }}
+        targets: wasm32-unknown-unknown
+    - name: Cache Cargo registry
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+      with:
+        path: |
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+        key: cargo-registry-msrv-${{ matrix.rust }}-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          cargo-registry-msrv-${{ matrix.rust }}-
+    - name: Cache Cargo target dir
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+      with:
+        path: |
+          ~/.cargo/bin/
+          target/
+        key: cargo-target-${{ runner.os }}-msrv-${{ matrix.rust }}-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          cargo-target-${{ runner.os }}-msrv-${{ matrix.rust }}-
+    - name: Check workspace compiles natively
+      run: cargo check --workspace
+    - name: Check contract crates compile for wasm32-unknown-unknown
+      # Deliberately not --workspace: native-only tooling crates (cli,
+      # integration_tests, scenarios) pull in dependencies (e.g. mio via
+      # tokio) that don't support wasm32-unknown-unknown. The deployable
+      # contracts are exactly Cargo.toml's [workspace] default-members,
+      # which this picks up implicitly — same convention as check_ci.sh's
+      # `cargo build --release --target wasm32-unknown-unknown`.
+      run: cargo check --target wasm32-unknown-unknown

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,10 @@
 name = "remitwise-contracts"
 version = "0.1.0"
 edition = "2021"
+# Verified via `cargo +<version> check -p remittance_split`: 1.85.1 fails
+# because `darling@0.23.0`/`serde_with@3.21.0` require 1.88.0; 1.88.0 builds
+# clean. Keep this in sync with the `msrv` matrix in .github/workflows/ci.yml.
+rust-version = "1.88.0"
 publish = false
 
 [workspace]


### PR DESCRIPTION
## Summary
No MSRV was declared anywhere in this repo (`rust-toolchain.toml` just floats on `channel = "stable"`), and there was no CI coverage checking the workspace against anything other than whatever `stable` happens to be on a given day.

## Determining the actual MSRV (verified, not guessed)
`soroban-sdk 21.7.7` itself declares `rust-version = "1.74.0"`, but that's not the real floor for this workspace — the committed `Cargo.lock` uses lockfile format v4, which `cargo` 1.74.0 can't even parse. I bisected against the Rust toolchains available locally:

| Toolchain | Result |
|---|---|
| 1.74.0 | Can't parse `Cargo.lock` (needs lockfile v4 support) |
| 1.79.0 / 1.81.0 | `base64ct v1.8.3` requires the `edition2024` Cargo feature (stabilized in 1.85) |
| 1.85.1 | `darling@0.23.0` / `serde_with@3.21.0` explicitly require rustc 1.88.0 (cargo's own error message) |
| **1.88.0** | **Builds clean** — `cargo check --workspace` and `cargo check --target wasm32-unknown-unknown` both succeed |

So **1.88.0** is the real, verified MSRV today. Declared it in `Cargo.toml` (`rust-version = "1.88.0"`) with a comment recording how it was derived, so it stays self-documenting and doesn't silently drift as dependencies update.

## CI change
Added an `msrv` job to `.github/workflows/ci.yml` with a `matrix.rust: [stable, "1.88.0"]`, running on every PR:
- `cargo check --workspace` (native)
- `cargo check --target wasm32-unknown-unknown` (the actual deploy target) — deliberately **not** `--workspace` here, matching `check_ci.sh`'s existing convention: native-only tooling crates (`cli`, `integration_tests`, `scenarios`) pull in dependencies like `mio` (via `tokio`) that don't support `wasm32-unknown-unknown` at all, so a `--workspace` wasm check fails for reasons unrelated to MSRV. The workspace's `default-members` (the actual deployable contracts) are what matters here, and omitting `--workspace` picks those up implicitly.

Actions are pinned by SHA (reusing the same pins already used elsewhere in this file for `actions/checkout`, `dtolnay/rust-toolchain`, `actions/cache`), and both cargo registry and target-dir are cached per-Rust-version so re-runs don't pay full compile cost twice.

Closes #1533

## Test plan
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — valid YAML
- `actionlint .github/workflows/ci.yml` — clean, no findings
- Locally verified every command the new job runs, on both matrix legs:
  - `cargo +1.88.0 check --workspace` — clean
  - `cargo +1.88.0 check --target wasm32-unknown-unknown` — clean (only pre-existing warnings)
  - `cargo +stable check --workspace` — clean
  - `cargo +stable check --target wasm32-unknown-unknown` — clean
- Also reproduced the failure mode this PR avoids: `cargo +1.88.0 check --workspace --target wasm32-unknown-unknown` (with `--workspace`) fails to compile `mio` for `wasm32-unknown-unknown` — confirms the job as written is correct and the naive version would not be