### PR TITLE
feat(reporting): add scoped delegated viewer access

### DIFF
--- a/reporting/docs/DELEGATED_VIEWER_ACL.md
+++ b/reporting/docs/DELEGATED_VIEWER_ACL.md
@@ -1,0 +1,161 @@
+# Delegated report viewers
+
+Reporting data is private by subject. The owner of a report can read it
+directly, and a different address can read it only after the owner grants the
+specific report scope. A grant is not a general reporting role and it is not a
+permission to act as the owner in another contract.
+
+## Scope model
+
+The ACL currently separates two data classes:
+
+| Scope | Entry point | Data exposed |
+| --- | --- | --- |
+| `Stored` | `get_stored_report_for` | Full stored financial-health report |
+| `Archived` | `get_archived_reports_page_for` | Archived health-score summaries |
+
+Granting `Archived` does not grant `Stored`. The owner and viewer are both
+part of the storage key. A grant for Alice and Bob cannot authorize Bob to
+read Alice's data by changing the owner argument to Carol.
+
+## Grant lifecycle
+
+The owner calls `grant_viewer(owner, viewer, scope, expires_at)`. The owner
+must authenticate the call. An expiry of zero means the grant has no time
+limit; a non-zero expiry must be strictly after the current ledger timestamp.
+The contract rejects the owner itself, the reporting contract address, and
+expired-at-creation grants.
+
+The owner calls `revoke_viewer` to remove the exact `(owner, viewer, scope)`
+entry. Removal is immediate for new queries in the same ledger transaction
+sequence. Revoking `Stored` leaves an independent `Archived` grant untouched,
+and vice versa. Re-granting the same tuple replaces its expiry deliberately;
+the latest owner-authenticated decision is the active decision.
+
+## Query authorization
+
+The delegated endpoints authenticate the `viewer` first, then check the
+subject, viewer, and scope tuple. The owner bypasses the grant lookup only for
+their own subject. A missing, expired, or revoked grant returns the same
+`Unauthorized` error as every other denied request.
+
+The contract performs the authorization check before reading the report map or
+archive index. This ordering prevents a caller from learning whether a report
+exists by comparing a missing-record result with an authorization failure.
+The response shape for an authorized empty result is distinct from an
+unauthorized error, but only after authorization has succeeded.
+
+## Expiry semantics
+
+An expiring grant is valid while `ledger_timestamp < expires_at`. At the exact
+expiry timestamp it is invalid. This boundary avoids an extra readable ledger
+at the end of a grant and makes client scheduling deterministic. Expired
+entries may remain in the bounded instance map until the owner revokes or
+replaces them; the authorization predicate treats them as inactive.
+
+Clients should refresh the ledger timestamp before submitting a read near the
+boundary. A successful simulation does not reserve access for a later
+transaction. The contract checks the timestamp and grant again during the
+actual invocation.
+
+## Adversarial cases
+
+The implementation is designed against these common mistakes:
+
+- passing a different owner in the query than the owner in the grant;
+- using a Stored grant to retrieve an Archived page or the reverse;
+- reusing a viewer grant after its expiry;
+- querying immediately after revocation;
+- asking a stranger to inspect another pair's grant state;
+- using the reporting contract address as a viewer;
+- creating a grant with an expiry at or before the current timestamp;
+- inferring report existence from an unauthorized request;
+- treating a viewer as if they were the subject in a downstream call.
+
+The viewer is authorized to read only the reporting contract's delegated
+entrypoint. The viewer does not receive the owner's signing authority and
+cannot grant access onward because `grant_viewer` requires the owner address
+to authenticate.
+
+## Compatibility
+
+Existing owner-only query methods retain their signatures and behavior. They
+continue to call `user.require_auth()`, so existing clients do not silently
+become public readers. New integrations that need delegation should use the
+explicit `*_for` methods and pass the viewer as the authenticated caller.
+
+The ACL uses a new instance-storage key, `VIEW_ACL`, and does not reinterpret
+existing report or archive keys. Deployments therefore do not need to migrate
+existing report records. The new key is initialized lazily on the first grant
+or revoke operation.
+
+The new `ReportScope` and `ViewerGrant` values are contract types. Indexers
+should decode them by their discriminants and preserve the owner, viewer,
+scope, and expiry from the grant events. They should not infer scope from an
+entrypoint name alone because future releases may add another explicitly
+versioned scope.
+
+## Indexing and audit
+
+`ViewerGranted` records the complete grant tuple and expiry. `ViewerRevoked`
+records the tuple with expiry zero to identify the exact permission removed.
+Indexers should key these records by ledger sequence and transaction hash,
+then maintain the latest state for each tuple. Event replay must be
+idempotent.
+
+An indexer must not turn a grant event into a general “user has reporting
+access” flag. Scope is part of the authorization decision. A viewer with an
+Archived grant is still unauthorized for stored reports, even if the indexer
+has seen a previous grant for the same owner and address.
+
+Operational dashboards should show active, expired, and revoked grants
+separately. Expired grants are useful audit evidence but must not be presented
+as active permissions. Revoke events should remain visible after a later grant
+so that the permission history is reconstructable.
+
+## Incident response
+
+If a viewer key is compromised, the owner should revoke each active scope for
+that viewer. Revocation is a contract state change and must be confirmed on
+the target network. Rotating a viewer address off-chain is not a substitute
+for revocation.
+
+If the owner key is compromised, the reporting contract's admin rotation and
+the owner's broader account recovery process must be followed. The admin is
+not a fallback viewer and cannot read a user's reports through these methods
+without an explicit grant from that user.
+
+If an indexer shows a viewer as active after revocation, query the contract's
+grant state and transaction history. Do not rely on the stale index to make a
+privacy decision. The on-chain authorization predicate is authoritative.
+
+## Testing matrix
+
+The focused test suite covers:
+
+1. Stored access is granted only to the exact owner/viewer tuple.
+2. Stored access does not imply Archived access.
+3. A grant cannot cross owners.
+4. Revocation blocks the next query.
+5. Expiry blocks access at the exact boundary timestamp.
+6. Invalid expiry values are rejected.
+7. Self-viewer grants are rejected.
+8. The owner can read without a grant.
+9. An unrelated caller cannot inspect grant state.
+
+Repository-level authorization tests continue to exercise the existing
+owner-only query matrix. Gas checks should include both delegated endpoints,
+the grant write, and the revoke write, with representative existing map sizes.
+
+## Rollback and release
+
+The change is additive for storage and API surface. If a deployment must be
+rolled back, the previous contract version can continue to read the existing
+report and archive keys; the ACL key is ignored by that version. Operators
+should nevertheless revoke sensitive viewer grants before rollback when the
+rollback version does not enforce the new delegated methods, and should record
+that compatibility decision in the release manifest.
+
+Before release, verify the complete matrix on a disposable network, inspect
+grant and revoke events, test the exact expiry boundary, and confirm that no
+unauthorized response reveals whether a stored or archived report exists.

--- a/reporting/src/events_schema_test.rs
+++ b/reporting/src/events_schema_test.rs
@@ -39,8 +39,10 @@ fn report_event_variant_set_is_stable() {
         ReportEvent::AddressesConfigured,
         ReportEvent::ReportsArchived,
         ReportEvent::ArchivesCleaned,
+        ReportEvent::ViewerGranted,
+        ReportEvent::ViewerRevoked,
     ];
-    assert_eq!(variants.len(), 5, "ReportEvent variant count drifted");
+    assert_eq!(variants.len(), 7, "ReportEvent variant count drifted");
 
     for v in variants {
         // Each variant must serialize cleanly so the topic

--- a/reporting/src/lib.rs
+++ b/reporting/src/lib.rs
@@ -272,6 +272,33 @@ pub enum ReportingError {
     /// for itself as an external caller. Mirrors `emergency_killswitch`'s
     /// `InvalidAdmin` guard on `transfer_admin`.
     InvalidAdmin = 12,
+    /// A grant expiry is in the past or is not strictly after the current ledger time.
+    InvalidGrantExpiry = 13,
+    /// A viewer grant does not exist or is no longer active.
+    ViewerNotGranted = 14,
+    /// A viewer cannot be granted access to the owner identity itself.
+    InvalidViewer = 15,
+}
+
+/// Explicit report data scopes that can be delegated independently.
+#[contracttype]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ReportScope {
+    /// Stored full financial-health reports.
+    Stored = 0,
+    /// Archived health-score summaries.
+    Archived = 1,
+}
+
+/// The subject and viewer identity recorded in an ACL event.
+#[contracttype]
+#[derive(Clone)]
+pub struct ViewerGrant {
+    pub owner: Address,
+    pub viewer: Address,
+    pub scope: ReportScope,
+    /// Zero means no expiry; otherwise access is valid while now < expires_at.
+    pub expires_at: u64,
 }
 
 #[contracttype]
@@ -282,6 +309,8 @@ pub enum ReportEvent {
     AddressesConfigured,
     ReportsArchived,
     ArchivesCleaned,
+    ViewerGranted,
+    ViewerRevoked,
 }
 
 /// Archived report - compressed summary
@@ -685,6 +714,143 @@ impl ReportingContract {
             .set(&symbol_short!("ADMIN"), &admin);
 
         Ok(())
+    }
+
+    // ---------------------------------------------------------------------
+    // Delegated report access
+    // ---------------------------------------------------------------------
+
+    /// Return the storage map used for explicit subject-to-viewer grants.
+    ///
+    /// The owner is part of the key, so a viewer grant for one subject can
+    /// never authorize access to another subject's records.
+    fn viewer_grants(env: &Env) -> Map<(Address, Address, ReportScope), u64> {
+        env.storage()
+            .instance()
+            .get(&symbol_short!("VIEW_ACL"))
+            .unwrap_or_else(|| Map::new(env))
+    }
+
+    fn viewer_is_authorized(
+        env: &Env,
+        caller: &Address,
+        owner: &Address,
+        scope: ReportScope,
+    ) -> bool {
+        if caller == owner {
+            return true;
+        }
+        let grants = Self::viewer_grants(env);
+        match grants.get((owner.clone(), caller.clone(), scope)) {
+            Some(expires_at) => expires_at == 0 || env.ledger().timestamp() < expires_at,
+            None => false,
+        }
+    }
+
+    fn require_viewer(
+        env: &Env,
+        caller: &Address,
+        owner: &Address,
+        scope: ReportScope,
+    ) -> Result<(), ReportingError> {
+        caller.require_auth();
+        if Self::viewer_is_authorized(env, caller, owner, scope) {
+            Ok(())
+        } else {
+            // Every denied subject/scope pair returns the same error. This
+            // prevents callers from probing whether a report exists.
+            Err(ReportingError::Unauthorized)
+        }
+    }
+
+    /// Grant a viewer access to one explicit report scope.
+    ///
+    /// `expires_at == 0` creates a non-expiring grant. Any non-zero expiry
+    /// must be in the future. Only the subject can grant or revoke access;
+    /// viewers cannot delegate the subject's authority onward.
+    pub fn grant_viewer(
+        env: Env,
+        owner: Address,
+        viewer: Address,
+        scope: ReportScope,
+        expires_at: u64,
+    ) -> Result<(), ReportingError> {
+        owner.require_auth();
+        let admin: Option<Address> = env.storage().instance().get(&symbol_short!("ADMIN"));
+        if admin.is_none() {
+            return Err(ReportingError::NotInitialized);
+        }
+        if viewer == owner || viewer == env.current_contract_address() {
+            return Err(ReportingError::InvalidViewer);
+        }
+        if expires_at != 0 && expires_at <= env.ledger().timestamp() {
+            return Err(ReportingError::InvalidGrantExpiry);
+        }
+
+        let mut grants = Self::viewer_grants(&env);
+        grants.set((owner.clone(), viewer.clone(), scope), expires_at);
+        env.storage()
+            .instance()
+            .set(&symbol_short!("VIEW_ACL"), &grants);
+        Self::extend_instance_ttl(&env);
+        env.events().publish(
+            (symbol_short!("report"), ReportEvent::ViewerGranted),
+            ViewerGrant {
+                owner,
+                viewer,
+                scope,
+                expires_at,
+            },
+        );
+        Ok(())
+    }
+
+    /// Revoke a viewer's access immediately for future queries.
+    pub fn revoke_viewer(
+        env: Env,
+        owner: Address,
+        viewer: Address,
+        scope: ReportScope,
+    ) -> Result<(), ReportingError> {
+        owner.require_auth();
+        let _: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("ADMIN"))
+            .ok_or(ReportingError::NotInitialized)?;
+        let mut grants = Self::viewer_grants(&env);
+        grants.remove((owner.clone(), viewer.clone(), scope));
+        env.storage()
+            .instance()
+            .set(&symbol_short!("VIEW_ACL"), &grants);
+        Self::extend_instance_ttl(&env);
+        env.events().publish(
+            (symbol_short!("report"), ReportEvent::ViewerRevoked),
+            ViewerGrant {
+                owner,
+                viewer,
+                scope,
+                expires_at: 0,
+            },
+        );
+        Ok(())
+    }
+
+    /// Read the effective grant without exposing report existence.
+    pub fn get_viewer_grant(
+        env: Env,
+        caller: Address,
+        owner: Address,
+        viewer: Address,
+        scope: ReportScope,
+    ) -> Result<Option<u64>, ReportingError> {
+        caller.require_auth();
+        if caller != owner && caller != viewer {
+            return Err(ReportingError::Unauthorized);
+        }
+        Ok(Self::viewer_grants(&env)
+            .get((owner, viewer, scope))
+            .filter(|expiry| *expiry == 0 || env.ledger().timestamp() < *expiry))
     }
 
     /// Propose a new administrator for the contract.
@@ -1691,12 +1857,7 @@ impl ReportingContract {
         remitwise_common::require_bounded_top_n(MAX_ITEMS_PER_REPORT, MAX_TOP_N)
             .map_err(|_| ReportingError::TopNTooLarge)?;
         user.require_auth();
-        Self::get_top_bills_report_internal(
-            &env,
-            user,
-            period_start,
-            period_end,
-        )
+        Self::get_top_bills_report_internal(&env, user, period_start, period_end)
     }
 
     /// ✅ FIXED: Now returns Result and uses proper error handling
@@ -1776,12 +1937,7 @@ impl ReportingContract {
         remitwise_common::require_bounded_top_n(MAX_ITEMS_PER_REPORT, MAX_TOP_N)
             .map_err(|_| ReportingError::TopNTooLarge)?;
         user.require_auth();
-        Self::get_top_savings_report_internal(
-            &env,
-            user,
-            period_start,
-            period_end,
-        )
+        Self::get_top_savings_report_internal(&env, user, period_start, period_end)
     }
 
     /// ✅ FIXED: Now returns Result and uses proper error handling
@@ -1959,6 +2115,25 @@ impl ReportingContract {
             .unwrap_or_else(|| Map::new(&env));
 
         reports.get((user, period_key))
+    }
+
+    /// Delegated equivalent of [`get_stored_report`]. The viewer must hold an
+    /// active `Stored` grant for this exact owner; the owner may always read
+    /// their own report. Unauthorized calls fail before the storage map is
+    /// inspected, so report existence is not distinguishable.
+    pub fn get_stored_report_for(
+        env: Env,
+        viewer: Address,
+        owner: Address,
+        period_key: u64,
+    ) -> Result<Option<FinancialHealthReport>, ReportingError> {
+        Self::require_viewer(&env, &viewer, &owner, ReportScope::Stored)?;
+        let reports: Map<(Address, u64), FinancialHealthReport> = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("REPORTS"))
+            .unwrap_or_else(|| Map::new(&env));
+        Ok(reports.get((owner, period_key)))
     }
 
     /// Get configured contract addresses.
@@ -2211,6 +2386,55 @@ impl ReportingContract {
         }
     }
 
+    /// Delegated, paginated archive read with the same cursor semantics as the
+    /// owner-only endpoint. The scope is `Archived`, not `Stored`, so granting
+    /// archive access never exposes full stored reports.
+    pub fn get_archived_reports_page_for(
+        env: Env,
+        viewer: Address,
+        owner: Address,
+        cursor: u32,
+        limit: u32,
+    ) -> Result<ArchivedPage, ReportingError> {
+        Self::require_viewer(&env, &viewer, &owner, ReportScope::Archived)?;
+        let arch_idx: Map<Address, Vec<u64>> = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("ARCH_IDX"))
+            .unwrap_or_else(|| Map::new(&env));
+        let user_idx = arch_idx
+            .get(owner.clone())
+            .unwrap_or_else(|| Vec::new(&env));
+        let total_count = user_idx.len();
+        let archived: Map<(Address, u64), ArchivedReport> = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("ARCH_RPT"))
+            .unwrap_or_else(|| Map::new(&env));
+        let mut items = Vec::new(&env);
+        if cursor >= total_count {
+            return Ok(ArchivedPage {
+                items,
+                next_cursor: 0,
+                count: total_count,
+            });
+        }
+        let normalized_limit = remitwise_common::clamp_limit(limit);
+        let end = cursor.saturating_add(normalized_limit).min(total_count);
+        for i in cursor..end {
+            if let Some(period_key) = user_idx.get(i) {
+                if let Some(report) = archived.get((owner.clone(), period_key)) {
+                    items.push_back(report);
+                }
+            }
+        }
+        Ok(ArchivedPage {
+            items,
+            next_cursor: if end < total_count { end } else { 0 },
+            count: total_count,
+        })
+    }
+
     /// Permanently delete old archives before specified timestamp (admin only).
     ///
     /// # Arguments
@@ -2387,3 +2611,6 @@ mod tests_archived_pagination_bound;
 
 #[cfg(test)]
 mod tests_safe_math;
+
+#[cfg(test)]
+mod tests_viewer_acl;

--- a/reporting/src/tests_viewer_acl.rs
+++ b/reporting/src/tests_viewer_acl.rs
@@ -1,0 +1,109 @@
+#![cfg(test)]
+#![allow(clippy::all)]
+
+use soroban_sdk::testutils::{Address as _, Ledger};
+use soroban_sdk::{Address, Env};
+
+use crate::{ReportScope, ReportingContract, ReportingContractClient, ReportingError};
+
+fn setup() -> (
+    Env,
+    ReportingContractClient<'static>,
+    Address,
+    Address,
+    Address,
+) {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let id = env.register_contract(None, ReportingContract);
+    let client = ReportingContractClient::new(&env, &id);
+    let admin = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let viewer = Address::generate(&env);
+    client.init(&admin);
+    (env, client, owner, viewer, admin)
+}
+
+#[test]
+fn grant_is_scoped_to_owner_viewer_and_data_class() {
+    let (env, client, owner, viewer, _admin) = setup();
+    client.grant_viewer(&owner, &viewer, &ReportScope::Stored, &0);
+    assert_eq!(
+        client.get_viewer_grant(&viewer, &owner, &viewer, &ReportScope::Stored),
+        Some(0)
+    );
+    assert_eq!(
+        client.try_get_stored_report_for(&viewer, &owner, &7),
+        Ok(None)
+    );
+    assert_eq!(
+        client.try_get_archived_reports_page_for(&viewer, &owner, &0, &20),
+        Err(Ok(ReportingError::Unauthorized))
+    );
+    let other_owner = Address::generate(&env);
+    assert_eq!(
+        client.try_get_stored_report_for(&viewer, &other_owner, &7),
+        Err(Ok(ReportingError::Unauthorized))
+    );
+}
+
+#[test]
+fn revoke_blocks_new_queries_immediately() {
+    let (_env, client, owner, viewer, _admin) = setup();
+    client.grant_viewer(&owner, &viewer, &ReportScope::Stored, &0);
+    client.revoke_viewer(&owner, &viewer, &ReportScope::Stored);
+    assert_eq!(
+        client.try_get_stored_report_for(&viewer, &owner, &7),
+        Err(Ok(ReportingError::Unauthorized))
+    );
+}
+
+#[test]
+fn expired_grant_is_not_authorized() {
+    let (env, client, owner, viewer, _admin) = setup();
+    let expiry = env.ledger().timestamp() + 10;
+    client.grant_viewer(&owner, &viewer, &ReportScope::Stored, &expiry);
+    env.ledger().set_timestamp(expiry);
+    assert_eq!(
+        client.try_get_stored_report_for(&viewer, &owner, &7),
+        Err(Ok(ReportingError::Unauthorized))
+    );
+}
+
+#[test]
+fn invalid_expiry_and_self_viewer_are_rejected() {
+    let (env, client, owner, viewer, _admin) = setup();
+    let now = env.ledger().timestamp();
+    assert_eq!(
+        client.try_grant_viewer(&owner, &viewer, &ReportScope::Stored, &now),
+        Err(Ok(ReportingError::InvalidGrantExpiry))
+    );
+    assert_eq!(
+        client.try_grant_viewer(&owner, &owner, &ReportScope::Stored, &0),
+        Err(Ok(ReportingError::InvalidViewer))
+    );
+}
+
+#[test]
+fn owner_can_read_without_a_grant() {
+    let (_env, client, owner, _viewer, _admin) = setup();
+    assert_eq!(
+        client.try_get_stored_report_for(&owner, &owner, &7),
+        Ok(None)
+    );
+    let page = client.get_archived_reports_page_for(&owner, &owner, &0, &20);
+    assert_eq!(page.items.len(), 0);
+    assert_eq!(page.next_cursor, 0);
+    assert_eq!(page.count, 0);
+}
+
+#[test]
+fn unrelated_caller_cannot_inspect_grant_state() {
+    let (env, client, owner, viewer, _admin) = setup();
+    let stranger = Address::generate(&env);
+    client.grant_viewer(&owner, &viewer, &ReportScope::Stored, &0);
+    assert_eq!(
+        client.try_get_viewer_grant(&stranger, &owner, &viewer, &ReportScope::Stored),
+        Err(Ok(ReportingError::Unauthorized))
+    );
+}


### PR DESCRIPTION
## Summary
- preserve owner authentication across existing user-scoped query endpoints
- add owner-controlled Stored and Archived viewer grants with expiry and immediate revoke
- add explicit delegated query entrypoints, uniform unauthorized errors, scoped events, tests, and security runbook

## Acceptance criteria
- [x] User-scoped existing queries require subject authorization.
- [x] Delegated viewers are limited to an explicit owner/viewer/scope tuple.
- [x] Revocation and expiry deny new queries immediately.
- [x] Unauthorized reads and grant inspection use uniform errors before storage lookup.

## Validation
- `git diff --check`
- 527 changed lines (513 additions, 14 deletions)
- `cargo fmt --all`
- Full cargo test is currently blocked by a pre-existing unclosed delimiter in `insurance/src/lib.rs`; no checks were disabled.

Closes #1719