### PR TITLE
fix(family_wallet): cap the caller-supplied initial_members list on init

### DIFF
--- a/family_wallet/src/lib.rs
+++ b/family_wallet/src/lib.rs
@@ -425,6 +425,17 @@ impl FamilyWallet {
             return false;
         }
         owner.require_auth();
+        // Reject an oversized initial member list up front, before any storage
+        // writes. `initial_members` is fully caller-controlled and, without this
+        // cap, is looped over unbounded below — an attacker (or a careless
+        // caller) could pass an arbitrarily large list and burn CPU/memory
+        // proportional to its length instead of hitting the same
+        // MAX_FAMILY_MEMBERS cap every other member-adding entrypoint
+        // (`batch_add_family_members`) already enforces. `+1` accounts for the
+        // owner, who is also added as a member below.
+        if initial_members.len().saturating_add(1) > MAX_FAMILY_MEMBERS {
+            panic!("Initial member cap exceeded");
+        }
         let existing: Option<Address> = env.storage().instance().get(&symbol_short!("OWNER"));
         if existing.is_some() {
             return false;

--- a/family_wallet/src/test.rs
+++ b/family_wallet/src/test.rs
@@ -55,6 +55,52 @@ fn test_initialize_wallet_succeeds() {
     assert_eq!(owner_data.unwrap().role, FamilyRole::Owner);
 }
 
+/// Exactly at the cap (owner + MAX_FAMILY_MEMBERS - 1 initial members =
+/// MAX_FAMILY_MEMBERS total) must still succeed — the cap rejects strictly
+/// more than the limit, not the limit itself.
+#[test]
+fn test_initialize_wallet_succeeds_at_member_cap_boundary() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, FamilyWallet);
+    let client = FamilyWalletClient::new(&env, &contract_id);
+    let owner = Address::generate(&env);
+
+    let mut initial_members = vec![&env];
+    for _ in 0..(MAX_FAMILY_MEMBERS - 1) {
+        initial_members.push_back(Address::generate(&env));
+    }
+
+    let result = client.init(&owner, &initial_members);
+    assert!(
+        result,
+        "initialization exactly at the member cap must succeed"
+    );
+}
+
+/// Regression test for the hardening in this PR: `initial_members` is fully
+/// caller-controlled and, before this fix, was looped over with no length
+/// check at all — an oversized list would burn CPU/memory proportional to
+/// its length instead of being rejected up front. One more than the cap
+/// (accounting for the owner, who is also added as a member) must panic
+/// immediately, not attempt the unbounded loop.
+#[test]
+#[should_panic(expected = "Initial member cap exceeded")]
+fn test_initialize_wallet_rejects_oversized_initial_members() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, FamilyWallet);
+    let client = FamilyWalletClient::new(&env, &contract_id);
+    let owner = Address::generate(&env);
+
+    let mut initial_members = vec![&env];
+    for _ in 0..MAX_FAMILY_MEMBERS {
+        initial_members.push_back(Address::generate(&env));
+    }
+
+    client.init(&owner, &initial_members);
+}
+
 #[test]
 #[should_panic(expected = "Wallet already initialized")]
 fn assert_no_double_init() {
@@ -3525,17 +3571,18 @@ fn test_too_many_signers_rejected() {
 
     let owner = Address::generate(&env);
 
-    // Create 101 members — far beyond MAX_SIGNERS (= 20; the boundary
-    // itself is pinned by test_signer_cap_boundary_* below).
-    let mut members = Vec::new(&env);
+    // 101 signers — far beyond MAX_SIGNERS (= 20; the boundary itself is
+    // pinned by test_signer_cap_boundary_* below). `configure_multisig`
+    // checks `signer_count > MAX_SIGNERS` without requiring each signer to
+    // already be a registered family member, so these don't need to be
+    // passed as `initial_members` too (which has its own, much lower,
+    // MAX_FAMILY_MEMBERS cap).
     let mut signers = Vec::new(&env);
     for _ in 0..101 {
-        let addr = Address::generate(&env);
-        members.push_back(addr.clone());
-        signers.push_back(addr);
+        signers.push_back(Address::generate(&env));
     }
 
-    client.init(&owner, &members);
+    client.init(&owner, &Vec::new(&env));
 
     let result = client.try_configure_multisig(
         &owner,


### PR DESCRIPTION
## Context
This exact issue wording ("cap loop bounds on user-supplied inputs") was already fixed once, under #1634 (`harden corridor validation loop bounds`), for `remittance_split::validate_corridors`. Before opening a duplicate PR, I looked for a still-open instance of the same bug class elsewhere in the workspace.

## Threat model
`family_wallet::try_initialize(env, owner, initial_members: Vec<Address>)` loops over the full, caller-supplied `initial_members` list with **no length check at all**, writing one storage entry per address:

```rust
for member_addr in initial_members.iter() {
    members.set(member_addr.clone(), FamilyMember { ... });
}
```

`initial_members` is fully attacker/caller-controlled. Unlike `batch_add_family_members`, which already enforces `MAX_FAMILY_MEMBERS` (= `MAX_BATCH_MEMBERS` = 30) before adding more members, `init`/`try_initialize` had no equivalent bound — a caller could pass an arbitrarily large list at initialization time and burn CPU/memory proportional to its length, with no clean rejection, instead of the same cap every other member-adding entrypoint in this same file already respects.

## Change
Added a length check as the first thing `try_initialize` does after auth (reject bad input at the boundary, before any storage writes):

```rust
if initial_members.len().saturating_add(1) > MAX_FAMILY_MEMBERS {
    panic!("Initial member cap exceeded");
}
```

The `+1` accounts for the owner, who is also added as a member in the same function. `init`/`try_initialize` return a bare `bool`, not `Result<_, Error>` — changing that to a typed `Result` would be a breaking API change well beyond this issue's scope, so this matches the *existing* local idiom for the exact same `MAX_FAMILY_MEMBERS` cap in `batch_add_family_members` (`panic!("Member cap exceeded")`), just with a distinguishable message for this call site.

Closes #1540

## An existing test exercised the exact behavior this closes
`test_too_many_signers_rejected` created **101 members** and passed them straight into `client.init(&owner, &members)` as a way to set up an unrelated scenario (testing `configure_multisig`'s separate `MAX_SIGNERS` cap) — relying on `init` accepting an unbounded list. Updated it to `init` with an empty member list and generate the 101 addresses only for the `signers` argument (`configure_multisig` checks `signer_count > MAX_SIGNERS` without requiring signers to already be registered members, so this is a legitimate, still-equivalent test of what it was actually testing).

## Test plan
- **New tests** in `family_wallet/src/test.rs`:
  - `test_initialize_wallet_succeeds_at_member_cap_boundary` — exactly at the cap (owner + `MAX_FAMILY_MEMBERS - 1` initial members = `MAX_FAMILY_MEMBERS` total) still succeeds.
  - `test_initialize_wallet_rejects_oversized_initial_members` — `#[should_panic(expected = "Initial member cap exceeded")]`, one over the cap. This references behavior that did not exist on `main` (the panic didn't fire; the loop would have run unbounded) — satisfies the "fails today, passes after" requirement.
- `cargo test -p family_wallet --lib`: **177 passed, 35 failed** — identical failure count/names to baseline `main` (confirmed via `git stash` A/B diff of the exact failing test names) plus my 2 new passing tests. The only test whose *result* changed is `test_too_many_signers_rejected`, fixed above to test what it always intended to.
- `cargo test -p family_wallet --test gas_bench --test operator_role_lifecycle` — all passing. `cargo test -p family_wallet --test signer_rotation` — 3 pre-existing failures, confirmed identical to baseline via the same `git stash` comparison, untouched by this change.
- `cargo build --release --target wasm32-unknown-unknown -p family_wallet` — clean build
- `cargo clippy -p family_wallet --all-targets --all-features` — zero new warnings (diffed full warning list against baseline via `git stash`)
- `cargo fmt -p family_wallet -- --check` — clean except one pre-existing, unrelated diff at `lib.rs:1126` (confirmed present on baseline `main`, nowhere near this change — deliberately left alone to keep this PR scoped to #1540)