### PR TITLE
fix: require admin/owner signature on initialize/init entrypoints

### DIFF
--- a/emergency_killswitch/src/lib.rs
+++ b/emergency_killswitch/src/lib.rs
@@ -46,8 +46,14 @@ pub struct EmergencyKillswitch;
 impl EmergencyKillswitch {
     /// Initializes the killswitch with an admin address.
     ///
+    /// Requires `admin`'s signature — without it, anyone could front-run
+    /// deployment and call `initialize` with themselves (or any address they
+    /// control) as `admin` before the intended admin does, permanently
+    /// seizing control of the kill switch.
+    ///
     /// Rejects the contract's own address as admin to prevent unrecoverable bricking.
     pub fn initialize(env: Env, admin: Address) -> Result<(), Error> {
+        admin.require_auth();
         if env.storage().instance().has(&DataKey::Admin) {
             return Err(Error::AlreadyInitialized);
         }

--- a/emergency_killswitch/tests/gas_bench.rs
+++ b/emergency_killswitch/tests/gas_bench.rs
@@ -10,107 +10,112 @@ struct RegressionSpec {
     mem_threshold_percent: u64,
 }
 
+// Baselines below were bumped for `initialize` requiring `admin.require_auth()`
+// (issue #1538 — front-running-the-constructor fix). Auth checks aren't free,
+// and every scenario here initializes the contract as setup, so the cost
+// ripples through all of them. Re-measured via
+// `cargo test -p emergency_killswitch --test gas_bench -- --nocapture`.
 const INITIALIZE: RegressionSpec = RegressionSpec {
-    cpu_baseline: 20769,
-    mem_baseline: 2378,
+    cpu_baseline: 33846,
+    mem_baseline: 4050,
     cpu_threshold_percent: 10,
     mem_threshold_percent: 10,
 };
 
 const PAUSE: RegressionSpec = RegressionSpec {
-    cpu_baseline: 43358,
-    mem_baseline: 5217,
+    cpu_baseline: 61908,
+    mem_baseline: 7300,
     cpu_threshold_percent: 10,
     mem_threshold_percent: 10,
 };
 
 const UNPAUSE: RegressionSpec = RegressionSpec {
-    cpu_baseline: 69428,
-    mem_baseline: 8000,
+    cpu_baseline: 97550,
+    mem_baseline: 11093,
     cpu_threshold_percent: 10,
     mem_threshold_percent: 10,
 };
 
 const CLEAR_EMERGENCY: RegressionSpec = RegressionSpec {
-    cpu_baseline: 53721,
-    mem_baseline: 6568,
+    cpu_baseline: 80435,
+    mem_baseline: 9613,
     cpu_threshold_percent: 10,
     mem_threshold_percent: 10,
 };
 
 const SCHEDULE_UNPAUSE: RegressionSpec = RegressionSpec {
-    cpu_baseline: 49093,
-    mem_baseline: 6317,
+    cpu_baseline: 67420,
+    mem_baseline: 9025,
     cpu_threshold_percent: 10,
     mem_threshold_percent: 10,
 };
 
 const TRANSFER_ADMIN: RegressionSpec = RegressionSpec {
-    cpu_baseline: 40575,
-    mem_baseline: 4936,
+    cpu_baseline: 55501,
+    mem_baseline: 6668,
     cpu_threshold_percent: 10,
     mem_threshold_percent: 10,
 };
 
 const PAUSE_FUNCTION: RegressionSpec = RegressionSpec {
-    cpu_baseline: 47263,
-    mem_baseline: 5701,
+    cpu_baseline: 59806,
+    mem_baseline: 7389,
     cpu_threshold_percent: 10,
     mem_threshold_percent: 10,
 };
 
 const UNPAUSE_FUNCTION: RegressionSpec = RegressionSpec {
-    cpu_baseline: 63556,
-    mem_baseline: 7538,
+    cpu_baseline: 79377,
+    mem_baseline: 9409,
     cpu_threshold_percent: 10,
     mem_threshold_percent: 10,
 };
 
 const PAUSE_MODULE: RegressionSpec = RegressionSpec {
-    cpu_baseline: 42067,
-    mem_baseline: 5238,
+    cpu_baseline: 53901,
+    mem_baseline: 6910,
     cpu_threshold_percent: 10,
     mem_threshold_percent: 10,
 };
 
 const UNPAUSE_MODULE: RegressionSpec = RegressionSpec {
-    cpu_baseline: 52384,
-    mem_baseline: 6750,
+    cpu_baseline: 67046,
+    mem_baseline: 8605,
     cpu_threshold_percent: 10,
     mem_threshold_percent: 10,
 };
 
 const IS_PAUSED: RegressionSpec = RegressionSpec {
-    cpu_baseline: 18092,
-    mem_baseline: 2070,
+    cpu_baseline: 23659,
+    mem_baseline: 2839,
     cpu_threshold_percent: 10,
     mem_threshold_percent: 10,
 };
 
 const IS_FUNCTION_PAUSED: RegressionSpec = RegressionSpec {
-    cpu_baseline: 38097,
-    mem_baseline: 3890,
+    cpu_baseline: 45103,
+    mem_baseline: 4659,
     cpu_threshold_percent: 10,
     mem_threshold_percent: 10,
 };
 
 const IS_MODULE_PAUSED: RegressionSpec = RegressionSpec {
-    cpu_baseline: 28118,
-    mem_baseline: 3142,
+    cpu_baseline: 33849,
+    mem_baseline: 3911,
     cpu_threshold_percent: 10,
     mem_threshold_percent: 10,
 };
 
 const LIST_PAUSED_FUNCTIONS: RegressionSpec = RegressionSpec {
-    cpu_baseline: 32686,
-    mem_baseline: 3757,
+    cpu_baseline: 38661,
+    mem_baseline: 4526,
     cpu_threshold_percent: 10,
     mem_threshold_percent: 10,
 };
 
 const GET_UNPAUSE_SCHEDULE: RegressionSpec = RegressionSpec {
-    cpu_baseline: 32393,
-    mem_baseline: 3702,
+    cpu_baseline: 42893,
+    mem_baseline: 5160,
     cpu_threshold_percent: 10,
     mem_threshold_percent: 10,
 };

--- a/emergency_killswitch/tests/test_killswitch.rs
+++ b/emergency_killswitch/tests/test_killswitch.rs
@@ -17,6 +17,7 @@ fn setup(env: &Env) -> (Address, EmergencyKillswitchClient<'_>) {
 #[test]
 fn initialize_rejects_self_address() {
     let env = Env::default();
+    env.mock_all_auths();
     let (contract_id, client) = setup(&env);
     assert_eq!(
         client.try_initialize(&contract_id),
@@ -27,14 +28,31 @@ fn initialize_rejects_self_address() {
 #[test]
 fn initialize_succeeds_with_valid_address() {
     let env = Env::default();
+    env.mock_all_auths();
     let (_, client) = setup(&env);
     let admin = Address::generate(&env);
     assert_eq!(client.try_initialize(&admin), Ok(Ok(())));
 }
 
+/// `initialize` must require `admin`'s signature. Without this, anyone could
+/// front-run deployment and call `initialize` with themselves (or any
+/// address they control) as `admin` before the intended admin does,
+/// permanently seizing control of the kill switch. No auth is mocked here —
+/// on `main` (before this fix) this call succeeds with zero authorization;
+/// after the fix it must panic on the missing signature.
+#[test]
+#[should_panic(expected = "HostError: Error(Auth, InvalidAction)")]
+fn initialize_requires_admin_signature() {
+    let env = Env::default();
+    let (_, client) = setup(&env);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+}
+
 #[test]
 fn assert_no_double_init() {
     let env = Env::default();
+    env.mock_all_auths();
     let (_, client) = setup(&env);
     let admin = Address::generate(&env);
     // First initialization should succeed

--- a/insurance/src/lib.rs
+++ b/insurance/src/lib.rs
@@ -370,9 +370,15 @@ impl Insurance {
 
     /// Initialize the insurance contract with the given owner.
     ///
+    /// Requires `owner`'s signature — without it, anyone could front-run
+    /// deployment and call `init` with themselves (or any address they
+    /// control) as `owner` before the intended owner does, permanently
+    /// seizing control of the contract.
+    ///
     /// # Errors
     /// - `AlreadyInitialized` if the contract has already been initialized
     pub fn init(env: Env, owner: Address) -> Result<(), InsuranceError> {
+        owner.require_auth();
         if env.storage().instance().has(&DataKey::Initialized) {
             return Err(InsuranceError::AlreadyInitialized);
         }

--- a/insurance/src/test.rs
+++ b/insurance/src/test.rs
@@ -101,6 +101,22 @@ mod tests {
         );
     }
 
+    /// `init` must require `owner`'s signature. Without this, anyone could
+    /// front-run deployment and call `init` with themselves (or any address
+    /// they control) as `owner` before the intended owner does, permanently
+    /// seizing control of the contract. No auth is mocked here — on `main`
+    /// (before this fix) this call succeeds with zero authorization; after
+    /// the fix it must panic on the missing signature.
+    #[test]
+    #[should_panic(expected = "HostError: Error(Auth, InvalidAction)")]
+    fn test_init_requires_owner_signature() {
+        let env = Env::default();
+        let id = env.register_contract(None, Insurance);
+        let c = InsuranceClient::new(&env, &id);
+        let owner = Address::generate(&env);
+        c.init(&owner);
+    }
+
     #[test]
     fn test_create_policy_success() {
         let env = Env::default();


### PR DESCRIPTION
## Threat model
Used `scripts/entrypoint_auth_inventory.py` to survey every public entrypoint's auth status across the workspace, then manually verified each `init`/`initialize` candidate against source (the script has false negatives — e.g. it flags `reporting::init` and `family_wallet::init` as unauthenticated when they actually do call `require_auth()`; static detection of this kind is inherently approximate). Two are genuinely missing it:

- **`emergency_killswitch::initialize`** — set the admin with no `admin.require_auth()` call.
- **`insurance::init`** — set the owner with no `owner.require_auth()` call.

**What an attacker gets if this is missing:** these are effectively the contracts' constructors. Soroban contracts have no real constructor — anyone can call any public function on a freshly-deployed, not-yet-initialized contract. Without requiring the named admin/owner's signature, an attacker can front-run the legitimate deployer: watch the mempool for the deploy transaction, then race a call to `initialize`/`init` naming themselves (or an address they control) as admin/owner, before the intended party's own initialization call lands. Whoever's transaction confirms first wins permanently — there's no recovery path once `AlreadyInitialized` locks it in.

## Change
- `emergency_killswitch::initialize`: added `admin.require_auth();` as the first line (matches this codebase's "auth first" convention, e.g. `remittance_split::distribute_usdc`'s documented ordering).
- `insurance::init`: added `owner.require_auth();` as the first line.

Both already reject the contract's own address as admin/owner (unrelated prior hardening) — this closes the actual identity-verification gap.

## An existing test was pinning the vulnerable behavior
`emergency_killswitch/tests/test_killswitch.rs::initialize_succeeds_with_valid_address` called `client.try_initialize(&admin)` with **no auth mocked at all** and asserted `Ok(Ok(()))` — i.e. it explicitly encoded "this succeeds with zero authorization" as correct. Updated it (added `env.mock_all_auths()`) along with two sibling tests (`initialize_rejects_self_address`, `assert_no_double_init`) that had the same gap, so they now test the *properly authorized* path instead of the vulnerable one.

## Test plan
- **New, previously-nonexistent negative tests** (the issue's "fails today, passes after" requirement — these reference `require_auth`/`Auth` behavior that plainly did not hold on `main`):
  - `emergency_killswitch/tests/test_killswitch.rs::initialize_requires_admin_signature` — `#[should_panic(expected = "HostError: Error(Auth, InvalidAction)")]`, no auth mocked, calls `client.initialize(&admin)` directly.
  - `insurance/src/test.rs::test_init_requires_owner_signature` — same pattern for `insurance::init`.
- `cargo test -p emergency_killswitch --lib` — 16/16 passing. `cargo test -p emergency_killswitch --test test_killswitch` — 36/36 passing (including the new + 3 updated tests).
- `cargo test -p insurance --lib` — 74 passed, 14 failed (13 pre-existing failures + 1 pre-existing SIGABRT-on-budget-exhaustion test) — **identical to baseline `main`** via `git stash` comparison; none are new, none touch `init`/auth.
- **Gas benchmarks**: adding a real auth check has a real, small CPU/mem cost. `emergency_killswitch`'s `gas_bench.rs` hardcodes a `RegressionSpec` baseline per benchmark (not the shared `benchmarks/baseline.json`, which doesn't cover this contract) — `initialize` is called as setup for every benchmark in this file, so the cost rippled through all 15. Re-measured via `cargo test -p emergency_killswitch --test gas_bench -- --nocapture` and updated all 15 baselines to the new observed values (with a comment explaining why). All 15 now pass. `insurance`'s two pre-existing gas-bench failures (`pay_premium` typical/worst-case) are unaffected — confirmed via `git stash`, byte-for-byte the same failure on baseline.
- `cargo build --release --target wasm32-unknown-unknown` (full workspace) — clean build
- `cargo clippy -p emergency_killswitch -p insurance --all-targets --all-features` — no new warnings (the two shown, `unused import: std::format` and `dead_code: policy_name` in `insurance/src/test.rs`, are pre-existing, confirmed via `git stash`)
- `cargo fmt -p emergency_killswitch -p insurance -- --check` — clean, no diff

Closes #1538