### PR TITLE
Perf: hoist the admin check out of a hot loop

### DIFF
--- a/reporting/src/lib.rs
+++ b/reporting/src/lib.rs
@@ -2344,15 +2344,12 @@ impl ReportingContract {
             .get(&symbol_short!("ARCH_RPT"))
             .unwrap_or_else(|| Map::new(env));
 
-        let mut active_count = 0u32;
-        for _ in reports.iter() {
-            active_count += 1;
-        }
-
-        let mut archived_count = 0u32;
-        for _ in archived.iter() {
-            archived_count += 1;
-        }
+        // `Map::iter()` deserializes every key/value pair off the host; doing
+        // that just to count entries is wasted work on every write path that
+        // calls this function. `Map::len()` reports the entry count directly
+        // without touching the values at all.
+        let active_count = reports.len();
+        let archived_count = archived.len();
 
         let stats = StorageStats {
             active_reports: active_count,


### PR DESCRIPTION
## Note on scope
I went looking for a literal per-item admin/auth re-check inside a loop across the crates that currently build and test cleanly on \`main\` (\`emergency_killswitch\`, \`orchestrator\`, \`reporting\`, \`remitwise-common\`; \`bill_payments\`, \`remittance_split\`, \`savings_goals\`, and \`insurance\` currently fail to compile on \`main\` for unrelated pre-existing reasons, so I steered clear of them) and didn't find one -- every admin/owner check I found was already hoisted above its loop. I'm instead fixing the closest real instance of the same class of bug: per-item work inside a loop whose result doesn't depend on the individual items, in \`reporting\`'s hot path. Flagging this clearly in case a maintainer knows of a literal admin-in-loop instance I missed (possibly in one of the currently-broken crates) -- happy to redo this against that instead.

## Summary
\`update_storage_stats\` -- called from every write path that touches reports or archives (\`archive_report\`, and others) -- counted entries by iterating the full \`REPORTS\` and \`ARCH_RPT\` maps and incrementing a counter, discarding each deserialized value immediately. \`Map::iter()\` deserializes every key/value pair off the host; doing that on every write solely to produce a count is wasted work identical in spirit to redoing an invariant check on every loop iteration.

## Change
Replace both counting loops with \`Map::len()\`, which reports the entry count directly without touching the values.

## Tests
No new test needed -- \`reporting/src/tests_updated.rs\` already asserts on \`get_storage_stats()\` counts before/after mutations, which exercises this function and would have caught a miscount.

\`cargo test -p reporting\`: 171 passed, 0 failed (full crate, no pre-existing failures).

Closes #1628