### PR TITLE
Refactor: split the god-file (data_migration/src/lib.rs)

### DIFF
--- a/data_migration/src/csv_transfer.rs
+++ b/data_migration/src/csv_transfer.rs
@@ -1,0 +1,169 @@
+//! CSV import/export for tabular payloads (savings goals).
+//!
+//! Split out of `lib.rs` (issue #1625) as a behavior-preserving move: every
+//! item here is unchanged, just relocated. Re-exported from the crate root
+//! so existing call sites (`data_migration::export_to_csv`, `::import_goals_from_csv`)
+//! and `use super::*;` test imports keep working unmodified.
+
+use super::*;
+
+/// Sanitize a CSV field to prevent formula injection.
+///
+/// # Security model
+///
+/// CSV-injection occurs when spreadsheet applications interpret leading characters
+/// as formulas:
+/// - `=` starts a formula
+/// - `+` starts a formula in some applications
+/// - `-` starts a formula in some applications
+/// - `@` starts a formula (Excel functions)
+///
+/// This function prefixes any field beginning with these characters with a single quote (`'`),
+/// which instructs spreadsheet applications to treat the field as text literal.
+///
+/// # Examples
+///
+/// ```text
+/// "=IMPORTXML(...)" → "'=IMPORTXML(...)"
+/// "+1+1" → "'+1+1"
+/// "-1+2" → "'-1+2"
+/// "@SUM(A1:A10)" → "'@SUM(A1:A10)"
+/// "normal text" → "normal text"
+/// "123" → "123"
+/// ```
+fn sanitize_csv_field(field: &str) -> String {
+    if field.starts_with('=')
+        || field.starts_with('+')
+        || field.starts_with('-')
+        || field.starts_with('@')
+    {
+        format!("'{}", field)
+    } else {
+        field.to_string()
+    }
+}
+
+/// Export to CSV (for tabular payloads only; e.g. goals list).
+///
+/// # Security
+///
+/// Fields beginning with `=`, `+`, `-`, or `@` are escaped with a leading single quote (`'`)
+/// to prevent formula injection in spreadsheet applications. This ensures that goal names
+/// and notes containing formula-like prefixes are safely exported as text literals.
+pub fn export_to_csv(payload: &SavingsGoalsExport) -> Result<Vec<u8>, MigrationError> {
+    let payload_bytes = serialize_json_bytes(payload)?;
+    validate_payload_bounds(payload.goals.len(), payload_bytes.len())?;
+
+    let mut wtr = csv::Writer::from_writer(Vec::new());
+    wtr.write_record([
+        "id",
+        "owner",
+        "name",
+        "target_amount",
+        "current_amount",
+        "target_date",
+        "locked",
+    ])
+    .map_err(|e| MigrationError::InvalidFormat(e.to_string()))?;
+
+    for goal in &payload.goals {
+        wtr.write_record(&[
+            goal.id.to_string(),
+            sanitize_csv_field(&goal.owner),
+            sanitize_csv_field(&goal.name),
+            goal.target_amount.to_string(),
+            goal.current_amount.to_string(),
+            goal.target_date.to_string(),
+            goal.locked.to_string(),
+        ])
+        .map_err(|e| MigrationError::InvalidFormat(e.to_string()))?;
+    }
+
+    wtr.flush()
+        .map_err(|e| MigrationError::InvalidFormat(e.to_string()))?;
+    let csv_bytes = wtr
+        .into_inner()
+        .map_err(|e| MigrationError::InvalidFormat(e.to_string()))?;
+    validate_payload_bounds(payload.goals.len(), csv_bytes.len())?;
+    Ok(csv_bytes)
+}
+
+/// Import goals from CSV into SavingsGoalsExport.
+pub fn import_goals_from_csv(bytes: &[u8]) -> Result<Vec<SavingsGoalExport>, MigrationError> {
+    // Pre-deserialization check: Ensure the raw CSV input bytes do not exceed
+    // MAX_MIGRATION_PAYLOAD_BYTES to prevent DoS from oversized requests before parsing.
+    // Logical record count (MAX_MIGRATION_RECORDS) is validated during iteration.
+    if bytes.len() > MAX_MIGRATION_PAYLOAD_BYTES {
+        return Err(MigrationError::PayloadTooLarge {
+            size: bytes.len(),
+            max: MAX_MIGRATION_PAYLOAD_BYTES,
+        });
+    }
+
+    let mut rdr = csv::Reader::from_reader(bytes);
+    let mut goals = Vec::new();
+    for result in rdr.deserialize() {
+        if goals.len() == MAX_MIGRATION_RECORDS {
+            return Err(MigrationError::TooManyRecords {
+                count: MAX_MIGRATION_RECORDS + 1,
+                max: MAX_MIGRATION_RECORDS,
+            });
+        }
+
+        let record: CsvGoalRow =
+            result.map_err(|e| MigrationError::DeserializeError(e.to_string()))?;
+
+        if record.target_amount < 0 || record.current_amount < 0 {
+            return Err(MigrationError::ValidationFailed(
+                "negative amounts are not allowed".into(),
+            ));
+        }
+
+        goals.push(SavingsGoalExport {
+            id: record.id,
+            owner: record.owner,
+            name: record.name,
+            target_amount: record.target_amount,
+            current_amount: record.current_amount,
+            target_date: record.target_date,
+            locked: record.locked,
+        });
+    }
+    Ok(goals)
+}
+
+fn deserialize_csv_safe_field<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let raw = String::deserialize(deserializer)?;
+    Ok(strip_csv_formula_prefix(&raw))
+}
+
+fn strip_csv_formula_prefix(value: &str) -> String {
+    if let Some(stripped) = value.strip_prefix('\'') {
+        if stripped.starts_with('=')
+            || stripped.starts_with('+')
+            || stripped.starts_with('-')
+            || stripped.starts_with('@')
+        {
+            return stripped.to_string();
+        }
+    }
+
+    value.to_string()
+}
+
+#[derive(Debug, Deserialize)]
+struct CsvGoalRow {
+    id: u32,
+    #[serde(deserialize_with = "deserialize_csv_safe_field")]
+    owner: String,
+    #[serde(deserialize_with = "deserialize_csv_safe_field")]
+    name: String,
+    target_amount: i64,
+    current_amount: i64,
+    target_date: u64,
+    locked: bool,
+}
+

--- a/data_migration/src/lib.rs
+++ b/data_migration/src/lib.rs
@@ -55,6 +55,9 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, HashMap};
 
+mod csv_transfer;
+pub use csv_transfer::{export_to_csv, import_goals_from_csv};
+
 /// Encrypted migration payload marker prefix.
 ///
 /// Format: `enc:v1:<base64>`
@@ -776,87 +779,6 @@ pub fn export_to_binary(snapshot: &ExportSnapshot) -> Result<Vec<u8>, MigrationE
     Ok(bytes)
 }
 
-/// Sanitize a CSV field to prevent formula injection.
-///
-/// # Security model
-///
-/// CSV-injection occurs when spreadsheet applications interpret leading characters
-/// as formulas:
-/// - `=` starts a formula
-/// - `+` starts a formula in some applications
-/// - `-` starts a formula in some applications
-/// - `@` starts a formula (Excel functions)
-///
-/// This function prefixes any field beginning with these characters with a single quote (`'`),
-/// which instructs spreadsheet applications to treat the field as text literal.
-///
-/// # Examples
-///
-/// ```text
-/// "=IMPORTXML(...)" → "'=IMPORTXML(...)"
-/// "+1+1" → "'+1+1"
-/// "-1+2" → "'-1+2"
-/// "@SUM(A1:A10)" → "'@SUM(A1:A10)"
-/// "normal text" → "normal text"
-/// "123" → "123"
-/// ```
-fn sanitize_csv_field(field: &str) -> String {
-    if field.starts_with('=')
-        || field.starts_with('+')
-        || field.starts_with('-')
-        || field.starts_with('@')
-    {
-        format!("'{}", field)
-    } else {
-        field.to_string()
-    }
-}
-
-/// Export to CSV (for tabular payloads only; e.g. goals list).
-///
-/// # Security
-///
-/// Fields beginning with `=`, `+`, `-`, or `@` are escaped with a leading single quote (`'`)
-/// to prevent formula injection in spreadsheet applications. This ensures that goal names
-/// and notes containing formula-like prefixes are safely exported as text literals.
-pub fn export_to_csv(payload: &SavingsGoalsExport) -> Result<Vec<u8>, MigrationError> {
-    let payload_bytes = serialize_json_bytes(payload)?;
-    validate_payload_bounds(payload.goals.len(), payload_bytes.len())?;
-
-    let mut wtr = csv::Writer::from_writer(Vec::new());
-    wtr.write_record([
-        "id",
-        "owner",
-        "name",
-        "target_amount",
-        "current_amount",
-        "target_date",
-        "locked",
-    ])
-    .map_err(|e| MigrationError::InvalidFormat(e.to_string()))?;
-
-    for goal in &payload.goals {
-        wtr.write_record(&[
-            goal.id.to_string(),
-            sanitize_csv_field(&goal.owner),
-            sanitize_csv_field(&goal.name),
-            goal.target_amount.to_string(),
-            goal.current_amount.to_string(),
-            goal.target_date.to_string(),
-            goal.locked.to_string(),
-        ])
-        .map_err(|e| MigrationError::InvalidFormat(e.to_string()))?;
-    }
-
-    wtr.flush()
-        .map_err(|e| MigrationError::InvalidFormat(e.to_string()))?;
-    let csv_bytes = wtr
-        .into_inner()
-        .map_err(|e| MigrationError::InvalidFormat(e.to_string()))?;
-    validate_payload_bounds(payload.goals.len(), csv_bytes.len())?;
-    Ok(csv_bytes)
-}
-
 /// ⚠️ WARNING: This function does NOT encrypt the payload.
 ///
 /// The `enc:v1:` format is an **encoding/marker only** and provides no
@@ -1164,84 +1086,6 @@ pub fn import_from_binary_untracked(bytes: &[u8]) -> Result<ExportSnapshot, Migr
     import_from_binary(bytes, &mut tracker, 0)
 }
 
-/// Import goals from CSV into SavingsGoalsExport.
-pub fn import_goals_from_csv(bytes: &[u8]) -> Result<Vec<SavingsGoalExport>, MigrationError> {
-    // Pre-deserialization check: Ensure the raw CSV input bytes do not exceed
-    // MAX_MIGRATION_PAYLOAD_BYTES to prevent DoS from oversized requests before parsing.
-    // Logical record count (MAX_MIGRATION_RECORDS) is validated during iteration.
-    if bytes.len() > MAX_MIGRATION_PAYLOAD_BYTES {
-        return Err(MigrationError::PayloadTooLarge {
-            size: bytes.len(),
-            max: MAX_MIGRATION_PAYLOAD_BYTES,
-        });
-    }
-
-    let mut rdr = csv::Reader::from_reader(bytes);
-    let mut goals = Vec::new();
-    for result in rdr.deserialize() {
-        if goals.len() == MAX_MIGRATION_RECORDS {
-            return Err(MigrationError::TooManyRecords {
-                count: MAX_MIGRATION_RECORDS + 1,
-                max: MAX_MIGRATION_RECORDS,
-            });
-        }
-
-        let record: CsvGoalRow =
-            result.map_err(|e| MigrationError::DeserializeError(e.to_string()))?;
-
-        if record.target_amount < 0 || record.current_amount < 0 {
-            return Err(MigrationError::ValidationFailed(
-                "negative amounts are not allowed".into(),
-            ));
-        }
-
-        goals.push(SavingsGoalExport {
-            id: record.id,
-            owner: record.owner,
-            name: record.name,
-            target_amount: record.target_amount,
-            current_amount: record.current_amount,
-            target_date: record.target_date,
-            locked: record.locked,
-        });
-    }
-    Ok(goals)
-}
-
-fn deserialize_csv_safe_field<'de, D>(deserializer: D) -> Result<String, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let raw = String::deserialize(deserializer)?;
-    Ok(strip_csv_formula_prefix(&raw))
-}
-
-fn strip_csv_formula_prefix(value: &str) -> String {
-    if let Some(stripped) = value.strip_prefix('\'') {
-        if stripped.starts_with('=')
-            || stripped.starts_with('+')
-            || stripped.starts_with('-')
-            || stripped.starts_with('@')
-        {
-            return stripped.to_string();
-        }
-    }
-
-    value.to_string()
-}
-
-#[derive(Debug, Deserialize)]
-struct CsvGoalRow {
-    id: u32,
-    #[serde(deserialize_with = "deserialize_csv_safe_field")]
-    owner: String,
-    #[serde(deserialize_with = "deserialize_csv_safe_field")]
-    name: String,
-    target_amount: i64,
-    current_amount: i64,
-    target_date: u64,
-    locked: bool,
-}
 
 /// Version compatibility check for migration scripts.
 pub fn check_version_compatibility(version: u32) -> Result<(), MigrationError> {


### PR DESCRIPTION
## Note on scope
The issue names \`contract.rs\`, which doesn't exist in this repo. I applied it to the largest file among the crates that currently build and test cleanly on \`main\` -- \`data_migration/src/lib.rs\` (5079 lines).

## Summary
Extracted the CSV import/export slice -- \`export_to_csv\`, \`import_goals_from_csv\`, their formula-injection helpers (\`sanitize_csv_field\`, \`strip_csv_formula_prefix\`, \`deserialize_csv_safe_field\`), and the \`CsvGoalRow\` row struct -- into a new \`data_migration/src/csv_transfer.rs\`. This is a cohesive, clearly-bounded unit distinct from the rest of the crate (JSON/binary/encrypted-payload snapshot import-export, checksum/versioning, migration-completion tracking).

## Behavior
No-op at runtime: every moved item is textually unchanged, just relocated. \`csv_transfer\` re-exports its two public functions from the crate root (\`pub use csv_transfer::{export_to_csv, import_goals_from_csv};\`), so:
- External call sites (\`data_migration::export_to_csv\`, \`data_migration::import_goals_from_csv\`) resolve identically.
- Existing tests' \`use super::*;\` imports keep working unmodified -- no test file was touched.

\`data_migration/src/lib.rs\`: 5079 → 4923 lines.

## Tests
No test changes. \`cargo test -p data_migration\`: 205 passed, 0 failed -- identical pass count to \`main\` before this change.

Closes #1625