### PR TITLE
feat(bill_payments): make the admin-rotation timelock a constructor parameter

### DIFF
--- a/bill_payments/src/lib.rs
+++ b/bill_payments/src/lib.rs
@@ -323,6 +323,10 @@ pub enum BillPaymentsError {
     /// upgrade admin — rejected so a mistyped no-op rotation is caught at the
     /// call site instead of silently doing nothing.
     SameAdmin = 33,
+    /// `init_admin` was called with a `rotation_timelock_seconds` below
+    /// `MIN_SCHEDULE_INTERVAL` — too short to serve its purpose of giving the
+    /// legitimate admin a window to notice and react to a rotation proposal.
+    RotationTimelockTooShort = 34,
 }
 
 pub type Error = BillPaymentsError;
@@ -409,7 +413,9 @@ pub struct PreUpgradeSnapshot {
     pub pause_admin: Option<Address>,
 }
 
-/// Seconds an admin rotation must sit proposed before it can be finalized.
+/// Sane default for the admin-rotation timelock, used when a deployment
+/// doesn't have its own opinion. See [`Self::init_admin`] to configure a
+/// different window per deployment.
 ///
 /// ## Why a timelock
 ///
@@ -423,7 +429,7 @@ pub struct PreUpgradeSnapshot {
 /// watching `AdminEvent::RotationProposed`) time to notice the proposal
 /// and respond, rather than a single signature being an irreversible,
 /// instant takeover.
-const ADMIN_ROTATION_TIMELOCK_SECONDS: u64 = 2 * 86400; // 2 days
+pub const DEFAULT_ADMIN_ROTATION_TIMELOCK_SECONDS: u64 = 2 * 86400; // 2 days
 
 /// A rotation that has been proposed but not yet finalized.
 #[derive(Clone, Debug, PartialEq)]
@@ -3561,26 +3567,57 @@ impl BillPayments {
 
     /// One-time admin setup.
     ///
+    /// `rotation_timelock_seconds` configures how long a future admin
+    /// rotation must sit proposed before `finalize_admin_rotation` can
+    /// complete it -- see [`DEFAULT_ADMIN_ROTATION_TIMELOCK_SECONDS`] for the
+    /// sane default and the rationale. Pass that constant to keep the
+    /// previous fixed behavior, or a different value to tune it per
+    /// deployment (e.g. a short window on a test network).
+    ///
     /// # Errors
     /// * `AdminAlreadyInitialized` - If an admin has already been set
-    pub fn init_admin(env: Env, admin: Address) -> Result<(), Error> {
+    /// * `RotationTimelockTooShort` - If `rotation_timelock_seconds` is
+    ///   below `MIN_SCHEDULE_INTERVAL`
+    pub fn init_admin(
+        env: Env,
+        admin: Address,
+        rotation_timelock_seconds: u64,
+    ) -> Result<(), Error> {
         admin.require_auth();
 
         if env.storage().instance().has(&symbol_short!("ADMIN")) {
             return Err(Error::AdminAlreadyInitialized);
         }
 
+        if rotation_timelock_seconds < MIN_SCHEDULE_INTERVAL {
+            return Err(Error::RotationTimelockTooShort);
+        }
+
         env.storage()
             .instance()
             .set(&symbol_short!("ADMIN"), &admin);
+        env.storage()
+            .instance()
+            .set(&symbol_short!("ROT_TL"), &rotation_timelock_seconds);
         env.events()
             .publish((symbol_short!("admin"), AdminEvent::Initialized), admin);
 
         Ok(())
     }
 
+    /// Get the configured admin-rotation timelock window, in seconds.
+    /// Returns [`DEFAULT_ADMIN_ROTATION_TIMELOCK_SECONDS`] if `init_admin`
+    /// hasn't run yet.
+    pub fn get_admin_rotation_timelock(env: Env) -> u64 {
+        env.storage()
+            .instance()
+            .get(&symbol_short!("ROT_TL"))
+            .unwrap_or(DEFAULT_ADMIN_ROTATION_TIMELOCK_SECONDS)
+    }
+
     /// Propose rotating the admin to `new_admin`. Does not take effect
-    /// immediately -- see `ADMIN_ROTATION_TIMELOCK_SECONDS`. Call
+    /// immediately -- uses the timelock window configured at `init_admin`
+    /// (see [`Self::get_admin_rotation_timelock`]). Call
     /// `finalize_admin_rotation` after the timelock elapses to complete it.
     /// A second call before finalization overwrites the still-pending
     /// proposal (and restarts its timelock) rather than stacking.
@@ -3605,7 +3642,12 @@ impl BillPayments {
             return Err(Error::Unauthorized);
         }
 
-        let executable_at = env.ledger().timestamp() + ADMIN_ROTATION_TIMELOCK_SECONDS;
+        let timelock: u64 = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("ROT_TL"))
+            .unwrap_or(DEFAULT_ADMIN_ROTATION_TIMELOCK_SECONDS);
+        let executable_at = env.ledger().timestamp() + timelock;
         let pending = PendingAdminRotation {
             new_admin: new_admin.clone(),
             executable_at,

--- a/bill_payments/src/test.rs
+++ b/bill_payments/src/test.rs
@@ -4485,21 +4485,64 @@ fn test_set_external_ref_owner_can_set() {
 
         set_time(&env, 1_000);
         env.mock_all_auths();
-        client.init_admin(&admin);
+        client.init_admin(&admin, &DEFAULT_ADMIN_ROTATION_TIMELOCK_SECONDS);
         client.propose_admin_rotation(&admin, &new_admin);
 
         // Still before the timelock elapses.
-        set_time(&env, 1_000 + ADMIN_ROTATION_TIMELOCK_SECONDS - 1);
+        set_time(&env, 1_000 + DEFAULT_ADMIN_ROTATION_TIMELOCK_SECONDS - 1);
         let too_early = client.try_finalize_admin_rotation();
         assert_eq!(too_early, Err(Ok(Error::TimelockNotElapsed)));
         assert_eq!(client.get_admin(), Some(admin.clone()));
 
         // Timelock has now elapsed.
-        set_time(&env, 1_000 + ADMIN_ROTATION_TIMELOCK_SECONDS);
+        set_time(&env, 1_000 + DEFAULT_ADMIN_ROTATION_TIMELOCK_SECONDS);
         client.finalize_admin_rotation();
 
         assert_eq!(client.get_admin(), Some(new_admin));
         assert_eq!(client.get_pending_admin_rotation(), None);
+    }
+
+    /// The whole point of this issue: a deployment can configure a
+    /// different timelock than the default, and that configured value —
+    /// not the default — is what actually gates `finalize_admin_rotation`.
+    #[test]
+    fn test_init_admin_configures_a_custom_rotation_timelock() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, BillPayments);
+        let client = BillPaymentsClient::new(&env, &contract_id);
+        let admin = <soroban_sdk::Address as AddressTrait>::generate(&env);
+        let new_admin = <soroban_sdk::Address as AddressTrait>::generate(&env);
+
+        let custom_timelock: u64 = MIN_SCHEDULE_INTERVAL * 2; // 2 hours, well under the 2-day default
+        set_time(&env, 1_000);
+        env.mock_all_auths();
+        client.init_admin(&admin, &custom_timelock);
+        assert_eq!(client.get_admin_rotation_timelock(), custom_timelock);
+
+        client.propose_admin_rotation(&admin, &new_admin);
+
+        // Would still be pending under the default (2-day) timelock, but the
+        // custom (2-hour) timelock has elapsed.
+        set_time(&env, 1_000 + custom_timelock);
+        client.finalize_admin_rotation();
+        assert_eq!(client.get_admin(), Some(new_admin));
+    }
+
+    /// A timelock below `MIN_SCHEDULE_INTERVAL` would defeat the whole
+    /// purpose of the window (giving the legitimate admin time to react) and
+    /// must be rejected at `init_admin`, before any state is set.
+    #[test]
+    fn test_init_admin_rejects_too_short_a_rotation_timelock() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, BillPayments);
+        let client = BillPaymentsClient::new(&env, &contract_id);
+        let admin = <soroban_sdk::Address as AddressTrait>::generate(&env);
+
+        env.mock_all_auths();
+        let result = client.try_init_admin(&admin, &(MIN_SCHEDULE_INTERVAL - 1));
+
+        assert_eq!(result, Err(Ok(Error::RotationTimelockTooShort)));
+        assert_eq!(client.get_admin(), None);
     }
 
     #[test]
@@ -4512,7 +4555,7 @@ fn test_set_external_ref_owner_can_set() {
         let new_admin = <soroban_sdk::Address as AddressTrait>::generate(&env);
 
         env.mock_all_auths();
-        client.init_admin(&admin);
+        client.init_admin(&admin, &DEFAULT_ADMIN_ROTATION_TIMELOCK_SECONDS);
 
         let result = client.try_propose_admin_rotation(&stranger, &new_admin);
 
@@ -4527,7 +4570,7 @@ fn test_set_external_ref_owner_can_set() {
         let admin = <soroban_sdk::Address as AddressTrait>::generate(&env);
 
         env.mock_all_auths();
-        client.init_admin(&admin);
+        client.init_admin(&admin, &DEFAULT_ADMIN_ROTATION_TIMELOCK_SECONDS);
 
         let result = client.try_finalize_admin_rotation();
 
@@ -4543,9 +4586,9 @@ fn test_set_external_ref_owner_can_set() {
         let other = <soroban_sdk::Address as AddressTrait>::generate(&env);
 
         env.mock_all_auths();
-        client.init_admin(&admin);
+        client.init_admin(&admin, &DEFAULT_ADMIN_ROTATION_TIMELOCK_SECONDS);
 
-        let result = client.try_init_admin(&other);
+        let result = client.try_init_admin(&other, &DEFAULT_ADMIN_ROTATION_TIMELOCK_SECONDS);
 
         assert_eq!(result, Err(Ok(Error::AdminAlreadyInitialized)));
     }


### PR DESCRIPTION
## ⚠️ Verification blocked by a pre-existing, unrelated break on `main`
`bill_payments/src/lib.rs` currently fails to compile with **152 errors** on `main` as of the latest sync — confirmed via `git stash` + `cargo build -p bill_payments` on a clean checkout, before touching anything. Root cause: commit `182ddb1` ("feat(bill_payments): validate and normalize currency codes (SC-015)", #1676) merged without rebasing against the admin-rotation-timelock work that had just landed (#1610/#1648), duplicating `ArchivedBill`, `ArchivedBillPage`, and `pub type Error = BillPaymentsError;` — the two `ArchivedBill` copies even disagree on a field type (`paid_at: Option<u64>` vs `paid_at: u64`). This is unrelated to admin rotation or this issue and needs a maintainer to pick the correct copy of each duplicated block.

Given that, **I could not run `cargo build`/`cargo test`/`cargo clippy` to verify this change** — any build of this crate fails regardless of what's in this diff. What I did verify:
- `cargo fmt -p bill_payments -- --check` — clean (this parses/formats successfully, confirming valid Rust syntax independent of the type-check failure)
- Diffed the exact set of compiler error messages between baseline `main` and this branch (`cargo build -p bill_payments 2>&1 | grep '^error' | sort`) — the *unique* error text is identical; my branch adds exactly one more line of output, which is just the same pre-existing "cannot find type `BillPaymentsError`" cascade additionally hitting my new code's own references to that (currently broken) type — not a new category of error.
- Careful manual review of the diff (posted in full below for anyone reviewing) — every change is a small, self-contained addition or signature change with no interaction with the duplicated region.

I'd normally never submit unverified, but the user I'm working for explicitly asked me to proceed this way given the blocker, understanding the risk. **This PR should not be merged before the duplication in #1676 is resolved on `main`**, and will need a final `cargo test` pass once it is.

## Summary
`ADMIN_ROTATION_TIMELOCK_SECONDS` (the delay between `propose_admin_rotation` and `finalize_admin_rotation`) was a hardcoded `2 * 86400` (2 days) module constant — every deployment got the same fixed window with no way to configure it, e.g. a shorter window for a test network.

## Change
- Renamed the constant to `DEFAULT_ADMIN_ROTATION_TIMELOCK_SECONDS` (now `pub`) — the sane default, used as a fallback.
- `init_admin` now takes a `rotation_timelock_seconds: u64` parameter, stored in instance storage (`ROT_TL`).
- `propose_admin_rotation` reads the configured value (falling back to the default) instead of the hardcoded constant.
- Added `get_admin_rotation_timelock()` — a read-only getter for the configured value.
- Added `RotationTimelockTooShort` — `init_admin` rejects a timelock below `MIN_SCHEDULE_INTERVAL` (1 hour), since anything shorter would defeat the whole point of the window (giving the legitimate admin time to notice and react to a rotation proposal).

Closes #1530

## Test plan (written, not run — see verification note above)
- Updated the 4 existing tests in `bill_payments/src/test.rs` that call `init_admin`/`try_init_admin` to pass `&DEFAULT_ADMIN_ROTATION_TIMELOCK_SECONDS`, preserving their original behavior exactly.
- New `test_init_admin_configures_a_custom_rotation_timelock`: configures a 2-hour timelock (vs. the 2-day default), proposes a rotation, advances time by exactly the custom window (which would still be pending under the default), and confirms `finalize_admin_rotation` succeeds — proving the configured value, not the default, actually gates finalization.
- New `test_init_admin_rejects_too_short_a_rotation_timelock`: `init_admin` with `MIN_SCHEDULE_INTERVAL - 1` returns `RotationTimelockTooShort` and leaves no admin set.