### PR TITLE
Validate: reject expiry earlier than now

### DIFF
--- a/family_wallet/src/lib.rs
+++ b/family_wallet/src/lib.rs
@@ -1948,8 +1948,7 @@ impl FamilyWallet {
         // expired role timestamp would immediately lock the member out of
         // their role with no way to recover except through admin intervention.
         if let Some(t) = expires_at {
-            let now = env.ledger().timestamp();
-            if t <= now {
+            if remitwise_common::require_future_timestamp(&env, t).is_err() {
                 panic_with_error!(&env, Error::RoleExpiryInPast);
             }
         }

--- a/remitwise-common/src/lib.rs
+++ b/remitwise-common/src/lib.rs
@@ -759,6 +759,34 @@ pub fn get_rate_limit_status(env: &Env, caller: &Address, operation: Symbol) -> 
     (record.count, window_id + RATE_LIMIT_WINDOW_SECONDS)
 }
 
+/// Typed error returned by [`require_future_timestamp`].
+#[soroban_sdk::contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum TimestampError {
+    /// `t <= env.ledger().timestamp()`.
+    NotInFuture = 1,
+}
+
+/// Central guard for validating a caller-supplied timestamp (e.g. an expiry
+/// or unlock time) is strictly after the current ledger time.
+///
+/// # Contract
+/// - `Ok(())` when `t > env.ledger().timestamp()`.
+/// - [`TimestampError::NotInFuture`] when `t` is equal to or before now.
+///
+/// Setting an already-past (or exactly-now) expiry would leave the affected
+/// state immediately expired with no way to recover except admin
+/// intervention, so this is checked at the boundary rather than left to each
+/// call site to reimplement.
+pub fn require_future_timestamp(env: &Env, t: u64) -> Result<(), TimestampError> {
+    if t <= env.ledger().timestamp() {
+        Err(TimestampError::NotInFuture)
+    } else {
+        Ok(())
+    }
+}
+
 /// Verifies that an amount is above the dust threshold (1 stroop).
 ///
 /// Returns `Ok(())` when `amount > 1`, otherwise returns an error.

--- a/remitwise-common/src/tests.rs
+++ b/remitwise-common/src/tests.rs
@@ -3007,3 +3007,37 @@ mod investigation_epoch_guard_comprehensive_tests {
         );
     }
 }
+
+mod require_future_timestamp_tests {
+    use super::*;
+
+    fn env_at(timestamp: u64) -> Env {
+        let env = Env::default();
+        env.ledger().with_mut(|li| li.timestamp = timestamp);
+        env
+    }
+
+    #[test]
+    fn rejects_timestamp_equal_to_now() {
+        let env = env_at(1_000);
+        assert_eq!(
+            require_future_timestamp(&env, 1_000),
+            Err(TimestampError::NotInFuture)
+        );
+    }
+
+    #[test]
+    fn rejects_timestamp_before_now() {
+        let env = env_at(1_000);
+        assert_eq!(
+            require_future_timestamp(&env, 999),
+            Err(TimestampError::NotInFuture)
+        );
+    }
+
+    #[test]
+    fn accepts_timestamp_after_now() {
+        let env = env_at(1_000);
+        assert_eq!(require_future_timestamp(&env, 1_001), Ok(()));
+    }
+}


### PR DESCRIPTION
## Summary
`family_wallet::set_role_expiry` already rejected `expires_at <= now` inline, but the check was ad-hoc and not reusable. Extracted it into a shared, unit-tested `remitwise_common::require_future_timestamp` guard so other contracts validating an expiry-like timestamp have a single, tested boundary check to call instead of reimplementing `t <= env.ledger().timestamp()` themselves.

## Change
- New `remitwise_common::require_future_timestamp(env, t) -> Result<(), TimestampError>`.
- `family_wallet::set_role_expiry` now delegates to it instead of its inline check. Behavior is unchanged: same condition (`t <= now` rejected), same `Error::RoleExpiryInPast` on failure.

## Tests
Added 3 tests for the new guard (equal-to-now rejected, before-now rejected, after-now accepted).

`cargo test -p remitwise-common`: 240 passed (52 pre-existing, unrelated failures also present on `main` without this change).

Note: `family_wallet`'s own test target (`family_wallet/src/test.rs`) currently fails to compile on `main` for an unrelated reason (`client.pause(&owner)` missing the `reason: Symbol` arg added to `pause`), so I could not run `cargo test -p family_wallet` to confirm end-to-end. `cargo check -p family_wallet` (library target) compiles cleanly both before and after this change, and the substitution is a straight 1:1 behavioral delegation.

Closes #1617