### PR TITLE
perf(remitwise-common): add single-tag canonicalizer, avoid Vec wrap

### DIFF
--- a/remitwise-common/src/lib.rs
+++ b/remitwise-common/src/lib.rs
@@ -2000,6 +2000,45 @@ pub fn verify_slash_signature(
 ///     Err(TagError::Empty) | Err(TagError::TooLong) => { /* map to caller error */ }
 /// }
 /// ```
+/// Validates and canonicalizes a single tag: enforces `1..=TAG_MAX_LEN` byte
+/// length and the `[a-z0-9\-_]` charset, lowercasing ASCII uppercase letters.
+///
+/// Extracted from [`canonicalize_tags_checked`] so single-tag lookups (e.g.
+/// a tag-index query keyed on one caller-supplied tag) don't need to
+/// allocate a one-element `Vec` just to call the batch API.
+pub fn canonicalize_tag_checked(
+    env: &soroban_sdk::Env,
+    tag: &soroban_sdk::String,
+) -> Result<soroban_sdk::String, TagError> {
+    let len = tag.len();
+    if len == 0 {
+        return Err(TagError::Empty);
+    }
+    if len > TAG_MAX_LEN {
+        return Err(TagError::TooLong);
+    }
+    let mut buf = [0u8; 32];
+    tag.copy_into_slice(&mut buf[..len as usize]);
+    for (position, byte) in buf.iter_mut().take(len as usize).enumerate() {
+        if byte.is_ascii_uppercase() {
+            *byte += b'a' - b'A';
+        }
+        let b = *byte;
+        if !(b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-' || b == b'_') {
+            return Err(TagError::InvalidChar {
+                position: position as u32,
+            });
+        }
+    }
+    let s = match core::str::from_utf8(&buf[..len as usize]) {
+        Ok(v) => v,
+        Err(_) => {
+            return Err(TagError::InvalidChar { position: 0 });
+        }
+    };
+    Ok(soroban_sdk::String::from_str(env, s))
+}
+
 pub fn canonicalize_tags_checked(
     env: &soroban_sdk::Env,
     tags: &soroban_sdk::Vec<soroban_sdk::String>,
@@ -2009,33 +2048,7 @@ pub fn canonicalize_tags_checked(
     }
     let mut out = soroban_sdk::Vec::new(env);
     for tag in tags.iter() {
-        let len = tag.len();
-        if len == 0 {
-            return Err(TagError::Empty);
-        }
-        if len > TAG_MAX_LEN {
-            return Err(TagError::TooLong);
-        }
-        let mut buf = [0u8; 32];
-        tag.copy_into_slice(&mut buf[..len as usize]);
-        for (position, byte) in buf.iter_mut().take(len as usize).enumerate() {
-            if byte.is_ascii_uppercase() {
-                *byte += b'a' - b'A';
-            }
-            let b = *byte;
-            if !(b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-' || b == b'_') {
-                return Err(TagError::InvalidChar {
-                    position: position as u32,
-                });
-            }
-        }
-        let s = match core::str::from_utf8(&buf[..len as usize]) {
-            Ok(v) => v,
-            Err(_) => {
-                return Err(TagError::InvalidChar { position: 0 });
-            }
-        };
-        out.push_back(soroban_sdk::String::from_str(env, s));
+        out.push_back(canonicalize_tag_checked(env, &tag)?);
     }
     Ok(out)
 }

--- a/remitwise-common/src/tests.rs
+++ b/remitwise-common/src/tests.rs
@@ -422,6 +422,56 @@ fn test_checked_empty_batch_before_length_check() {
     assert_eq!(err, TagError::Empty);
 }
 
+// ─── canonicalize_tag_checked: single-tag entry point ────────────────────────
+//
+// Issue #1593: single-tag lookups (e.g. a tag-index query keyed on one
+// caller-supplied tag) previously had to wrap that tag in a one-element `Vec`
+// just to call the batch `canonicalize_tags_checked` API, which then
+// allocated a second `Vec` for its output. `canonicalize_tag_checked` does
+// the identical validation/lowercasing with no `Vec` involved at all, and
+// `canonicalize_tags_checked` is now defined in terms of it.
+
+#[test]
+fn test_single_canonicalize_lowercases_and_matches_batch() {
+    let env = Env::default();
+    let single_result = canonicalize_tag_checked(&env, &String::from_str(&env, "MyGoal")).unwrap();
+    let batch_result = canonicalize_tags_checked(&env, &single(&env, "MyGoal")).unwrap();
+
+    let mut wrapped = Vec::new(&env);
+    wrapped.push_back(single_result.clone());
+    assert_eq!(get(&env, &wrapped, 0), "mygoal");
+    assert_eq!(batch_result.get(0).unwrap(), single_result);
+}
+
+#[test]
+fn test_single_canonicalize_rejects_empty() {
+    let env = Env::default();
+    assert_eq!(
+        canonicalize_tag_checked(&env, &String::from_str(&env, "")),
+        Err(TagError::Empty)
+    );
+}
+
+#[test]
+fn test_single_canonicalize_rejects_too_long() {
+    let env = Env::default();
+    let tag = "a".repeat(33);
+    let tag = std::string::String::from_utf8(tag.into_bytes()).unwrap();
+    assert_eq!(
+        canonicalize_tag_checked(&env, &String::from_str(&env, &tag)),
+        Err(TagError::TooLong)
+    );
+}
+
+#[test]
+fn test_single_canonicalize_rejects_invalid_char() {
+    let env = Env::default();
+    assert_eq!(
+        canonicalize_tag_checked(&env, &String::from_str(&env, "#savings")),
+        Err(TagError::InvalidChar { position: 0 })
+    );
+}
+
 // ─── canonicalise_symbol ──────────────────────────────────────────────────────
 
 /// A deterministic helper: get string content from a Symbol for assertions.

--- a/savings_goals/src/lib.rs
+++ b/savings_goals/src/lib.rs
@@ -1753,13 +1753,17 @@ impl SavingsGoalContract {
     ) -> GoalPage {
         let limit = Self::clamp_limit(limit);
 
-        // Canonicalize the tag for lookup
-        let mut tags_vec = Vec::new(&env);
-        tags_vec.push_back(tag.clone());
-        let normalized = Self::validate_and_normalize_tags(&env, &tags_vec);
-        let canonical_tag = normalized
-            .get(0)
-            .unwrap_or_else(|| panic!("Tag normalization failed"));
+        // Canonicalize the single lookup tag directly -- no need to wrap it
+        // in a one-element Vec just to call the batch normalizer.
+        let canonical_tag = match remitwise_common::canonicalize_tag_checked(&env, &tag) {
+            Ok(t) => t,
+            Err(remitwise_common::TagError::Empty) | Err(remitwise_common::TagError::TooLong) => {
+                panic!("Tag must be between 1 and 32 characters")
+            }
+            Err(remitwise_common::TagError::InvalidChar { .. }) => {
+                soroban_sdk::panic_with_error!(&env, SavingsGoalError::InvalidTagContent)
+            }
+        };
 
         let ids: Vec<u32> = env
             .storage()


### PR DESCRIPTION
## Summary

**Note on interpretation:** this issue's title/template is generic ("avoid a Vec copy in the whitelist path") and I couldn't find a literal "whitelist" data structure anywhere in the codebase with an unnecessary `Vec` copy -- I looked hard, including at `remitwise-common`'s stable-currency allowlist (already a static `&[&str]`, no `Vec` involved) and every signer/member list in `family_wallet`/`remittance_split` (all already O(n), no unnecessary clones). The closest genuine, real "unnecessary Vec allocation on a lookup/filter path" I found is described below. Flagging this so a reviewer can redirect me if there's a more specific target in mind -- happy to iterate.

## The inefficiency

`savings_goals::get_goals_by_tag` looks up goals by a single caller-supplied tag. To canonicalize that one tag, it had to:
1. Allocate a one-element `Vec<String>` and push the tag into it.
2. Call `canonicalize_tags_checked` (a batch API), which allocates a *second* `Vec` for its output.
3. Pull element `0` back out and discard both Vecs.

Two heap `Vec` allocations just to validate/lowercase one string.

## Fix

- Extracts the per-tag validation/lowercasing logic out of `canonicalize_tags_checked` into a new `canonicalize_tag_checked(env, &String) -> Result<String, TagError>` in `remitwise-common` -- no `Vec` involved at all.
- `canonicalize_tags_checked` is now defined in terms of it (`out.push_back(canonicalize_tag_checked(env, &tag)?)` in the loop) -- identical behavior for the batch path, verified by the existing (unmodified) batch tests all still passing.
- `savings_goals::get_goals_by_tag` now calls `canonicalize_tag_checked` directly instead of wrapping/unwrapping a temporary Vec.

**Note:** `savings_goals` currently doesn't compile on `main` (pre-existing, unrelated -- ~171 errors from an incomplete refactor). I verified this diff doesn't add to that: `cargo check -p savings_goals --tests` reports the identical 171 errors with and without this change. The `remitwise-common` half of this change is fully verified (see below); the `savings_goals` half is a small, mechanical two-Vec-to-zero-Vec substitution I'm confident in but couldn't run tests against.

## Testing

- Added 4 tests in `remitwise-common` for `canonicalize_tag_checked` (lowercases + matches batch output, rejects empty/too-long/invalid-char) -- all pass.
- `cargo test -p remitwise-common` -- 240 passed (up from 236; the +4 are new), same 30 pre-existing unrelated failures as the baseline (confirmed via `git stash` A/B comparison).
- `cargo fmt -p remitwise-common -- --check` / `cargo clippy -p remitwise-common --lib` -- clean
- `cargo build -p remitwise-common --target wasm32-unknown-unknown --release` -- builds clean

Closes #1593