### PR TITLE
Fix: storage bump uses the wrong TTL bucket

### DIFF
--- a/orchestrator/src/lib.rs
+++ b/orchestrator/src/lib.rs
@@ -92,7 +92,8 @@ pub enum FlowStep {
 }
 
 use remitwise_common::{
-    EventCategory, EventPriority, RemitwiseEvents, CONTRACT_VERSION, SNAPSHOT_KEY, SNAPSHOT_VERSION,
+    EventCategory, EventPriority, RemitwiseEvents, CONTRACT_VERSION, PERSISTENT_BUMP_AMOUNT,
+    PERSISTENT_LIFETIME_THRESHOLD, SNAPSHOT_KEY, SNAPSHOT_VERSION,
 };
 
 // Storage TTL constants for active data
@@ -1071,6 +1072,23 @@ impl Orchestrator {
         env.storage()
             .persistent()
             .set(&symbol_short!("SNAP_TS"), &env.ledger().timestamp());
+        // The only other extend_ttl call in this contract targets the
+        // *instance* bucket (see `extend_instance_ttl`); it does not, and
+        // cannot, keep this *persistent* entry alive. Without bumping the
+        // persistent bucket's own TTL here, the snapshot can be archived off
+        // the ledger and `restore_from_snapshot` starts failing with
+        // `InvalidDependency` well before `PERSISTENT_LIFETIME_THRESHOLD`
+        // would suggest, even while the instance itself is still healthy.
+        env.storage().persistent().extend_ttl(
+            &SNAPSHOT_KEY,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+        env.storage().persistent().extend_ttl(
+            &symbol_short!("SNAP_TS"),
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
         env.events().publish(
             (symbol_short!("orch"), symbol_short!("snap_pre")),
             SNAPSHOT_VERSION,

--- a/orchestrator/src/test.rs
+++ b/orchestrator/src/test.rs
@@ -1477,6 +1477,31 @@ fn test_pre_upgrade_roundtrip() {
 }
 
 #[test]
+fn test_pre_upgrade_bumps_persistent_snapshot_ttl() {
+    // Before this fix, pre_upgrade wrote SNAPSHOT_KEY / SNAP_TS to the
+    // *persistent* bucket but only ever called extend_ttl on the *instance*
+    // bucket elsewhere in the contract -- the persistent entry's TTL was
+    // never bumped at all, so it could be archived off the ledger (breaking
+    // restore_from_snapshot) well before the instance itself expired.
+    use soroban_sdk::testutils::storage::Persistent;
+
+    let (env, owner) = setup_test();
+    let (orchestrator_id, client) = register_orchestrator(&env);
+    init_orchestrator(&env, &client, &owner);
+    env.ledger().with_mut(|li| li.max_entry_ttl = 6_000_000);
+
+    client.pre_upgrade(&owner);
+
+    let ttl = env.as_contract(&orchestrator_id, || {
+        env.storage().persistent().get_ttl(&SNAPSHOT_KEY)
+    });
+    assert_eq!(
+        ttl, PERSISTENT_BUMP_AMOUNT,
+        "persistent snapshot entry must be bumped with the persistent bucket's amount"
+    );
+}
+
+#[test]
 fn test_pre_upgrade_unauthorized_fails() {
     let (env, owner) = setup_test();
     let (_, client) = register_orchestrator(&env);


### PR DESCRIPTION
## Summary
\`pre_upgrade\` writes its snapshot (\`SNAPSHOT_KEY\`, \`SNAP_TS\`) to **persistent** storage, but the contract's only \`extend_ttl\` call (\`extend_instance_ttl\`) only ever bumps the **instance** bucket. The persistent entries never had their own TTL extended, so they could be archived off the ledger on their default/initial TTL -- silently breaking \`restore_from_snapshot\` with \`InvalidDependency\` well before the instance itself was anywhere near expiring.

\`remitwise_common\` already defines \`PERSISTENT_LIFETIME_THRESHOLD\`/\`PERSISTENT_BUMP_AMOUNT\` for exactly this bucket (and \`savings_goals\` already hit this same bug class -- see its \`ttl_bucket_test.rs\` for issue #1516, a case where the *wrong constants* were used; here the persistent bucket got *no bump* at all), but orchestrator never applied them to the persistent snapshot entries.

## Change
- Import \`PERSISTENT_LIFETIME_THRESHOLD\` / \`PERSISTENT_BUMP_AMOUNT\` from \`remitwise_common\`.
- After writing \`SNAPSHOT_KEY\` and \`SNAP_TS\` in \`pre_upgrade\`, extend both entries' TTL in the persistent bucket.

## Tests
Added \`test_pre_upgrade_bumps_persistent_snapshot_ttl\`, which reproduces the bug (TTL was previously whatever the default/initial persistent TTL is, not \`PERSISTENT_BUMP_AMOUNT\`) and asserts the entry now carries the correct persistent-bucket bump via \`storage().persistent().get_ttl(...)\`.

\`cargo test -p orchestrator --lib\`: 96 passed, 1 pre-existing unrelated failure (requires wasm artifacts to be pre-built).

Closes #1629