### PR TITLE
Document the pause/unpause state machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,7 @@ To run an example, use `cargo run --example <example_name>`:
 - [Epoch Model](docs/EPOCH_MODEL.md) - How epoch counters bump, what they invalidate, and the stale-authorization replay threat they mitigate in the emergency killswitch and orchestrator contracts
 - [Dispute Epoch Model](docs/DISPUTE_EPOCH_MODEL.md) - Semantics + when dispute epochs bump
 - [Killswitch Trust Model](docs/killswitch-trust-model.md) - Who can trigger, who can clear, what state is preserved in the emergency killswitch
+- [Killswitch Pause/Unpause State Machine](docs/killswitch-pause-state-machine.md) - The global Unpaused/Paused/PendingUnpause states and transitions, plus how module- and function-level pauses layer on top
 - [Kill-Switch Recovery Runbook](docs/KILL_SWITCH_RECOVERY.md) - Operator runbook: how to engage the kill switch, verify the freeze, and safely resume operations after an incident
 - [Ledger Monotonicity](docs/LEDGER_MONOTONICITY.md) - Where and why contract code relies on ledger sequence and timestamp monotonicity
 - [Timestamp Conventions](docs/TIMESTAMP_CONVENTIONS.md) - How timestamps are represented, stored, and compared across all contracts

--- a/docs/killswitch-pause-state-machine.md
+++ b/docs/killswitch-pause-state-machine.md
@@ -1,0 +1,65 @@
+# Emergency Killswitch: Pause/Unpause State Machine
+
+Audience: contributors modifying `emergency_killswitch` or wiring a new
+contract's `pause`/`unpause` entrypoints to match its conventions.
+
+This complements [Killswitch Trust Model](killswitch-trust-model.md) (who can
+act) and [killswitch-timelock.md](killswitch-timelock.md) (why the timelock
+exists) by pinning down the states themselves and the exact entrypoint that
+drives each transition.
+
+## Global state
+
+```
+        pause()                schedule_unpause(t)         unpause()  [only if now >= t]
+Unpaused ───────────► Paused ───────────────────► PendingUnpause ───────────► Unpaused
+   ▲                     │  ▲                            │
+   │                     │  └──────── pause() ────────────┘   (re-pause cancels the
+   │                     │             (re-pause)               pending schedule)
+   └── clear_emergency_state() ────────┘
+        (admin-only bypass, from either Paused or PendingUnpause)
+```
+
+- **Unpaused**: `is_paused() == false`. Default state after `initialize`.
+- **Paused**: `is_paused() == true`, `get_unpause_schedule() == None`. Entered via `pause()`.
+- **PendingUnpause**: `is_paused() == true`, `get_unpause_schedule() == Some(t)`. Entered via `schedule_unpause(t)` while `Paused`. `unpause()` only succeeds once `env.ledger().timestamp() >= t`; calling it earlier returns `Error::Unauthorized`.
+
+Calling `pause()` again while already `Paused` or `PendingUnpause` clears any
+pending schedule (see `emergency_killswitch/src/lib.rs::pause`) — this is
+intentional so a fresh incident always requires a fresh cool-down, not a
+stale one left over from a previous unpause attempt. A consequence: if the
+schedule is dropped this way, `unpause()` fails with `Error::InvalidSchedule`
+until a new `schedule_unpause` is issued.
+
+`clear_emergency_state()` is the admin-only escape hatch from either `Paused`
+or `PendingUnpause` straight back to `Unpaused`, bypassing the timelock. Use
+it only to recover from the stuck state above, or genuine emergencies — it
+exists precisely because the timelock has no other way to be short-circuited.
+
+## Module and function layers
+
+Independently of the global state above, individual modules and functions
+carry their own pause flags:
+
+- `pause_module(module_id)` / `unpause_module(module_id)` — `is_module_paused(module_id)`.
+- `pause_function(module_id, func)` / `unpause_function(module_id, func)` — `is_function_paused(module_id, func)`, capped at `MAX_PAUSED_FUNCTIONS` (10) entries per module.
+
+These are independent axes, not sub-states of the global machine above: a
+module can be paused while the contract is globally unpaused, and vice
+versa. A caller checking whether a specific function is currently callable
+must check all three, in this precedence order: **global → module →
+function**. `is_module_paused` and `is_function_paused` do not consult
+`is_paused()`, so callers must not skip the global check.
+
+## Worked example
+
+```text
+initialize(admin)                  -> Unpaused
+pause()                            -> Paused
+schedule_unpause(now + 3600)       -> PendingUnpause, get_unpause_schedule() == Some(now + 3600)
+unpause()  [called at now + 1800]  -> Error::Unauthorized (schedule not reached), still PendingUnpause
+unpause()  [called at now + 3600]  -> Unpaused
+```
+
+See `emergency_killswitch/tests/test_killswitch.rs` for the executable
+version of this and the re-pause/recovery cases.


### PR DESCRIPTION
## Summary
\`emergency_killswitch\` had docs for the trust model and the timelock rationale, but nothing pinning down the actual states and transitions of the pause/unpause machine itself, or how the module-/function-level pauses relate to the global one.

## Change
Adds \`docs/killswitch-pause-state-machine.md\` (audience: contributors), covering:
- The three global states (\`Unpaused\` / \`Paused\` / \`PendingUnpause\`) and the exact entrypoint driving each transition.
- The re-pause-cancels-pending-schedule behavior and the stuck-paused edge case it can create, plus \`clear_emergency_state\` as the documented way out.
- How module- and function-level pauses are independent axes layered on top, with the \`global → module → function\` precedence a caller must check in.
- A worked example trace.

Cross-linked from the README alongside the existing trust-model/timelock docs it complements.

Closes #1619