### PR TITLE
ci: gate merges on cargo audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,10 +61,14 @@ jobs:
     - name: Install cargo-audit
       run: "if ! command -v cargo-audit &> /dev/null; then\n  cargo install cargo-audit --locked\nfi\n"
     - name: Run cargo audit
-      run: 'cargo audit --deny warnings
-
-        '
-      continue-on-error: true
+      # Deliberately plain `cargo audit`, not `--deny warnings`: as of this
+      # writing two transitive dependencies (bincode, paste) are flagged
+      # "unmaintained" (RUSTSEC-2025-0141, RUSTSEC-2024-0436) with no fix
+      # available — `--deny warnings` would fail every PR on an advisory
+      # nobody here can act on. Plain `cargo audit` still fails (and blocks
+      # this merge gate) on actual RUSTSEC *vulnerabilities*, which is the
+      # thing worth gating merges on.
+      run: cargo audit
   workspace-invariants:
     name: Workspace Invariants
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
The `security` job in `.github/workflows/ci.yml` already ran `cargo audit --deny warnings` on every PR, but with `continue-on-error: true` — meaning the check always reported green regardless of the result, so it never actually gated a merge.

## Why not just flip `continue-on-error` off as-is
Ran `cargo audit --deny warnings` locally against the current `Cargo.lock` first, before changing anything:

```
Crate:     bincode   Warning: unmaintained (RUSTSEC-2025-0141)
Crate:     paste     Warning: unmaintained (RUSTSEC-2024-0436)
error: 2 denied warnings found!
```

Both are transitive dependencies flagged "unmaintained" (not vulnerabilities — no CVE/exploit, just no longer actively maintained upstream), with no fix currently available. Naively removing `continue-on-error` on top of `--deny warnings` would make this gate permanently red for every future PR on advisories nobody working in this repo can act on — the opposite of a useful gate.

Plain `cargo audit` (no `--deny warnings`) only fails on actual RUSTSEC *vulnerability* advisories, not "unmaintained"/"notice"-level warnings. Ran it the same way:

```
$ cargo audit; echo "exit: $?"
...same 2 unmaintained warnings printed...
warning: 2 allowed warnings found
exit: 0
```

Zero real vulnerabilities today, exit 0. That's the right thing to gate on.

## Change
- `run: cargo audit --deny warnings` → `run: cargo audit` (with a comment explaining why, referencing both advisory IDs).
- Removed `continue-on-error: true`.

Closes #1537

## Test plan
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — valid YAML
- `actionlint .github/workflows/ci.yml` — clean, no findings
- Happy path: `cargo audit` locally against the current lockfile exits `0` (shown above) — the gate passes today and won't block unrelated PRs.
- Failure mode: `cargo audit --deny warnings` locally exits non-zero today (shown above) — proving `cargo-audit`'s exit-code propagation genuinely fails when it detects something, i.e. this isn't a gate that silently passes no matter what; it will fail CI the moment a real vulnerability advisory lands, which plain `cargo audit` also does (unlike `--deny warnings`, it just doesn't additionally fail on unmaintained-only notices).