### PR TITLE
feat(remittance-split): add batch_transfer entrypoint

### DIFF
--- a/remittance_split/src/lib.rs
+++ b/remittance_split/src/lib.rs
@@ -15,6 +15,18 @@ use remitwise_common::{
     PERSISTENT_BUMP_AMOUNT, PERSISTENT_LIFETIME_THRESHOLD, SNAPSHOT_KEY, SNAPSHOT_VERSION,
 };
 
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, symbol_short, token::TokenClient, vec,
+    Address, Bytes, BytesN, Env, IntoVal, Map, Symbol, Vec,
+};
+
+// Event topics
+const SPLIT_INITIALIZED: Symbol = symbol_short!("init");
+const SPLIT_CALCULATED: Symbol = symbol_short!("calc");
+
+// Request hash domain separator for signing (prevents cross-domain attacks)
+const DISTRIBUTE_USDC_DOMAIN: &[u8] = b"distribute_usdc_v1";
+
 mod fee_math;
 
 #[derive(Clone)]
@@ -1244,14 +1256,14 @@ impl RemittanceSplit {
             EventCategory::State,
             EventPriority::Medium,
             symbol_short!("init"),
-            owner,
+            owner.clone(),
         );
 
         // Emit event for audit trail
         env.events()
             .publish((symbol_short!("admin"), SplitEvent::Initialized), owner);
 
-        true
+        Ok(true)
     }
 
     pub fn update_split(
@@ -1316,7 +1328,7 @@ impl RemittanceSplit {
         env.events()
             .publish((symbol_short!("admin"), SplitEvent::Updated), caller);
 
-        true
+        Ok(true)
     }
 
     /// Rotate the split configuration's owner.
@@ -2615,6 +2627,17 @@ impl RemittanceSplit {
         Ok([spending, savings, bills, insurance])
     }
 
+    /// Extend the TTL of a persistent storage entry using
+    /// PERSISTENT_BUMP_AMOUNT / PERSISTENT_LIFETIME_THRESHOLD from
+    /// remitwise-common.
+    fn extend_persistent_ttl(env: &Env, key: &DataKey) {
+        env.storage().persistent().extend_ttl(
+            key,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+    }
+
     /// Extend the TTL of instance storage using INSTANCE_BUMP_AMOUNT / INSTANCE_LIFETIME_THRESHOLD
     /// from remitwise-common.
     fn extend_instance_ttl(env: &Env) {
@@ -2622,55 +2645,6 @@ impl RemittanceSplit {
             .instance()
             .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
     }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use soroban_sdk::{
-        testutils::{Address as _, Events as _},
-        token::{StellarAssetClient, TokenClient},
-        Env, TryFromVal,
-    };
-
-    #[test]
-    fn distribute_usdc_apportions_tokens_to_recipients() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let contract_id = env.register_contract(None, RemittanceSplit);
-        let client = RemittanceSplitClient::new(&env, &contract_id);
-
-        let admin = Address::generate(&env);
-        let token_contract = env.register_stellar_asset_contract_v2(admin.clone());
-        let payer = Address::generate(&env);
-        let amount = 1_000i128;
-
-        StellarAssetClient::new(&env, &token_contract.address()).mint(&payer, &amount);
-
-        let spending = Address::generate(&env);
-        let savings = Address::generate(&env);
-        let bills = Address::generate(&env);
-        let insurance = Address::generate(&env);
-
-        let accounts = AccountGroup {
-            spending: spending.clone(),
-            savings: savings.clone(),
-            bills: bills.clone(),
-            insurance: insurance.clone(),
-        };
-
-        let distributed =
-            client.distribute_usdc(&token_contract.address(), &payer, &accounts, &amount);
-
-        assert!(distributed);
-
-        let token_client = TokenClient::new(&env, &token_contract.address());
-        assert_eq!(token_client.balance(&spending), 500);
-        assert_eq!(token_client.balance(&savings), 300);
-        assert_eq!(token_client.balance(&bills), 150);
-        assert_eq!(token_client.balance(&insurance), 50);
-        assert_eq!(token_client.balance(&payer), 0);
-    }
-
     /// Create a new automatic remittance schedule for the split owner.
     ///
     /// # Arguments
@@ -3263,6 +3237,98 @@ mod tests {
             count,
         }
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{
+        testutils::{Address as _, Events as _},
+        token::{StellarAssetClient, TokenClient},
+        Env, TryFromVal,
+    };
+
+    #[test]
+    fn distribute_usdc_apportions_tokens_to_recipients() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, RemittanceSplit);
+        let client = RemittanceSplitClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let token_contract = env.register_stellar_asset_contract_v2(admin.clone());
+        let payer = Address::generate(&env);
+        let amount = 1_000i128;
+
+        StellarAssetClient::new(&env, &token_contract.address()).mint(&payer, &amount);
+
+        let spending = Address::generate(&env);
+        let savings = Address::generate(&env);
+        let bills = Address::generate(&env);
+        let insurance = Address::generate(&env);
+
+        let accounts = AccountGroup {
+            spending: spending.clone(),
+            savings: savings.clone(),
+            bills: bills.clone(),
+            insurance: insurance.clone(),
+        };
+
+        client.initialize_split(
+            &payer,
+            &0,
+            &token_contract.address(),
+            &5000,
+            &3000,
+            &1500,
+            &500,
+        );
+
+        let nonce = 1u64; // initialize_split already consumed nonce 0 for `payer`
+        let deadline = env.ledger().timestamp() + 100;
+        let request_hash = RemittanceSplit::compute_request_hash(
+            symbol_short!("distrib"),
+            payer.clone(),
+            nonce,
+            amount,
+            deadline,
+        );
+
+        let distributed = client.distribute_usdc(
+            &token_contract.address(),
+            &payer,
+            &nonce,
+            &deadline,
+            &request_hash,
+            &accounts,
+            &amount,
+        );
+
+        assert!(distributed);
+
+        let token_client = TokenClient::new(&env, &token_contract.address());
+        assert_eq!(token_client.balance(&spending), 500);
+        assert_eq!(token_client.balance(&savings), 300);
+        assert_eq!(token_client.balance(&bills), 150);
+        assert_eq!(token_client.balance(&insurance), 50);
+        assert_eq!(token_client.balance(&payer), 0);
+
+        // get_usdc_balance() is the contract's own read-only balance view --
+        // it must reflect the transfers `distribute_usdc` just made in this
+        // same call, not whatever the balance was before the transaction
+        // that moved the funds. It has no storage-backed cache of its own
+        // (it always queries the token contract directly), so this pins
+        // down that the view is never stale relative to a transfer that
+        // already landed.
+        assert_eq!(
+            client.get_usdc_balance(&token_contract.address(), &payer),
+            0
+        );
+        assert_eq!(
+            client.get_usdc_balance(&token_contract.address(), &spending),
+            500
+        );
+    }
 
     /// Returns the `Symbol` topic prefix (the first element of the topic
     /// tuple) of the most recently published event.
@@ -3280,10 +3346,12 @@ mod tests {
         let client = RemittanceSplitClient::new(&env, &contract_id);
 
         let owner = Address::generate(&env);
-        client.initialize_split(&owner, &50, &30, &15, &5);
+        let usdc_admin = Address::generate(&env);
+        let usdc_contract = env.register_stellar_asset_contract_v2(usdc_admin).address();
+        client.initialize_split(&owner, &0, &usdc_contract, &5000, &3000, &1500, &500);
         assert_eq!(last_event_topic_prefix(&env), symbol_short!("admin"));
 
-        client.update_split(&owner, &40, &30, &20, &10);
+        client.update_split(&owner, &1, &4000, &3000, &2000, &1000);
         assert_eq!(last_event_topic_prefix(&env), symbol_short!("admin"));
     }
 
@@ -3308,7 +3376,9 @@ mod tests {
 
         let owner = Address::generate(&env);
         let new_owner = Address::generate(&env);
-        client.initialize_split(&owner, &50, &30, &15, &5);
+        let usdc_admin = Address::generate(&env);
+        let usdc_contract = env.register_stellar_asset_contract_v2(usdc_admin).address();
+        client.initialize_split(&owner, &0, &usdc_contract, &5000, &3000, &1500, &500);
 
         client.rotate_owner(&owner, &new_owner);
 
@@ -3326,7 +3396,9 @@ mod tests {
         let owner = Address::generate(&env);
         let stranger = Address::generate(&env);
         let new_owner = Address::generate(&env);
-        client.initialize_split(&owner, &50, &30, &15, &5);
+        let usdc_admin = Address::generate(&env);
+        let usdc_contract = env.register_stellar_asset_contract_v2(usdc_admin).address();
+        client.initialize_split(&owner, &0, &usdc_contract, &5000, &3000, &1500, &500);
 
         client.rotate_owner(&stranger, &new_owner);
     }
@@ -3340,7 +3412,9 @@ mod tests {
         let client = RemittanceSplitClient::new(&env, &contract_id);
 
         let owner = Address::generate(&env);
-        client.initialize_split(&owner, &50, &30, &15, &5);
+        let usdc_admin = Address::generate(&env);
+        let usdc_contract = env.register_stellar_asset_contract_v2(usdc_admin).address();
+        client.initialize_split(&owner, &0, &usdc_contract, &5000, &3000, &1500, &500);
 
         client.rotate_owner(&owner, &contract_id);
     }

--- a/remittance_split/src/lib.rs
+++ b/remittance_split/src/lib.rs
@@ -11,7 +11,7 @@ mod tests_safe_math;
 
 use remitwise_common::{
     clamp_limit, guard_bytes_len, verify_no_dust, EventCategory, EventPriority, RemitwiseEvents,
-    Timestamp, ToI128Checked, INSTANCE_BUMP_AMOUNT, INSTANCE_LIFETIME_THRESHOLD,
+    Timestamp, ToI128Checked, INSTANCE_BUMP_AMOUNT, INSTANCE_LIFETIME_THRESHOLD, MAX_BATCH_SIZE,
     PERSISTENT_BUMP_AMOUNT, PERSISTENT_LIFETIME_THRESHOLD, SNAPSHOT_KEY, SNAPSHOT_VERSION,
 };
 
@@ -106,6 +106,10 @@ pub enum RemittanceSplitError {
     DuplicateCorridorId = 38,
     /// Fee rounding error.
     FeeRounding = 39,
+    /// `batch_transfer`'s `recipients` and `amounts` vectors have different lengths.
+    BatchLengthMismatch = 40,
+    /// `batch_transfer`'s recipient count exceeds `remitwise_common::MAX_BATCH_SIZE`.
+    BatchSizeExceeded = 41,
 }
 
 #[derive(Clone)]
@@ -1847,6 +1851,80 @@ impl RemittanceSplit {
         Self::increment_nonce(&env, &request.from)?;
         Self::append_audit(&env, symbol_short!("distH"), &request.from, true);
         Self::emit_distribution_completed(&env, &request.from, request.total_amount, &amounts);
+        Ok(true)
+    }
+
+    /// Transfers the configured USDC asset from `caller` to each address in
+    /// `recipients`, in the paired `amounts`, in one call.
+    ///
+    /// Unlike `distribute_usdc` (which always splits into the four fixed
+    /// spending/savings/bills/insurance accounts), this sends arbitrary
+    /// amounts to arbitrary recipients -- for owner-directed payouts that
+    /// don't follow the split percentages.
+    ///
+    /// # Errors
+    /// - `NotInitialized` if the split has not been initialized.
+    /// - `Unauthorized` if `caller` is not the configured owner.
+    /// - `UntrustedTokenContract` if `usdc_contract` != the trusted address
+    ///   pinned at initialization.
+    /// - `BatchLengthMismatch` if `recipients.len() != amounts.len()`.
+    /// - `BatchSizeExceeded` if `recipients.len() > MAX_BATCH_SIZE`.
+    /// - `InvalidAmount` if any amount is <= 0.
+    /// - `InvalidNonce` on replay.
+    pub fn batch_transfer(
+        env: Env,
+        caller: Address,
+        nonce: u64,
+        usdc_contract: Address,
+        recipients: Vec<Address>,
+        amounts: Vec<i128>,
+    ) -> Result<bool, RemittanceSplitError> {
+        caller.require_auth();
+        Self::require_not_paused(&env)?;
+
+        let config: SplitConfig = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("CONFIG"))
+            .ok_or(RemittanceSplitError::NotInitialized)?;
+        if config.owner != caller {
+            Self::append_audit(&env, symbol_short!("batchtx"), &caller, false);
+            return Err(RemittanceSplitError::Unauthorized);
+        }
+        if config.usdc_contract != usdc_contract {
+            Self::append_audit(&env, symbol_short!("batchtx"), &caller, false);
+            return Err(RemittanceSplitError::UntrustedTokenContract);
+        }
+
+        if recipients.len() != amounts.len() {
+            return Err(RemittanceSplitError::BatchLengthMismatch);
+        }
+        if recipients.len() > MAX_BATCH_SIZE {
+            return Err(RemittanceSplitError::BatchSizeExceeded);
+        }
+
+        Self::require_nonce(&env, &caller, nonce)?;
+
+        for amount in amounts.iter() {
+            if amount <= 0 {
+                return Err(RemittanceSplitError::InvalidAmount);
+            }
+        }
+
+        let token = TokenClient::new(&env, &usdc_contract);
+        for i in 0..recipients.len() {
+            let recipient = recipients.get(i).ok_or(RemittanceSplitError::Overflow)?;
+            let amount = amounts.get(i).ok_or(RemittanceSplitError::Overflow)?;
+            token.transfer(&caller, &recipient, &amount);
+        }
+
+        Self::increment_nonce(&env, &caller)?;
+        Self::append_audit(&env, symbol_short!("batchtx"), &caller, true);
+        env.events().publish(
+            (symbol_short!("split"), symbol_short!("batch_tx")),
+            (caller, recipients.len()),
+        );
+
         Ok(true)
     }
 

--- a/remittance_split/src/test.rs
+++ b/remittance_split/src/test.rs
@@ -3035,3 +3035,137 @@ fn test_fractional_bps_corridor_now_validates() {
         Ok(())
     );
 }
+
+/// Issue #1592: an owner-directed `batch_transfer` entrypoint for sending
+/// arbitrary amounts to arbitrary recipients in a single call.
+#[test]
+fn test_batch_transfer_sends_funds_to_each_recipient() {
+    let env = Env::default();
+    let harness = setup_split(&env, 4_000, 3_000, 2_000, 1_000);
+    harness.stellar_client.mint(&harness.owner, &1_000);
+
+    let r1 = Address::generate(&env);
+    let r2 = Address::generate(&env);
+    let recipients = vec![&env, r1.clone(), r2.clone()];
+    let amounts = vec![&env, 300i128, 700i128];
+
+    let result = harness.client.batch_transfer(
+        &harness.owner,
+        &1, // nonce 0 used in initialize_split
+        &harness.token_addr,
+        &recipients,
+        &amounts,
+    );
+    assert!(result);
+    assert_eq!(
+        RemittanceSplit::get_usdc_balance(&env, harness.token_addr.clone(), r1),
+        300
+    );
+    assert_eq!(
+        RemittanceSplit::get_usdc_balance(&env, harness.token_addr.clone(), r2),
+        700
+    );
+}
+
+#[test]
+fn test_batch_transfer_rejects_length_mismatch() {
+    let env = Env::default();
+    let harness = setup_split(&env, 4_000, 3_000, 2_000, 1_000);
+    harness.stellar_client.mint(&harness.owner, &1_000);
+
+    let recipients = vec![&env, Address::generate(&env), Address::generate(&env)];
+    let amounts = vec![&env, 300i128];
+
+    let result = harness.client.try_batch_transfer(
+        &harness.owner,
+        &0,
+        &harness.token_addr,
+        &recipients,
+        &amounts,
+    );
+    assert_eq!(result, Err(Ok(RemittanceSplitError::BatchLengthMismatch)));
+}
+
+#[test]
+fn test_batch_transfer_rejects_batch_over_max_size() {
+    let env = Env::default();
+    let harness = setup_split(&env, 4_000, 3_000, 2_000, 1_000);
+
+    let mut recipients = vec![&env];
+    let mut amounts = vec![&env];
+    for _ in 0..=MAX_BATCH_SIZE {
+        recipients.push_back(Address::generate(&env));
+        amounts.push_back(1i128);
+    }
+
+    let result = harness.client.try_batch_transfer(
+        &harness.owner,
+        &0,
+        &harness.token_addr,
+        &recipients,
+        &amounts,
+    );
+    assert_eq!(result, Err(Ok(RemittanceSplitError::BatchSizeExceeded)));
+}
+
+#[test]
+fn test_batch_transfer_rejects_non_owner_caller() {
+    let env = Env::default();
+    let harness = setup_split(&env, 4_000, 3_000, 2_000, 1_000);
+    let not_owner = Address::generate(&env);
+    let recipients = vec![&env, Address::generate(&env)];
+    let amounts = vec![&env, 100i128];
+
+    let result = harness.client.try_batch_transfer(
+        &not_owner,
+        &0,
+        &harness.token_addr,
+        &recipients,
+        &amounts,
+    );
+    assert_eq!(result, Err(Ok(RemittanceSplitError::Unauthorized)));
+}
+
+#[test]
+fn test_batch_transfer_rejects_untrusted_token_contract() {
+    let env = Env::default();
+    let harness = setup_split(&env, 4_000, 3_000, 2_000, 1_000);
+    let other_token = Address::generate(&env);
+    let recipients = vec![&env, Address::generate(&env)];
+    let amounts = vec![&env, 100i128];
+
+    let result =
+        harness
+            .client
+            .try_batch_transfer(&harness.owner, &0, &other_token, &recipients, &amounts);
+    assert_eq!(
+        result,
+        Err(Ok(RemittanceSplitError::UntrustedTokenContract))
+    );
+}
+
+#[test]
+fn test_batch_transfer_rejects_replayed_nonce() {
+    let env = Env::default();
+    let harness = setup_split(&env, 4_000, 3_000, 2_000, 1_000);
+    harness.stellar_client.mint(&harness.owner, &1_000);
+
+    let recipients = vec![&env, Address::generate(&env)];
+    let amounts = vec![&env, 100i128];
+
+    harness.client.batch_transfer(
+        &harness.owner,
+        &1, // nonce 0 used in initialize_split
+        &harness.token_addr,
+        &recipients,
+        &amounts,
+    );
+    let result = harness.client.try_batch_transfer(
+        &harness.owner,
+        &1,
+        &harness.token_addr,
+        &recipients,
+        &amounts,
+    );
+    assert_eq!(result, Err(Ok(RemittanceSplitError::InvalidNonce)));
+}


### PR DESCRIPTION
## Summary

**Note:** builds on #1666 (`remittance_split` didn't compile on `main` at all -- fixed there). Until that merges, this diff includes that repair too; the actual fix here is small (see the last commit / diff against #1666's branch for the real delta).

Adds an owner-directed `batch_transfer` entrypoint: sends arbitrary USDC amounts to arbitrary recipients in a single call. This is distinct from `distribute_usdc`, which always splits into the four fixed spending/savings/bills/insurance accounts by percentage -- `batch_transfer` is for owner-directed payouts that don't follow the split at all.

- `caller` must be the configured owner (`Unauthorized` otherwise).
- `usdc_contract` must match the trusted address pinned at initialization (`UntrustedTokenContract` otherwise).
- `recipients`/`amounts` must be the same length (`BatchLengthMismatch` otherwise).
- Batch size is capped at `remitwise_common::MAX_BATCH_SIZE` (`BatchSizeExceeded` otherwise), matching the batch-size convention already documented for other entrypoints in this repo.
- Each amount must be positive (`InvalidAmount` otherwise).
- Standard nonce replay protection (`InvalidNonce` on reuse).

Adds two new error variants: `BatchLengthMismatch = 40`, `BatchSizeExceeded = 41`.

## Testing

- Added 6 tests: happy-path multi-recipient transfer, length mismatch, batch-size-exceeded, non-owner caller, untrusted token contract, and nonce replay rejection.
- `cargo test -p remittance_split` -- all 6 new tests pass. (Note: this crate has ~52 pre-existing test failures unrelated to this change -- confirmed via `git stash` that they fail identically on the base branch before this PR's diff; out of scope here.)
- `cargo fmt -p remittance_split -- --check` -- clean
- `cargo check -p remittance_split` -- clean
- `cargo build -p remittance_split --target wasm32-unknown-unknown --release` -- builds clean

Closes #1592