### PR TITLE
perf(remittance-split): stop re-reading the split/fee table mid-call

### DIFF
--- a/remittance_split/src/lib.rs
+++ b/remittance_split/src/lib.rs
@@ -15,6 +15,18 @@ use remitwise_common::{
     PERSISTENT_BUMP_AMOUNT, PERSISTENT_LIFETIME_THRESHOLD, SNAPSHOT_KEY, SNAPSHOT_VERSION,
 };
 
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, symbol_short, token::TokenClient, vec,
+    Address, Bytes, BytesN, Env, IntoVal, Map, Symbol, Vec,
+};
+
+// Event topics
+const SPLIT_INITIALIZED: Symbol = symbol_short!("init");
+const SPLIT_CALCULATED: Symbol = symbol_short!("calc");
+
+// Request hash domain separator for signing (prevents cross-domain attacks)
+const DISTRIBUTE_USDC_DOMAIN: &[u8] = b"distribute_usdc_v1";
+
 mod fee_math;
 
 #[derive(Clone)]
@@ -1244,14 +1256,14 @@ impl RemittanceSplit {
             EventCategory::State,
             EventPriority::Medium,
             symbol_short!("init"),
-            owner,
+            owner.clone(),
         );
 
         // Emit event for audit trail
         env.events()
             .publish((symbol_short!("admin"), SplitEvent::Initialized), owner);
 
-        true
+        Ok(true)
     }
 
     pub fn update_split(
@@ -1316,7 +1328,7 @@ impl RemittanceSplit {
         env.events()
             .publish((symbol_short!("admin"), SplitEvent::Updated), caller);
 
-        true
+        Ok(true)
     }
 
     /// Rotate the split configuration's owner.
@@ -2615,6 +2627,17 @@ impl RemittanceSplit {
         Ok([spending, savings, bills, insurance])
     }
 
+    /// Extend the TTL of a persistent storage entry using
+    /// PERSISTENT_BUMP_AMOUNT / PERSISTENT_LIFETIME_THRESHOLD from
+    /// remitwise-common.
+    fn extend_persistent_ttl(env: &Env, key: &DataKey) {
+        env.storage().persistent().extend_ttl(
+            key,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+    }
+
     /// Extend the TTL of instance storage using INSTANCE_BUMP_AMOUNT / INSTANCE_LIFETIME_THRESHOLD
     /// from remitwise-common.
     fn extend_instance_ttl(env: &Env) {
@@ -2622,55 +2645,6 @@ impl RemittanceSplit {
             .instance()
             .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
     }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use soroban_sdk::{
-        testutils::{Address as _, Events as _},
-        token::{StellarAssetClient, TokenClient},
-        Env, TryFromVal,
-    };
-
-    #[test]
-    fn distribute_usdc_apportions_tokens_to_recipients() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let contract_id = env.register_contract(None, RemittanceSplit);
-        let client = RemittanceSplitClient::new(&env, &contract_id);
-
-        let admin = Address::generate(&env);
-        let token_contract = env.register_stellar_asset_contract_v2(admin.clone());
-        let payer = Address::generate(&env);
-        let amount = 1_000i128;
-
-        StellarAssetClient::new(&env, &token_contract.address()).mint(&payer, &amount);
-
-        let spending = Address::generate(&env);
-        let savings = Address::generate(&env);
-        let bills = Address::generate(&env);
-        let insurance = Address::generate(&env);
-
-        let accounts = AccountGroup {
-            spending: spending.clone(),
-            savings: savings.clone(),
-            bills: bills.clone(),
-            insurance: insurance.clone(),
-        };
-
-        let distributed =
-            client.distribute_usdc(&token_contract.address(), &payer, &accounts, &amount);
-
-        assert!(distributed);
-
-        let token_client = TokenClient::new(&env, &token_contract.address());
-        assert_eq!(token_client.balance(&spending), 500);
-        assert_eq!(token_client.balance(&savings), 300);
-        assert_eq!(token_client.balance(&bills), 150);
-        assert_eq!(token_client.balance(&insurance), 50);
-        assert_eq!(token_client.balance(&payer), 0);
-    }
-
     /// Create a new automatic remittance schedule for the split owner.
     ///
     /// # Arguments
@@ -3263,6 +3237,98 @@ mod tests {
             count,
         }
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{
+        testutils::{Address as _, Events as _},
+        token::{StellarAssetClient, TokenClient},
+        Env, TryFromVal,
+    };
+
+    #[test]
+    fn distribute_usdc_apportions_tokens_to_recipients() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, RemittanceSplit);
+        let client = RemittanceSplitClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let token_contract = env.register_stellar_asset_contract_v2(admin.clone());
+        let payer = Address::generate(&env);
+        let amount = 1_000i128;
+
+        StellarAssetClient::new(&env, &token_contract.address()).mint(&payer, &amount);
+
+        let spending = Address::generate(&env);
+        let savings = Address::generate(&env);
+        let bills = Address::generate(&env);
+        let insurance = Address::generate(&env);
+
+        let accounts = AccountGroup {
+            spending: spending.clone(),
+            savings: savings.clone(),
+            bills: bills.clone(),
+            insurance: insurance.clone(),
+        };
+
+        client.initialize_split(
+            &payer,
+            &0,
+            &token_contract.address(),
+            &5000,
+            &3000,
+            &1500,
+            &500,
+        );
+
+        let nonce = 1u64; // initialize_split already consumed nonce 0 for `payer`
+        let deadline = env.ledger().timestamp() + 100;
+        let request_hash = RemittanceSplit::compute_request_hash(
+            symbol_short!("distrib"),
+            payer.clone(),
+            nonce,
+            amount,
+            deadline,
+        );
+
+        let distributed = client.distribute_usdc(
+            &token_contract.address(),
+            &payer,
+            &nonce,
+            &deadline,
+            &request_hash,
+            &accounts,
+            &amount,
+        );
+
+        assert!(distributed);
+
+        let token_client = TokenClient::new(&env, &token_contract.address());
+        assert_eq!(token_client.balance(&spending), 500);
+        assert_eq!(token_client.balance(&savings), 300);
+        assert_eq!(token_client.balance(&bills), 150);
+        assert_eq!(token_client.balance(&insurance), 50);
+        assert_eq!(token_client.balance(&payer), 0);
+
+        // get_usdc_balance() is the contract's own read-only balance view --
+        // it must reflect the transfers `distribute_usdc` just made in this
+        // same call, not whatever the balance was before the transaction
+        // that moved the funds. It has no storage-backed cache of its own
+        // (it always queries the token contract directly), so this pins
+        // down that the view is never stale relative to a transfer that
+        // already landed.
+        assert_eq!(
+            client.get_usdc_balance(&token_contract.address(), &payer),
+            0
+        );
+        assert_eq!(
+            client.get_usdc_balance(&token_contract.address(), &spending),
+            500
+        );
+    }
 
     /// Returns the `Symbol` topic prefix (the first element of the topic
     /// tuple) of the most recently published event.
@@ -3280,10 +3346,12 @@ mod tests {
         let client = RemittanceSplitClient::new(&env, &contract_id);
 
         let owner = Address::generate(&env);
-        client.initialize_split(&owner, &50, &30, &15, &5);
+        let usdc_admin = Address::generate(&env);
+        let usdc_contract = env.register_stellar_asset_contract_v2(usdc_admin).address();
+        client.initialize_split(&owner, &0, &usdc_contract, &5000, &3000, &1500, &500);
         assert_eq!(last_event_topic_prefix(&env), symbol_short!("admin"));
 
-        client.update_split(&owner, &40, &30, &20, &10);
+        client.update_split(&owner, &1, &4000, &3000, &2000, &1000);
         assert_eq!(last_event_topic_prefix(&env), symbol_short!("admin"));
     }
 
@@ -3308,7 +3376,9 @@ mod tests {
 
         let owner = Address::generate(&env);
         let new_owner = Address::generate(&env);
-        client.initialize_split(&owner, &50, &30, &15, &5);
+        let usdc_admin = Address::generate(&env);
+        let usdc_contract = env.register_stellar_asset_contract_v2(usdc_admin).address();
+        client.initialize_split(&owner, &0, &usdc_contract, &5000, &3000, &1500, &500);
 
         client.rotate_owner(&owner, &new_owner);
 
@@ -3326,7 +3396,9 @@ mod tests {
         let owner = Address::generate(&env);
         let stranger = Address::generate(&env);
         let new_owner = Address::generate(&env);
-        client.initialize_split(&owner, &50, &30, &15, &5);
+        let usdc_admin = Address::generate(&env);
+        let usdc_contract = env.register_stellar_asset_contract_v2(usdc_admin).address();
+        client.initialize_split(&owner, &0, &usdc_contract, &5000, &3000, &1500, &500);
 
         client.rotate_owner(&stranger, &new_owner);
     }
@@ -3340,7 +3412,9 @@ mod tests {
         let client = RemittanceSplitClient::new(&env, &contract_id);
 
         let owner = Address::generate(&env);
-        client.initialize_split(&owner, &50, &30, &15, &5);
+        let usdc_admin = Address::generate(&env);
+        let usdc_contract = env.register_stellar_asset_contract_v2(usdc_admin).address();
+        client.initialize_split(&owner, &0, &usdc_contract, &5000, &3000, &1500, &500);
 
         client.rotate_owner(&owner, &contract_id);
     }

--- a/remittance_split/src/lib.rs
+++ b/remittance_split/src/lib.rs
@@ -1683,7 +1683,7 @@ impl RemittanceSplit {
         Self::require_nonce_hardened(&env, &from, nonce, deadline, request_hash, expected_hash)?;
 
         // 9. Calculate split amounts and execute transfers.
-        let amounts = Self::calculate_split_amounts(&env, total_amount, false)?;
+        let amounts = Self::calculate_split_amounts(&env, &config, total_amount, false)?;
         let token = TokenClient::new(&env, &usdc_contract);
 
         if amounts[0] > 0 {
@@ -1826,7 +1826,7 @@ impl RemittanceSplit {
         Self::require_nonce(&env, &request.from, request.nonce)?;
 
         // Calculate split amounts
-        let amounts = Self::calculate_split_amounts(&env, request.total_amount, false)?;
+        let amounts = Self::calculate_split_amounts(&env, &config, request.total_amount, false)?;
         let token = TokenClient::new(&env, &request.usdc_contract);
 
         // Execute transfers
@@ -2552,8 +2552,14 @@ impl RemittanceSplit {
     ///   allocation is computed.
     /// - [`RemittanceSplitError::Overflow`] — any `checked_mul` or `checked_sub` step fails;
     ///   returned immediately before any partial allocation value is produced.
+    /// Takes `config` by reference rather than re-reading `CONFIG` from
+    /// storage (as `Self::get_split(env)` would) -- every caller already
+    /// has it loaded for owner/token validation, so re-fetching the same
+    /// instance-storage entry a second time within the same call was a
+    /// redundant read of the fee/split table for no reason.
     fn calculate_split_amounts(
         env: &Env,
+        config: &SplitConfig,
         total_amount: i128,
         emit_events: bool,
     ) -> Result<[i128; 4], RemittanceSplitError> {
@@ -2561,25 +2567,18 @@ impl RemittanceSplit {
             return Err(RemittanceSplitError::InvalidAmount);
         }
 
-        let split = Self::get_split(env);
-        let s0 = match split.get(0) {
-            Some(v) => v
-                .to_i128_checked()
-                .map_err(|_| RemittanceSplitError::Overflow)?,
-            None => return Err(RemittanceSplitError::Overflow),
-        };
-        let s1 = match split.get(1) {
-            Some(v) => v
-                .to_i128_checked()
-                .map_err(|_| RemittanceSplitError::Overflow)?,
-            None => return Err(RemittanceSplitError::Overflow),
-        };
-        let s2 = match split.get(2) {
-            Some(v) => v
-                .to_i128_checked()
-                .map_err(|_| RemittanceSplitError::Overflow)?,
-            None => return Err(RemittanceSplitError::Overflow),
-        };
+        let s0 = config
+            .spending_percent
+            .to_i128_checked()
+            .map_err(|_| RemittanceSplitError::Overflow)?;
+        let s1 = config
+            .savings_percent
+            .to_i128_checked()
+            .map_err(|_| RemittanceSplitError::Overflow)?;
+        let s2 = config
+            .bills_percent
+            .to_i128_checked()
+            .map_err(|_| RemittanceSplitError::Overflow)?;
 
         let spending = total_amount
             .checked_mul(s0)
@@ -3328,6 +3327,35 @@ mod tests {
             client.get_usdc_balance(&token_contract.address(), &spending),
             500
         );
+    }
+
+    #[test]
+    fn calculate_split_amounts_does_not_re_read_config_from_storage() {
+        // calculate_split_amounts takes `config` by parameter instead of
+        // calling Self::get_split(env) (which re-reads CONFIG from instance
+        // storage) -- distribute_usdc / distribute_usdc_hashed already have
+        // it loaded for owner/token validation before calling this, and the
+        // old internal re-fetch cost an extra storage read per call for no
+        // reason. Proof: this contract is never initialized (no CONFIG
+        // entry exists in storage at all here), yet the calculation still
+        // produces the correct split purely from the config passed in.
+        let env = Env::default();
+        let owner = Address::generate(&env);
+        let usdc_contract = Address::generate(&env);
+        let config = SplitConfig {
+            owner,
+            spending_percent: 5000,
+            savings_percent: 3000,
+            bills_percent: 1500,
+            insurance_percent: 500,
+            timestamp: 0,
+            initialized: true,
+            usdc_contract,
+        };
+
+        let amounts = RemittanceSplit::calculate_split_amounts(&env, &config, 1000, false).unwrap();
+
+        assert_eq!(amounts, [500, 300, 150, 50]);
     }
 
     /// Returns the `Symbol` topic prefix (the first element of the topic


### PR DESCRIPTION
## Summary

**Note:** this branch is built on top of #1666 (\`remittance_split\` didn't compile at all on \`main\` -- 352 errors, root-caused and fixed there). Until that merges, this PR's diff includes that repair too; the fee-table fix itself is small.

\`calculate_split_amounts()\` called \`Self::get_split(env)\`, which re-reads \`CONFIG\` (the split percentages -- the \"fee table\") from instance storage -- even though both of its callers (\`distribute_usdc\` and \`distribute_usdc_hashed\`) already load that exact same \`CONFIG\` entry earlier in the same call, for owner/token validation. That's a redundant storage read of the same value within one call.

\`calculate_split_amounts\` now takes \`config: &SplitConfig\` directly from the caller instead of re-fetching it. \`get_split()\` itself is untouched and still available as a public read-only view for external callers.

## Testing

Added a test proving the fix: \`calculate_split_amounts\` produces the correct split purely from the \`config\` parameter with \`CONFIG\` never written to storage at all in that test (no \`initialize_split\` call) -- if it still internally re-read storage, this would need a stored entry to work, and it doesn't.

- \`cargo test -p remittance_split\` — 73 passed (1 new), 52 failed (pre-existing, unrelated -- see #1666)
- \`cargo fmt -p remittance_split -- --check\` — clean
- \`cargo check -p remittance_split\` — clean

Closes #1588