### PR TITLE
API: add a pause_reason(): Symbol getter

### DIFF
--- a/emergency_killswitch/src/lib.rs
+++ b/emergency_killswitch/src/lib.rs
@@ -22,6 +22,7 @@ enum DataKey {
     Admin,
     GlobalPaused,
     PausedSince,
+    PauseReason,
     ModulePaused(Symbol),
     PausedFunctions(Symbol),
     UnpauseSchedule,
@@ -183,6 +184,17 @@ impl EmergencyKillswitch {
     }
 
     pub fn pause(env: Env) -> Result<(), Error> {
+        Self::pause_internal(env, None)
+    }
+
+    /// Same as [`pause`], but records `reason` for later retrieval via
+    /// [`pause_reason`]. Additive alternative kept separate from `pause` so
+    /// existing callers/signatures are unaffected.
+    pub fn pause_with_reason(env: Env, reason: Symbol) -> Result<(), Error> {
+        Self::pause_internal(env, Some(reason))
+    }
+
+    fn pause_internal(env: Env, reason: Option<Symbol>) -> Result<(), Error> {
         let admin: Address = env
             .storage()
             .instance()
@@ -194,6 +206,10 @@ impl EmergencyKillswitch {
             .instance()
             .set(&DataKey::PausedSince, &env.ledger().timestamp());
         env.storage().instance().remove(&DataKey::UnpauseSchedule);
+        match &reason {
+            Some(r) => env.storage().instance().set(&DataKey::PauseReason, r),
+            None => env.storage().instance().remove(&DataKey::PauseReason),
+        }
         env.events().publish(
             (
                 symbol_short!("emergency"),
@@ -205,6 +221,13 @@ impl EmergencyKillswitch {
             },
         );
         Ok(())
+    }
+
+    /// Returns the reason recorded by [`pause_with_reason`], or `None` if the
+    /// contract is not paused or was paused via plain [`pause`] with no reason.
+    /// Cleared on `unpause` and `clear_emergency_state`.
+    pub fn pause_reason(env: Env) -> Option<Symbol> {
+        env.storage().instance().get(&DataKey::PauseReason)
     }
 
     pub fn unpause(env: Env) -> Result<(), Error> {
@@ -224,6 +247,7 @@ impl EmergencyKillswitch {
         }
         env.storage().instance().set(&DataKey::GlobalPaused, &false);
         env.storage().instance().remove(&DataKey::PausedSince);
+        env.storage().instance().remove(&DataKey::PauseReason);
         env.storage().instance().remove(&DataKey::UnpauseSchedule);
         env.events().publish(
             (
@@ -265,6 +289,7 @@ impl EmergencyKillswitch {
         admin.require_auth();
         env.storage().instance().set(&DataKey::GlobalPaused, &false);
         env.storage().instance().remove(&DataKey::PausedSince);
+        env.storage().instance().remove(&DataKey::PauseReason);
         env.storage().instance().remove(&DataKey::UnpauseSchedule);
         env.events().publish(
             (

--- a/emergency_killswitch/tests/test_killswitch.rs
+++ b/emergency_killswitch/tests/test_killswitch.rs
@@ -619,3 +619,59 @@ fn is_module_paused_does_not_affect_function_list() {
     // Module being paused doesn't populate PausedFunctions
     assert!(client.list_paused_functions(&module).is_empty());
 }
+
+#[test]
+fn pause_reason_none_before_any_pause() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup(&env);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+    assert_eq!(client.pause_reason(), None);
+}
+
+#[test]
+fn pause_reason_none_when_paused_without_reason() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup(&env);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+    client.pause();
+    assert!(client.is_paused());
+    assert_eq!(client.pause_reason(), None);
+}
+
+#[test]
+fn pause_reason_set_by_pause_with_reason_and_cleared_on_unpause() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup(&env);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let reason = symbol_short!("exploit");
+    client.pause_with_reason(&reason);
+    assert!(client.is_paused());
+    assert_eq!(client.pause_reason(), Some(reason));
+
+    env.ledger().with_mut(|l| l.timestamp += 1);
+    client.schedule_unpause(&env.ledger().timestamp());
+    env.ledger().with_mut(|l| l.timestamp += 1);
+    client.unpause();
+    assert_eq!(client.pause_reason(), None);
+}
+
+#[test]
+fn pause_reason_cleared_by_clear_emergency_state() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup(&env);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    client.pause_with_reason(&symbol_short!("exploit"));
+    client.clear_emergency_state();
+    assert!(!client.is_paused());
+    assert_eq!(client.pause_reason(), None);
+}


### PR DESCRIPTION
## Summary
Adds a `pause_reason(): Option<Symbol>` getter to `emergency_killswitch`, backed by a new `pause_with_reason(reason: Symbol)` entrypoint.

## Change
- New `DataKey::PauseReason` storage slot.
- `pause()` now delegates to a shared `pause_internal` helper; its behavior/signature is unchanged.
- New `pause_with_reason(env, reason)` pauses and records `reason`.
- New `pause_reason(env) -> Option<Symbol>` getter.
- `reason` is cleared on `unpause` and `clear_emergency_state`, mirroring how `PausedSince` is already handled.

Additive only: no existing entrypoint signature changed.

## Tests
Added 4 tests covering: no reason before any pause, `pause()` leaves it `None`, `pause_with_reason` sets and `unpause` clears it, and `clear_emergency_state` also clears it.

`cargo test -p emergency_killswitch`: 40 passed, 0 failed.

Closes #1624