### PR TITLE
docs: standardize Storage terminology

### DIFF
--- a/STORAGE_LAYOUT.md
+++ b/STORAGE_LAYOUT.md
@@ -15,6 +15,10 @@ Scope: current implementation in this repository, focused on auditability and mi
 
 ## Storage Key Naming Conventions
 
+Contract documentation uses `Storage` consistently for Soroban instance and
+persistent storage. `Store` is reserved for describing an action (for example,
+storing a report), not as the name of a storage abstraction or key namespace.
+
 All storage keys follow strict naming conventions to ensure consistency and compatibility with Soroban's `symbol_short!` macro:
 
 - **Maximum length:** 9 characters (enforced by `symbol_short!`)


### PR DESCRIPTION
Closes #1595

Clarify the contract storage documentation so Storage names the persistence abstraction while Store is used only as an action verb.

Validation: git diff --check passed.