### PR TITLE
Fix: cross-contract call swallows the inner error

### DIFF
--- a/orchestrator/src/lib.rs
+++ b/orchestrator/src/lib.rs
@@ -1341,21 +1341,31 @@ impl Orchestrator {
 
         if savings_amt > 0 {
             let s_client = interface::SavingsGoalsClient::new(env, &routing.savings);
-            if s_client
-                .try_add_to_goal(caller, &routing.goal_id, &savings_amt)
-                .is_err()
-            {
-                return Err(OrchestratorError::CrossContractCallFailed);
+            match s_client.try_add_to_goal(caller, &routing.goal_id, &savings_amt) {
+                Ok(Ok(_)) => savings_done = true,
+                Ok(Err(_)) => {
+                    Self::emit_cross_contract_failure(env, symbol_short!("savings"), true);
+                    return Err(OrchestratorError::CrossContractCallFailed);
+                }
+                Err(_) => {
+                    Self::emit_cross_contract_failure(env, symbol_short!("savings"), false);
+                    return Err(OrchestratorError::CrossContractCallFailed);
+                }
             }
-            savings_done = true;
         }
 
         if bills_amt > 0 {
             let b_client = interface::BillPaymentsClient::new(env, &routing.bills);
-            if b_client
-                .try_pay_bill(caller, &routing.bill_id, &bills_amt)
-                .is_err()
-            {
+            let rejected_by_contract = match b_client.try_pay_bill(caller, &routing.bill_id, &bills_amt) {
+                Ok(Ok(_)) => {
+                    bills_done = true;
+                    None
+                }
+                Ok(Err(_)) => Some(true),
+                Err(_) => Some(false),
+            };
+            if let Some(from_contract) = rejected_by_contract {
+                Self::emit_cross_contract_failure(env, symbol_short!("bills"), from_contract);
                 if compensate_on_failure {
                     Self::compensate_savings(
                         env,
@@ -1368,15 +1378,17 @@ impl Orchestrator {
                 }
                 return Err(OrchestratorError::CrossContractCallFailed);
             }
-            bills_done = true;
         }
 
         if insurance_amt > 0 {
             let i_client = interface::InsuranceClient::new(env, &routing.insurance);
-            if i_client
-                .try_pay_premium(caller, &routing.policy_id, &insurance_amt)
-                .is_err()
-            {
+            let rejected_by_contract = match i_client.try_pay_premium(caller, &routing.policy_id, &insurance_amt) {
+                Ok(Ok(_)) => None,
+                Ok(Err(_)) => Some(true),
+                Err(_) => Some(false),
+            };
+            if let Some(from_contract) = rejected_by_contract {
+                Self::emit_cross_contract_failure(env, symbol_short!("insur"), from_contract);
                 if compensate_on_failure {
                     Self::compensate_savings(
                         env,
@@ -1393,6 +1405,22 @@ impl Orchestrator {
         }
 
         Ok(())
+    }
+
+    /// Surfaces the inner failure that `run_remittance_fan_out` would otherwise
+    /// swallow behind a single generic [`OrchestratorError::CrossContractCallFailed`].
+    ///
+    /// `step` identifies which downstream call failed; `rejected_by_contract`
+    /// distinguishes a deliberate rejection from the callee's own logic (`true`,
+    /// e.g. its own validation/auth failed) from a lower-level invocation failure
+    /// (`false`, e.g. the address is not a deployed contract with a matching
+    /// interface). Both were previously indistinguishable from the caller's
+    /// perspective.
+    fn emit_cross_contract_failure(env: &Env, step: Symbol, rejected_by_contract: bool) {
+        env.events().publish(
+            (symbol_short!("cctx_err"), step),
+            rejected_by_contract,
+        );
     }
 
     /// Compensate a savings-goal contribution if it was applied.

--- a/orchestrator/src/test.rs
+++ b/orchestrator/src/test.rs
@@ -1038,6 +1038,46 @@ fn test_rollback_savings_step_returns_cross_contract_error() {
 }
 
 #[test]
+fn test_cross_contract_failure_emits_step_and_cause() {
+    // Before this fix, every downstream failure collapsed into the same
+    // generic `CrossContractCallFailed` error with no way to tell which step
+    // failed or whether it was the callee's own logic vs. the invocation
+    // itself. Assert the swallowed information is now surfaced as an event.
+    let (env, owner) = setup_test();
+    let (orchestrator_id, client) = register_orchestrator(&env);
+
+    let fw = env.register_contract(None, MockContract);
+    let rs = env.register_contract(None, MockContract);
+    let sg = env.register_contract(None, mock_fail_savings::Contract);
+    let bp = env.register_contract(None, MockContract);
+    let ins = env.register_contract(None, MockContract);
+    init_orchestrator_with_mocks(&env, &client, &owner, fw, rs, sg, bp, ins);
+
+    let executor = Address::generate(&env);
+    let deadline = signed_flow_deadline(&env);
+    let hash = signed_flow_hash(&env, &executor, 10000, 0, deadline);
+    let _ =
+        client.try_execute_remittance_flow_signed(&executor, &10000, &0, &deadline, &hash, &0u64);
+
+    let expected_topics = soroban_sdk::vec![
+        &env,
+        symbol_short!("cctx_err").into_val(&env),
+        symbol_short!("savings").into_val(&env),
+    ];
+    let matched: std::vec::Vec<_> = env
+        .events()
+        .all()
+        .iter()
+        .filter(|(cid, topics, _)| cid == &orchestrator_id && *topics == expected_topics)
+        .collect();
+    assert_eq!(matched.len(), 1);
+    // `mock_fail_savings` panics rather than returning a typed error, so this
+    // is an invocation-level failure (`rejected_by_contract == false`).
+    let (_, _, data) = &matched[0];
+    assert_eq!(bool::from_val(&env, data), false);
+}
+
+#[test]
 fn test_rollback_bill_step_triggers_compensation() {
     let (env, owner) = setup_test();
     let (_, client) = register_orchestrator(&env);


### PR DESCRIPTION
## Summary
`run_remittance_fan_out` collapsed every downstream cross-contract failure (savings, bills, insurance) into the same generic `OrchestratorError::CrossContractCallFailed`, discarding whether the callee itself rejected the call (`Ok(Err(_))`) or the invocation could not be made at all (`Err(_)`, e.g. bad address/interface mismatch). Callers and off-chain indexers had no way to tell which step failed or why.

## Change
- Match on the full nested `try_*` result instead of collapsing it with `.is_err()`.
- Emit a `(cctx_err, <step>)` event carrying a `bool` (`rejected_by_contract`) before returning the existing error, for each of the three downstream calls (savings, bills, insurance). Existing return values/error variants are unchanged, so this is additive.

## Tests
- Added `test_cross_contract_failure_emits_step_and_cause`, which reproduces the swallow (a failing mock previously produced identical, undifferentiated errors) and asserts the new event carries the failing step and cause.
- `cargo test -p orchestrator --lib`: 95 passed (1 pre-existing, unrelated failure that requires wasm artifacts to be pre-built).

Closes #1627