### PR TITLE
Config: make the timelock window a constructor parameter

### DIFF
--- a/orchestrator/src/lib.rs
+++ b/orchestrator/src/lib.rs
@@ -408,6 +408,62 @@ impl Orchestrator {
         bill_payments: Address,
         insurance: Address,
     ) -> Result<bool, OrchestratorError> {
+        Self::init_internal(
+            env,
+            caller,
+            family_wallet,
+            remittance_split,
+            savings_goals,
+            bill_payments,
+            insurance,
+            None,
+        )
+    }
+
+    /// Same as [`init`], but also configures the signed-flow deadline window
+    /// (see `require_nonce_hardened`) instead of relying on the
+    /// `MAX_DEADLINE_WINDOW_SECS` default. Kept as a separate entrypoint so
+    /// `init`'s signature and existing callers are unaffected.
+    ///
+    /// # Errors
+    /// - `InvalidAmount` if `deadline_window_secs == 0` -- a zero window
+    ///   would make every signed flow deadline immediately expired.
+    pub fn init_with_deadline_window(
+        env: Env,
+        caller: Address,
+        family_wallet: Address,
+        remittance_split: Address,
+        savings_goals: Address,
+        bill_payments: Address,
+        insurance: Address,
+        deadline_window_secs: u64,
+    ) -> Result<bool, OrchestratorError> {
+        if deadline_window_secs == 0 {
+            return Err(OrchestratorError::InvalidAmount);
+        }
+        Self::init_internal(
+            env,
+            caller,
+            family_wallet,
+            remittance_split,
+            savings_goals,
+            bill_payments,
+            insurance,
+            Some(deadline_window_secs),
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn init_internal(
+        env: Env,
+        caller: Address,
+        family_wallet: Address,
+        remittance_split: Address,
+        savings_goals: Address,
+        bill_payments: Address,
+        insurance: Address,
+        deadline_window_secs: Option<u64>,
+    ) -> Result<bool, OrchestratorError> {
         caller.require_auth();
 
         let existing: Option<Address> = env.storage().instance().get(&symbol_short!("OWNER"));
@@ -466,6 +522,11 @@ impl Orchestrator {
         env.storage()
             .instance()
             .set(&symbol_short!("NONCES"), &Map::<Address, u64>::new(&env));
+        if let Some(window) = deadline_window_secs {
+            env.storage()
+                .instance()
+                .set(&symbol_short!("DL_WIN"), &window);
+        }
 
         // Store default execution parameters for the signed flow.
         // These can be updated by the owner via a future admin method.
@@ -708,6 +769,18 @@ impl Orchestrator {
     /// in basis points (1% = 100 basis points).
     ///
     /// This is a read-only view function that does not require authorization.
+    /// Returns the configured signed-flow deadline window in seconds -- the
+    /// maximum distance into the future a caller-supplied deadline may sit
+    /// (see `require_nonce_hardened`). Falls back to `MAX_DEADLINE_WINDOW_SECS`
+    /// if `init_with_deadline_window` was never called (i.e. plain `init` was
+    /// used). No authentication required — observable on-chain.
+    pub fn get_deadline_window(env: Env) -> u64 {
+        env.storage()
+            .instance()
+            .get(&symbol_short!("DL_WIN"))
+            .unwrap_or(MAX_DEADLINE_WINDOW_SECS)
+    }
+
     pub fn get_fee_schedule(env: Env) -> Option<(u32, u32, u32, u32)> {
         let rs_addr: Address = env.storage().instance().get(&symbol_short!("RS_ADDR"))?;
 
@@ -1462,7 +1535,7 @@ impl Orchestrator {
         if deadline <= now {
             return Err(OrchestratorError::DeadlineExpired);
         }
-        if deadline > now + MAX_DEADLINE_WINDOW_SECS {
+        if deadline > now + Self::get_deadline_window(env.clone()) {
             return Err(OrchestratorError::DeadlineExpired);
         }
 

--- a/orchestrator/src/test.rs
+++ b/orchestrator/src/test.rs
@@ -1011,6 +1011,81 @@ fn signed_flow_hash(
     compute_test_hash(_env, symbol_short!("flow"), nonce, amount, deadline)
 }
 
+// ---------------------------------------------------------------------------
+// Configurable deadline window (init_with_deadline_window)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn get_deadline_window_defaults_to_max_when_plain_init_used() {
+    let (env, owner) = setup_test();
+    let (_, client) = register_orchestrator(&env);
+    init_orchestrator(&env, &client, &owner);
+
+    assert_eq!(client.get_deadline_window(), MAX_DEADLINE_WINDOW_SECS);
+}
+
+#[test]
+fn init_with_deadline_window_rejects_zero_window() {
+    let (env, owner) = setup_test();
+    let (_, client) = register_orchestrator(&env);
+    let fw = env.register_contract(None, MockContract);
+    let rs = env.register_contract(None, MockContract);
+    let sg = env.register_contract(None, MockContract);
+    let bp = env.register_contract(None, MockContract);
+    let ins = env.register_contract(None, MockContract);
+
+    let result =
+        client.try_init_with_deadline_window(&owner, &fw, &rs, &sg, &bp, &ins, &0u64);
+    assert_eq!(result, Err(Ok(OrchestratorError::InvalidAmount)));
+}
+
+#[test]
+fn init_with_deadline_window_enforces_custom_window() {
+    let (env, owner) = setup_test();
+    let (_, client) = register_orchestrator(&env);
+    let fw = env.register_contract(None, MockContract);
+    let rs = env.register_contract(None, MockContract);
+    let sg = env.register_contract(None, MockContract);
+    let bp = env.register_contract(None, MockContract);
+    let ins = env.register_contract(None, MockContract);
+
+    let custom_window = 500u64;
+    client.init_with_deadline_window(&owner, &fw, &rs, &sg, &bp, &ins, &custom_window);
+    assert_eq!(client.get_deadline_window(), custom_window);
+
+    let executor = Address::generate(&env);
+
+    // Before this fix, MAX_DEADLINE_WINDOW_SECS (3600s) was hardcoded, so a
+    // deadline 1000s out would have been accepted. With a configured 500s
+    // window it must now be rejected.
+    let too_far_deadline = env.ledger().timestamp() + 1000;
+    let hash = signed_flow_hash(&env, &executor, 10000, 0, too_far_deadline);
+    let result = client.try_execute_remittance_flow_signed(
+        &executor,
+        &10000,
+        &0u64,
+        &too_far_deadline,
+        &hash,
+        &0u64,
+    );
+    assert_eq!(result, Err(Ok(OrchestratorError::DeadlineExpired)));
+
+    // A deadline within the custom window passes the deadline check (it may
+    // still fail later for unrelated reasons, e.g. mock dependencies not
+    // implementing every entrypoint -- this only pins the deadline gate).
+    let ok_deadline = env.ledger().timestamp() + 400;
+    let hash2 = signed_flow_hash(&env, &executor, 10000, 0, ok_deadline);
+    let result2 = client.try_execute_remittance_flow_signed(
+        &executor,
+        &10000,
+        &0u64,
+        &ok_deadline,
+        &hash2,
+        &0u64,
+    );
+    assert_ne!(result2, Err(Ok(OrchestratorError::DeadlineExpired)));
+}
+
 #[test]
 fn test_rollback_savings_step_returns_cross_contract_error() {
     let (env, owner) = setup_test();


### PR DESCRIPTION
## Summary
\`orchestrator\`'s signed-flow deadline window (\`MAX_DEADLINE_WINDOW_SECS\`, the maximum distance into the future a caller-supplied deadline may sit -- see \`require_nonce_hardened\`) was a hardcoded 1-hour constant, so every deployment was stuck with the same tolerance regardless of its own latency or threat profile.

## Change
- New \`init_with_deadline_window(..., deadline_window_secs: u64)\`, an additive alternative constructor: same as \`init\`, but also stores a custom window. Rejects \`deadline_window_secs == 0\` (would make every signed deadline instantly expired).
- \`init\` is refactored to share logic via a private \`init_internal\`; its signature and behavior are unchanged (still uses the \`MAX_DEADLINE_WINDOW_SECS\` default).
- \`require_nonce_hardened\` now reads the configured window instead of the hardcoded constant.
- New \`get_deadline_window() -> u64\` getter, falling back to \`MAX_DEADLINE_WINDOW_SECS\` when unset.

## Tests
- Default window is \`MAX_DEADLINE_WINDOW_SECS\` when plain \`init\` is used.
- \`init_with_deadline_window\` rejects a zero window.
- A deployment configured with a narrower window (500s) now rejects a 1000s-out deadline that the old hardcoded 3600s window would have accepted, and accepts a 400s-out deadline.

\`cargo test -p orchestrator --lib\`: 98 passed, 1 pre-existing unrelated failure (requires wasm artifacts to be pre-built).

Closes #1623