### PR TITLE
chore(dx): add a justfile with a help target

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,11 @@ cargo install --locked --version 21.0.0 soroban-cli
 cargo build --release --target wasm32-unknown-unknown
 ```
 
+If you have [`just`](https://github.com/casey/just) installed, `just help`
+(or plain `just`) lists the available recipes -- thin wrappers around the
+same cargo/make commands used above (`just check`, `just test`, `just wasm`,
+`just build`, ...). It's optional; nothing here requires it.
+
 ## Examples
 
 The workspace includes runnable examples for each contract in the `examples/` directory. These examples demonstrate basic read and write operations using the Soroban SDK test environment.

--- a/justfile
+++ b/justfile
@@ -1,0 +1,42 @@
+# Convenience recipes around the workspace's existing cargo/make commands.
+# `just` is optional -- every recipe here is a thin wrapper, not new tooling.
+
+# Running `just` with no recipe name shows this list (matches `just help`).
+default: help
+
+# List available recipes.
+help:
+    @just --list
+
+# Type-check every workspace member without building artifacts.
+check:
+    cargo check --workspace
+
+# Run the workspace's unit and integration tests.
+test:
+    cargo test --workspace
+
+# Check formatting without writing changes.
+fmt-check:
+    cargo fmt --all -- --check
+
+# Apply formatting.
+fmt:
+    cargo fmt --all
+
+# Lint with clippy across the workspace.
+clippy:
+    cargo clippy --workspace
+
+# Build every contract's release WASM -- see Makefile's `wasm` target.
+wasm:
+    @make wasm
+
+# Regenerate TypeScript client bindings from each contract's WASM -- see
+# Makefile's `bindings` target.
+bindings:
+    @make bindings
+
+# One-command build: WASM plus its bindings -- see Makefile's `build` target.
+build:
+    @make build


### PR DESCRIPTION
## Summary

No \`justfile\` existed in this repo. Adds one with a \`help\` recipe (\`just help\`, or plain \`just\`, which defaults to it) that lists every available recipe via \`just --list\`, plus thin wrappers around the workspace's existing cargo/make commands: \`check\`, \`test\`, \`fmt\`, \`fmt-check\`, \`clippy\`, and \`wasm\`/\`bindings\`/\`build\` (delegating to the existing \`Makefile\` targets). No new tooling behavior -- \`just\` is optional and nothing here requires it.

Documented in the README's Installation section.

## Testing

- Verified locally: \`just\` and \`just help\` both print the recipe list correctly.

Closes #1596