### PR TITLE
fix(ci): make cargo audit actually gate merges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,6 @@ jobs:
       run: 'cargo audit --deny warnings
 
         '
-      continue-on-error: true
   workspace-invariants:
     name: Workspace Invariants
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #1582

## Summary
The `Security Checks` job in `.github/workflows/ci.yml` already installs `cargo-audit` and runs `cargo audit --deny warnings`, but the step was marked `continue-on-error: true` — meaning a detected vulnerability never failed the job or blocked a merge; the audit only ran informationally. Removed that flag so a real audit finding actually fails the check and gates the merge, per this issue's ask.

## Verification
`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — valid YAML. `actionlint .github/workflows/ci.yml` — only a pre-existing, unrelated shellcheck warning at line 47 (present identically before this change, in a different job's script). No new issues introduced.
