### PR TITLE
feat(remittance-split): expose min-amount as a stored, owner-configurable value

### DIFF
--- a/remittance_split/src/lib.rs
+++ b/remittance_split/src/lib.rs
@@ -110,6 +110,8 @@ pub enum RemittanceSplitError {
     BatchLengthMismatch = 40,
     /// `batch_transfer`'s recipient count exceeds `remitwise_common::MAX_BATCH_SIZE`.
     BatchSizeExceeded = 41,
+    /// A `set_min_deposit` value is below `params::MIN_CORRIDOR_AMOUNT`.
+    InvalidMinDeposit = 42,
 }
 
 #[derive(Clone)]
@@ -1489,10 +1491,64 @@ impl RemittanceSplit {
 
     /// Return the minimum amount accepted for a remittance deposit.
     ///
-    /// The value is shared with corridor validation so callers can discover
-    /// the active lower bound without duplicating contract configuration.
-    pub fn min_deposit(_env: Env) -> i128 {
-        params::MIN_CORRIDOR_AMOUNT
+    /// Returns the owner-configured value set via [`set_min_deposit`], or
+    /// [`params::MIN_CORRIDOR_AMOUNT`] if none has been set. Shared with
+    /// corridor validation so callers can discover the active lower bound
+    /// without duplicating contract configuration.
+    pub fn min_deposit(env: Env) -> i128 {
+        env.storage()
+            .instance()
+            .get(&symbol_short!("MINDEP"))
+            .unwrap_or(params::MIN_CORRIDOR_AMOUNT)
+    }
+
+    /// Configure the minimum accepted deposit amount, overriding the
+    /// [`params::MIN_CORRIDOR_AMOUNT`] default returned by [`min_deposit`].
+    ///
+    /// Only the contract owner may call this. `value` must be at least
+    /// [`params::MIN_CORRIDOR_AMOUNT`] -- the protocol-wide floor is not
+    /// lowerable, only raisable, to prevent a compromised owner key from
+    /// reopening a previously-closed dust-amount griefing vector.
+    ///
+    /// # Errors
+    /// - `NotInitialized` if `initialize_split` has not been called
+    /// - `Unauthorized`   if `caller` is not the owner
+    /// - `InvalidNonce`   if `nonce` does not match the caller's expected nonce
+    /// - `InvalidMinDeposit` if `value` < `params::MIN_CORRIDOR_AMOUNT`
+    pub fn set_min_deposit(
+        env: Env,
+        caller: Address,
+        nonce: u64,
+        value: i128,
+    ) -> Result<(), RemittanceSplitError> {
+        caller.require_auth();
+        Self::extend_instance_ttl(&env);
+        Self::require_not_paused(&env)?;
+        Self::require_nonce(&env, &caller, nonce)?;
+
+        let config: SplitConfig = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("CONFIG"))
+            .ok_or(RemittanceSplitError::NotInitialized)?;
+
+        if config.owner != caller {
+            Self::append_audit(&env, symbol_short!("min_dep"), &caller, false);
+            return Err(RemittanceSplitError::Unauthorized);
+        }
+
+        if value < params::MIN_CORRIDOR_AMOUNT {
+            return Err(RemittanceSplitError::InvalidMinDeposit);
+        }
+
+        env.storage()
+            .instance()
+            .set(&symbol_short!("MINDEP"), &value);
+
+        Self::increment_nonce(&env, &caller)?;
+        Self::append_audit(&env, symbol_short!("min_dep"), &caller, true);
+
+        Ok(())
     }
 
     pub fn calculate_split(


### PR DESCRIPTION
Closes #1578

## Summary
`min_deposit()` in `remittance_split` previously returned the hardcoded `params::MIN_CORRIDOR_AMOUNT` constant. This adds `set_min_deposit(caller, nonce, value)` — owner-only, nonce-protected, following the exact same pattern already used by `init_corridors` (`require_auth` → `require_not_paused` → `require_nonce` → owner check → validate → store → `increment_nonce` → `append_audit`) — storing an override under a new `MINDEP` instance-storage key. `min_deposit()` now returns that override when set, falling back to `params::MIN_CORRIDOR_AMOUNT` otherwise.

The new value must be `>= params::MIN_CORRIDOR_AMOUNT`: the floor can be *raised* by the owner but never lowered below the protocol-wide minimum, so a compromised owner key can't reopen a previously-closed dust-amount griefing vector. Out-of-range values are rejected with a new `RemittanceSplitError::InvalidMinDeposit = 42` (the next unused discriminant after `BatchSizeExceeded = 41`).

## Important: pre-existing, unrelated breakage in this file
`remittance_split/src/lib.rs` currently fails to compile on `main`, **independent of this change** — it contains leftover, unresolved merge-conflict artifacts:
- Line ~2786: a stray branch-name remnant (`validate/rotate-admin-same-address`) left in place of a proper conflict-marker line.
- Line ~2837-2838: a bare `=======` conflict separator followed by a stray ` main` branch-name remnant.
- Two full, duplicate `#[cfg(test)] mod tests { ... fn distribute_usdc_apportions_tokens_to_recipients() ... }` blocks (one starting ~line 2790, a second starting ~line 3433), and the first one appears to be missing its closing `}` before the next `pub fn` begins.

This is a structural, historical merge-conflict resolution error unrelated to `min_deposit`/`set_min_deposit` (which live at line ~1492, far from the corruption) and well beyond the scope of this issue to untangle — I'd recommend filing it as its own dedicated issue. I verified my own addition by careful manual review against the working `init_corridors` pattern elsewhere in the same file, since I could not get a clean local build to run `cargo test` against.

## Errors enum
Added `InvalidMinDeposit = 42` to `RemittanceSplitError`.
