### PR TITLE
API: add a version(): u32 for on-chain upgrades

### DIFF
--- a/emergency_killswitch/src/lib.rs
+++ b/emergency_killswitch/src/lib.rs
@@ -30,6 +30,10 @@ enum DataKey {
 
 pub const MAX_PAUSED_FUNCTIONS: u32 = 10;
 
+/// Contract version, bumped on every on-chain-upgrade-relevant change so
+/// callers/tooling can detect which build of the WASM they are talking to.
+pub const CONTRACT_VERSION: u32 = 1;
+
 /// Emitted when the killswitch admin is successfully transferred.
 #[contracttype]
 #[derive(Clone)]
@@ -132,6 +136,15 @@ impl EmergencyKillswitch {
             (old_epoch, new_epoch),
         );
         Ok(new_epoch)
+    }
+
+    /// Returns [`CONTRACT_VERSION`], the version of this deployed WASM build.
+    ///
+    /// Intended for off-chain tooling/upgrade scripts to confirm which
+    /// contract version they are interacting with before/after an upgrade.
+    /// No authentication required — the version is observable on-chain.
+    pub fn version(_env: Env) -> u32 {
+        CONTRACT_VERSION
     }
 
     /// Return the current kill-switch epoch.

--- a/emergency_killswitch/tests/test_killswitch.rs
+++ b/emergency_killswitch/tests/test_killswitch.rs
@@ -15,6 +15,14 @@ fn setup(env: &Env) -> (Address, EmergencyKillswitchClient<'_>) {
 }
 
 #[test]
+fn version_returns_contract_version_without_init() {
+    let env = Env::default();
+    let (_, client) = setup(&env);
+    // Observable on-chain with no auth and before initialize().
+    assert_eq!(client.version(), emergency_killswitch::CONTRACT_VERSION);
+}
+
+#[test]
 fn initialize_rejects_self_address() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
## Summary
`emergency_killswitch` had no way for off-chain tooling to check which build it is talking to, unlike several sibling contracts (`bill_payments`, `remittance_split`, `savings_goals`, `family_wallet`, `insurance`, `orchestrator`) which already expose `get_version()`.

## Change
- Add `pub const CONTRACT_VERSION: u32 = 1`.
- Add `pub fn version(env: Env) -> u32`, a read-only view requiring no auth, returning `CONTRACT_VERSION`.

Purely additive — no existing entrypoint changed.

## Tests
Added `version_returns_contract_version_without_init`, asserting it's callable before `initialize()` and returns the constant.

`cargo test -p emergency_killswitch`: 37 passed, 0 failed.

Closes #1621