### PR TITLE
fix(orchestrator): fanout succeeded inversion, memoize fee lookup, add toolchain docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,141 @@
+# Contributing to Remitwise Contracts
+
+Thank you for contributing to **Remitwise Contracts**! This document covers the required environment setup, toolchain version requirements, and the workflow for making your first contribution.
+
+For a more in-depth orientation, see [docs/CONTRIBUTOR_OVERVIEW.md](docs/CONTRIBUTOR_OVERVIEW.md).
+
+---
+
+## Required Rust Toolchain
+
+### Toolchain Version
+
+This repository uses the **stable** Rust channel, pinned by [`rust-toolchain.toml`](rust-toolchain.toml) at the workspace root.
+
+Current requirements (from `rust-toolchain.toml`):
+
+| Field        | Value                                         |
+|-------------|-----------------------------------------------|
+| channel      | `stable`                                      |
+| components   | `rustfmt`, `clippy`                           |
+| targets      | `wasm32-unknown-unknown`, `wasm32v1-none`     |
+
+> **Why stable?** Soroban's `soroban-sdk = "21.x"` and the WASM targets require a stable toolchain. Using nightly may produce incompatible artifacts or fail to link.
+
+### Installing the Toolchain
+
+[`rustup`](https://rustup.rs) reads `rust-toolchain.toml` automatically and will install the right toolchain on first use:
+
+```bash
+# Install rustup if you don't have it
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
+# From the repo root — rustup picks up rust-toolchain.toml automatically
+rustup show
+```
+
+You should see output like:
+
+```
+stable-<your-host-triple> (overridden by '/path/to/Remitwise-Contracts/rust-toolchain.toml')
+```
+
+### Verifying Your Setup
+
+Run the bundled verification script before starting any work:
+
+```bash
+bash scripts/verify_toolchain.sh
+```
+
+The script checks:
+
+1. `rustc` is available and reports the stable channel.
+2. The `wasm32-unknown-unknown` target is installed.
+3. The `wasm32v1-none` target is installed.
+4. `rustfmt` and `clippy` components are present.
+5. A quick `cargo check` on the workspace succeeds.
+
+Expected successful output:
+
+```
+✅ rustc stable found: rustc X.Y.Z (... stable)
+✅ target wasm32-unknown-unknown installed
+✅ target wasm32v1-none installed
+✅ component rustfmt installed
+✅ component clippy installed
+✅ cargo check passed
+✅ All toolchain checks passed.
+```
+
+If any check fails, the script exits with a non-zero status and prints a remediation hint.
+
+---
+
+## Development Prerequisites
+
+| Tool              | Version       | Install                                        |
+|-------------------|---------------|------------------------------------------------|
+| Rust (stable)     | see above     | `rustup toolchain install stable`              |
+| Soroban CLI       | `21.0.0`      | `cargo install --locked --version 21.0.0 soroban-cli` |
+| Python 3          | `3.9+`        | Used by workspace invariant scripts             |
+
+---
+
+## Pre-PR Checklist
+
+Run all steps locally before opening a pull request. CI enforces the same checks.
+
+```bash
+# 1. Verify your toolchain
+bash scripts/verify_toolchain.sh
+
+# 2. Build all WASM contracts
+cargo build --release --target wasm32-unknown-unknown
+
+# 3. Run tests for the affected crate(s)
+cargo test -p orchestrator
+cargo test -p remitwise-common
+
+# 4. Lint (no warnings, no unwrap/expect in production code)
+cargo clippy --workspace --all-targets -- -D warnings
+cargo clippy --workspace --lib -- -D clippy::unwrap_used -D clippy::expect_used
+
+# 5. Format check
+cargo fmt --all -- --check
+```
+
+Or run the single CI gate script that chains all of the above:
+
+```bash
+bash check_ci.sh
+```
+
+---
+
+## Repo-Specific Rules
+
+- **No `#[allow(unused)]` in production code** without a comment explaining why.
+- **No hard-coded limits in call sites** — put them in `params.rs` (see `remittance_split/src/params.rs` for the pattern).
+- **Prefer typed newtypes** (`Amount`, `Percent`, etc.) over raw `i128` — do not lose the currency tag.
+- **`#![no_std]` discipline** in every contract crate — use `soroban_sdk` types, not `std::vec::Vec`.
+- **`require_auth()` first** in every state-mutating entrypoint.
+- Follow `Closes #<issue>` in PR descriptions.
+
+---
+
+## How to Claim an Issue
+
+1. Comment on the issue that you'd like to take it on and wait for a maintainer to assign it to you. This avoids duplicated effort.
+2. Open a PR that references the issue (`Closes #NNNN`).
+3. Make sure CI is green and request a review from a `CODEOWNERS` maintainer.
+
+---
+
+## Further Reading
+
+- [Architecture Overview](ARCHITECTURE.md)
+- [Storage Layout Reference](STORAGE_LAYOUT.md)
+- [Authorization Matrix](docs/AUTHORIZATION_MATRIX.md)
+- [Threat Model](THREAT_MODEL.md)
+- [Changelog](CHANGELOG.md)

--- a/orchestrator/src/lib.rs
+++ b/orchestrator/src/lib.rs
@@ -609,6 +609,18 @@ impl Orchestrator {
     ///
     /// Useful for idempotent retries or best-effort distribution where partial progress
     /// is preferable to full rollback.
+    ///
+    /// # Memoised fee lookup — fix for #1339
+    /// Dependency addresses and execution IDs are read from instance storage exactly
+    /// once via `FlowRouting::from_storage`, and the split allocation is computed via
+    /// a single `calculate_split` cross-contract call.  Previous versions called
+    /// 6 individual `instance().get(...)` lookups and used a hardcoded `amount / 3`
+    /// approximation rather than the configured split percentages.
+    ///
+    /// # Correct succeeded semantics — fix for #1345
+    /// `succeeded` is set to `true` when the downstream `try_*` call returns `Ok`,
+    /// and `false` when it returns `Err`.  The previous code used `.is_err()` for
+    /// all three assignments, which inverted both per-step flags and `all_succeeded`.
     pub fn execute_flow_fanout(
         env: Env,
         executor: Address,
@@ -621,64 +633,59 @@ impl Orchestrator {
             return Err(OrchestratorError::InvalidAmount);
         }
 
-        let sg_addr: Address = env
-            .storage()
-            .instance()
-            .get(&symbol_short!("SG_ADDR"))
-            .ok_or(OrchestratorError::InvalidDependency)?;
-        let bp_addr: Address = env
-            .storage()
-            .instance()
-            .get(&symbol_short!("BP_ADDR"))
-            .ok_or(OrchestratorError::InvalidDependency)?;
-        let ins_addr: Address = env
-            .storage()
-            .instance()
-            .get(&symbol_short!("INS_ADDR"))
-            .ok_or(OrchestratorError::InvalidDependency)?;
-        let goal_id: u32 = env
-            .storage()
-            .instance()
-            .get(&symbol_short!("GOAL_ID"))
-            .unwrap_or(1);
-        let bill_id: u32 = env
-            .storage()
-            .instance()
-            .get(&symbol_short!("BILL_ID"))
-            .unwrap_or(1);
-        let policy_id: u32 = env
-            .storage()
-            .instance()
-            .get(&symbol_short!("POL_ID"))
-            .unwrap_or(1);
+        // --- #1339: read all dependency addresses and IDs in one pass ----------
+        let routing = FlowRouting::from_storage(&env)?;
 
-        let split = amount / 3;
-        let remainder = amount - split * 3;
+        // --- #1339: single cross-contract call to fetch the configured split ---
+        // `calculate_split` returns [spending, savings, bills, insurance] amounts.
+        // We call it once and reuse the result for all three fan-out steps,
+        // so the fee schedule is fetched exactly once per batch invocation.
+        let rs_client = interface::RemittanceSplitClient::new(&env, &routing.remittance_split);
+        let allocations = rs_client.calculate_split(&amount);
 
-        let s_ok = interface::SavingsGoalsClient::new(&env, &sg_addr)
-            .try_add_to_goal(&executor, &goal_id, &(split + remainder))
-            .is_err();
-        let b_ok = interface::BillPaymentsClient::new(&env, &bp_addr)
-            .try_pay_bill(&executor, &bill_id, &split)
-            .is_err();
-        let i_ok = interface::InsuranceClient::new(&env, &ins_addr)
-            .try_pay_premium(&executor, &policy_id, &split)
-            .is_err();
+        if allocations.len() < 4 {
+            return Err(OrchestratorError::InvalidAmount);
+        }
+
+        let savings_amt = allocations
+            .get(1)
+            .ok_or(OrchestratorError::InvalidAmount)?;
+        let bills_amt = allocations
+            .get(2)
+            .ok_or(OrchestratorError::InvalidAmount)?;
+        let insurance_amt = allocations
+            .get(3)
+            .ok_or(OrchestratorError::InvalidAmount)?;
+
+        if savings_amt < 0 || bills_amt < 0 || insurance_amt < 0 {
+            return Err(OrchestratorError::InvalidAmount);
+        }
+
+        // --- #1345: use .is_ok() so succeeded=true when the call succeeds -----
+        let s_ok = interface::SavingsGoalsClient::new(&env, &routing.savings)
+            .try_add_to_goal(&executor, &routing.goal_id, &savings_amt)
+            .is_ok();
+        let b_ok = interface::BillPaymentsClient::new(&env, &routing.bills)
+            .try_pay_bill(&executor, &routing.bill_id, &bills_amt)
+            .is_ok();
+        let i_ok = interface::InsuranceClient::new(&env, &routing.insurance)
+            .try_pay_premium(&executor, &routing.policy_id, &insurance_amt)
+            .is_ok();
 
         let savings = FanOutStepResult {
             step: FlowStep::SavingsGoal,
             succeeded: s_ok,
-            amount: split + remainder,
+            amount: savings_amt,
         };
         let bills = FanOutStepResult {
             step: FlowStep::BillPayment,
             succeeded: b_ok,
-            amount: split,
+            amount: bills_amt,
         };
         let insurance = FanOutStepResult {
             step: FlowStep::InsurancePremium,
             succeeded: i_ok,
-            amount: split,
+            amount: insurance_amt,
         };
         let all_succeeded = s_ok && b_ok && i_ok;
 

--- a/orchestrator/src/test.rs
+++ b/orchestrator/src/test.rs
@@ -2614,3 +2614,281 @@ fn test_get_fee_schedule_returns_none_when_not_initialized() {
     let result = client.get_fee_schedule();
     assert!(result.is_none(), "fee schedule should be None when not initialized");
 }
+
+// ---------------------------------------------------------------------------
+// execute_flow_fanout — #1339 (memoised fee lookup) + #1345 (error semantics)
+// ---------------------------------------------------------------------------
+//
+// Setup convention for all fanout tests:
+//  • `mock_remittance_split::Contract` returns allocations [5000, 3000, 1500, 500]
+//    for any input amount, so with total=10_000: savings=3000, bills=1500, ins=500.
+//  • `MockContract` succeeds for every downstream call.
+//  • Failing mocks (mock_fail_savings, mock_fail_bill, mock_fail_insurance) panic
+//    inside their respective method, which the `try_*` harness surfaces as Err.
+
+// ---------------------------------------------------------------------------
+// #1345 happy-path: succeeded must be true when calls succeed
+// ---------------------------------------------------------------------------
+
+/// When all three downstream calls succeed, every `succeeded` flag must be
+/// `true` and `all_succeeded` must be `true`.
+///
+/// Before the fix, `.is_err()` was used instead of `.is_ok()`, so a successful
+/// call would set `succeeded = false`.
+#[test]
+fn test_fanout_all_succeed_flags_are_true() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.budget().reset_unlimited();
+
+    let owner = Address::generate(&env);
+    let executor = Address::generate(&env);
+
+    let orch_id = env.register_contract(None, Orchestrator);
+    let fw = env.register_contract(None, MockContract);
+    let rs = env.register_contract(None, mock_remittance_split::Contract);
+    let sg = env.register_contract(None, MockContract);
+    let bp = env.register_contract(None, MockContract);
+    let ins = env.register_contract(None, MockContract);
+
+    let client = OrchestratorClient::new(&env, &orch_id);
+    client.init(&owner, &fw, &rs, &sg, &bp, &ins);
+
+    let result = client.execute_flow_fanout(&executor, &10_000i128);
+
+    assert!(
+        result.savings.succeeded,
+        "savings.succeeded must be true when add_to_goal succeeds (fix for #1345)"
+    );
+    assert!(
+        result.bills.succeeded,
+        "bills.succeeded must be true when pay_bill succeeds (fix for #1345)"
+    );
+    assert!(
+        result.insurance.succeeded,
+        "insurance.succeeded must be true when pay_premium succeeds (fix for #1345)"
+    );
+    assert!(
+        result.all_succeeded,
+        "all_succeeded must be true when all steps succeed (fix for #1345)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #1345 failure-path: succeeded must be false when a call fails
+// ---------------------------------------------------------------------------
+
+/// When the savings step fails (mock panics), savings.succeeded must be
+/// false and all_succeeded must be false, but bills and insurance still run.
+#[test]
+fn test_fanout_savings_failure_reports_succeeded_false() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.budget().reset_unlimited();
+
+    let owner = Address::generate(&env);
+    let executor = Address::generate(&env);
+
+    let orch_id = env.register_contract(None, Orchestrator);
+    // savings-goals uses the panicking mock; fw and other deps use the no-op mock
+    let fw = env.register_contract(None, MockContract);
+    let rs = env.register_contract(None, mock_remittance_split::Contract);
+    let sg = env.register_contract(None, mock_fail_savings::Contract);
+    let bp = env.register_contract(None, MockContract);
+    let ins = env.register_contract(None, MockContract);
+
+    let client = OrchestratorClient::new(&env, &orch_id);
+    client.init(&owner, &fw, &rs, &sg, &bp, &ins);
+
+    let result = client.execute_flow_fanout(&executor, &10_000i128);
+
+    assert!(
+        !result.savings.succeeded,
+        "savings.succeeded must be false when add_to_goal fails (fix for #1345)"
+    );
+    // bills and insurance still attempt and succeed independently
+    assert!(
+        result.bills.succeeded,
+        "bills.succeeded should be true — fan-out continues after savings failure"
+    );
+    assert!(
+        result.insurance.succeeded,
+        "insurance.succeeded should be true — fan-out continues after savings failure"
+    );
+    assert!(
+        !result.all_succeeded,
+        "all_succeeded must be false when any step fails (fix for #1345)"
+    );
+}
+
+/// When the bill step fails, bills.succeeded is false, all_succeeded is false,
+/// and savings/insurance retain their own outcomes.
+#[test]
+fn test_fanout_bill_failure_reports_succeeded_false() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.budget().reset_unlimited();
+
+    let owner = Address::generate(&env);
+    let executor = Address::generate(&env);
+
+    let orch_id = env.register_contract(None, Orchestrator);
+    let fw = env.register_contract(None, MockContract);
+    let rs = env.register_contract(None, mock_remittance_split::Contract);
+    let sg = env.register_contract(None, MockContract);
+    let bp = env.register_contract(None, mock_fail_bill::Contract);
+    let ins = env.register_contract(None, MockContract);
+
+    let client = OrchestratorClient::new(&env, &orch_id);
+    client.init(&owner, &fw, &rs, &sg, &bp, &ins);
+
+    let result = client.execute_flow_fanout(&executor, &10_000i128);
+
+    assert!(result.savings.succeeded, "savings step should succeed");
+    assert!(
+        !result.bills.succeeded,
+        "bills.succeeded must be false when pay_bill fails (fix for #1345)"
+    );
+    assert!(result.insurance.succeeded, "insurance step should succeed");
+    assert!(!result.all_succeeded, "all_succeeded must be false");
+}
+
+/// When the insurance step fails, insurance.succeeded is false.
+#[test]
+fn test_fanout_insurance_failure_reports_succeeded_false() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.budget().reset_unlimited();
+
+    let owner = Address::generate(&env);
+    let executor = Address::generate(&env);
+
+    let orch_id = env.register_contract(None, Orchestrator);
+    let fw = env.register_contract(None, MockContract);
+    let rs = env.register_contract(None, mock_remittance_split::Contract);
+    let sg = env.register_contract(None, MockContract);
+    let bp = env.register_contract(None, MockContract);
+    let ins = env.register_contract(None, mock_fail_insurance::Contract);
+
+    let client = OrchestratorClient::new(&env, &orch_id);
+    client.init(&owner, &fw, &rs, &sg, &bp, &ins);
+
+    let result = client.execute_flow_fanout(&executor, &10_000i128);
+
+    assert!(result.savings.succeeded, "savings step should succeed");
+    assert!(result.bills.succeeded, "bills step should succeed");
+    assert!(
+        !result.insurance.succeeded,
+        "insurance.succeeded must be false when pay_premium fails (fix for #1345)"
+    );
+    assert!(!result.all_succeeded, "all_succeeded must be false");
+}
+
+// ---------------------------------------------------------------------------
+// #1339 memoised fee lookup: allocations come from calculate_split, not amount/3
+// ---------------------------------------------------------------------------
+
+/// The allocated amounts must match the split percentages returned by the
+/// remittance-split contract, not a naive `amount / 3` division.
+///
+/// `mock_remittance_split::Contract` returns [5000, 3000, 1500, 500] for any
+/// amount, so with total = 10_000:
+///   savings   = 3000
+///   bills     = 1500
+///   insurance = 500
+///
+/// The old hardcoded path produced  savings=3334, bills=3333, insurance=3333.
+#[test]
+fn test_fanout_amounts_match_calculate_split_not_hardcoded_thirds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.budget().reset_unlimited();
+
+    let owner = Address::generate(&env);
+    let executor = Address::generate(&env);
+
+    let orch_id = env.register_contract(None, Orchestrator);
+    let fw = env.register_contract(None, MockContract);
+    let rs = env.register_contract(None, mock_remittance_split::Contract);
+    let sg = env.register_contract(None, MockContract);
+    let bp = env.register_contract(None, MockContract);
+    let ins = env.register_contract(None, MockContract);
+
+    let client = OrchestratorClient::new(&env, &orch_id);
+    client.init(&owner, &fw, &rs, &sg, &bp, &ins);
+
+    let result = client.execute_flow_fanout(&executor, &10_000i128);
+
+    // Amounts must reflect the split percentages, not amount/3.
+    assert_eq!(
+        result.savings.amount, 3000,
+        "savings amount must be 3000 (30% of 10_000 from calculate_split) — fix for #1339"
+    );
+    assert_eq!(
+        result.bills.amount, 1500,
+        "bills amount must be 1500 (15% of 10_000 from calculate_split) — fix for #1339"
+    );
+    assert_eq!(
+        result.insurance.amount, 500,
+        "insurance amount must be 500 (5% of 10_000 from calculate_split) — fix for #1339"
+    );
+}
+
+/// InvalidAmount is returned when amount ≤ 0 (explicit failure mode).
+#[test]
+fn test_fanout_rejects_zero_amount() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.budget().reset_unlimited();
+
+    let owner = Address::generate(&env);
+    let executor = Address::generate(&env);
+
+    let orch_id = env.register_contract(None, Orchestrator);
+    let fw = env.register_contract(None, MockContract);
+    let rs = env.register_contract(None, mock_remittance_split::Contract);
+    let sg = env.register_contract(None, MockContract);
+    let bp = env.register_contract(None, MockContract);
+    let ins = env.register_contract(None, MockContract);
+
+    let client = OrchestratorClient::new(&env, &orch_id);
+    client.init(&owner, &fw, &rs, &sg, &bp, &ins);
+
+    let result = client.try_execute_flow_fanout(&executor, &0i128);
+    assert_eq!(
+        result,
+        Err(Ok(OrchestratorError::InvalidAmount)),
+        "fanout must reject zero amount"
+    );
+}
+
+/// InvalidAmount is returned when calculate_split returns fewer than 4 entries.
+#[test]
+fn test_fanout_rejects_short_split_vector() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.budget().reset_unlimited();
+
+    let owner = Address::generate(&env);
+    let executor = Address::generate(&env);
+
+    let orch_id = env.register_contract(None, Orchestrator);
+    let fw = env.register_contract(None, MockContract);
+    // mock_remittance_split_invalid returns only 2 entries
+    let rs = env.register_contract(None, mock_remittance_split_invalid::Contract);
+    let sg = env.register_contract(None, MockContract);
+    let bp = env.register_contract(None, MockContract);
+    let ins = env.register_contract(None, MockContract);
+
+    let client = OrchestratorClient::new(&env, &orch_id);
+    client.init(&owner, &fw, &rs, &sg, &bp, &ins);
+
+    let result = client.try_execute_flow_fanout(&executor, &10_000i128);
+    assert_eq!(
+        result,
+        Err(Ok(OrchestratorError::InvalidAmount)),
+        "fanout must return InvalidAmount when split vector is short"
+    );
+}
+
+

--- a/scripts/verify_toolchain.sh
+++ b/scripts/verify_toolchain.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# scripts/verify_toolchain.sh
+#
+# Verifies that the local Rust toolchain satisfies the requirements specified
+# in rust-toolchain.toml. Exits with status 1 and a remediation hint if any
+# check fails. Idempotent — safe to run multiple times.
+#
+# Usage:
+#   bash scripts/verify_toolchain.sh
+#
+# Closes #1336
+
+set -euo pipefail
+
+PASS=0
+FAIL=1
+all_ok=true
+
+pass() { echo "✅ $*"; }
+fail() { echo "❌ $*"; all_ok=false; }
+
+# ---------------------------------------------------------------------------
+# 1. rustc available and on the stable channel
+# ---------------------------------------------------------------------------
+if ! command -v rustc &>/dev/null; then
+  fail "rustc not found. Install rustup: https://rustup.rs"
+  all_ok=false
+else
+  rustc_version=$(rustc --version 2>&1)
+  if echo "$rustc_version" | grep -q "stable\|nightly\|beta"; then
+    # The active toolchain is controlled by rust-toolchain.toml; we just
+    # confirm rustc is callable and note the version.
+    channel=$(rustup show active-toolchain 2>/dev/null | grep -oE 'stable|nightly|beta' | head -1 || echo "unknown")
+    if [ "$channel" = "stable" ]; then
+      pass "rustc stable found: $rustc_version"
+    else
+      fail "Active toolchain channel is '$channel', expected 'stable'."
+      echo "     Hint: run 'rustup override set stable' or ensure rust-toolchain.toml is present."
+    fi
+  else
+    pass "rustc found: $rustc_version (channel detection inconclusive, proceeding)"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Required WASM targets
+# ---------------------------------------------------------------------------
+check_target() {
+  local target="$1"
+  if rustup target list --installed 2>/dev/null | grep -q "^${target}$"; then
+    pass "target ${target} installed"
+  else
+    fail "target ${target} not installed."
+    echo "     Hint: run 'rustup target add ${target}'"
+    all_ok=false
+  fi
+}
+
+check_target "wasm32-unknown-unknown"
+check_target "wasm32v1-none"
+
+# ---------------------------------------------------------------------------
+# 3. Required components
+# ---------------------------------------------------------------------------
+check_component() {
+  local component="$1"
+  if rustup component list --installed 2>/dev/null | grep -q "^${component}"; then
+    pass "component ${component} installed"
+  else
+    fail "component ${component} not installed."
+    echo "     Hint: run 'rustup component add ${component}'"
+    all_ok=false
+  fi
+}
+
+check_component "rustfmt"
+check_component "clippy"
+
+# ---------------------------------------------------------------------------
+# 4. Quick workspace check (no WASM compile — just host target)
+# ---------------------------------------------------------------------------
+# Scope to the root of the repo regardless of where the script is invoked.
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [ "$all_ok" = true ]; then
+  echo ""
+  echo "Running cargo check (host target)..."
+  if cargo check --quiet --manifest-path "$REPO_ROOT/Cargo.toml" 2>&1; then
+    pass "cargo check passed"
+  else
+    fail "cargo check failed. Fix compilation errors before contributing."
+    all_ok=false
+  fi
+else
+  echo ""
+  echo "⚠️  Skipping cargo check because earlier checks failed."
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+if [ "$all_ok" = true ]; then
+  echo "✅ All toolchain checks passed."
+  exit $PASS
+else
+  echo "❌ One or more toolchain checks failed. See hints above."
+  exit $FAIL
+fi


### PR DESCRIPTION
## Summary

Closes #1336
Closes #1339
Closes #1345

---

## #1336 — DX: document required Rust toolchain version

**New files:**
- `CONTRIBUTING.md` — toolchain version table (channel, components, targets), install instructions, idempotent verification steps, pre-PR checklist, and repo-specific rules
- `scripts/verify_toolchain.sh` — idempotent script that checks `rustc` stable channel, `wasm32-unknown-unknown` + `wasm32v1-none` targets, `rustfmt` and `clippy` components, and `cargo check`; exits 1 with remediation hints on any failure

---

## #1345 — Fix: cross-contract call swallows the inner error

**Root cause:** `execute_flow_fanout` used `.is_err()` on all three `try_*` downstream calls and assigned the result to `FanOutStepResult::succeeded`. This inverted the semantics: a *successful* call set `succeeded = false` and a *failing* call set `succeeded = true`. `all_succeeded` was therefore always wrong.

**Fix (`orchestrator/src/lib.rs`):** Changed `.is_err()` → `.is_ok()` for `s_ok`, `b_ok`, `i_ok`.

---

## #1339 — Perf: memoize the fee lookup across a batch

**Root cause:** `execute_flow_fanout` made 6 individual `instance().get()` storage lookups and computed splits with a hardcoded `amount / 3` approximation instead of calling `calculate_split`. This ignored the configured split percentages entirely.

**Fix (`orchestrator/src/lib.rs`):**
- Replaced 6 individual storage reads with a single `FlowRouting::from_storage(&env)` call (the same pattern used by all other flow paths)
- Replaced `amount / 3` with one `calculate_split(&amount)` cross-contract call; the result is stored in a local `Vec` and its four elements are reused for all three downstream steps — the fee schedule is fetched exactly once per batch invocation

**Before vs after (for a 10 000-unit remittance with a 50/30/15/5 split):**

| | Before (hardcoded thirds) | After (memoised split) |
|---|---|---|
| savings | 3 334 | 3 000 |
| bills | 3 333 | 1 500 |
| insurance | 3 333 | 500 |

---

## Tests added (`orchestrator/src/test.rs`)

| Test | Issue |
|------|-------|
| `test_fanout_all_succeed_flags_are_true` | #1345 happy path |
| `test_fanout_savings_failure_reports_succeeded_false` | #1345 failure path |
| `test_fanout_bill_failure_reports_succeeded_false` | #1345 failure path |
| `test_fanout_insurance_failure_reports_succeeded_false` | #1345 failure path |
| `test_fanout_amounts_match_calculate_split_not_hardcoded_thirds` | #1339 |
| `test_fanout_rejects_zero_amount` | explicit failure mode |
| `test_fanout_rejects_short_split_vector` | explicit failure mode |

---

## Checklist

- [x] Change matches the summary of each issue
- [x] Tests cover happy path + explicit failure mode for each fix
- [x] `verify_toolchain.sh` is idempotent and exits non-zero on any failure
- [x] No hard-coded limits in call sites (thresholds read from `params.rs` / contract storage)
- [x] No unrelated refactors or style-only changes
- [x] `scripts/verify_toolchain.sh` is executable (`chmod +x`)