### PR TITLE
feat(killswitch): enforce thresholded epoch recovery

### DIFF
--- a/emergency_killswitch/ACTIVATION_RECOVERY_POLICY.md
+++ b/emergency_killswitch/ACTIVATION_RECOVERY_POLICY.md
@@ -1,0 +1,185 @@
+# Emergency activation and recovery policy
+
+The killswitch exposes a high-impact control surface. The threshold protocol
+in this change is an explicit state machine for activating and recovering one
+pause scope. It does not silently change the older admin-only pause methods;
+integrators adopting quorum authorization must call `configure_signers`,
+`activate`, and `recover` and must pass the returned signer epoch.
+
+## State and epochs
+
+The configured signer list, threshold, and signer epoch are stored together.
+Every successful signer-set update increments the epoch. An activation records
+the epoch that approved it. A recovery must present both the activation epoch
+and the current signer epoch. Rotating the signer set therefore invalidates
+recovery approvals collected under the previous policy.
+
+An approval is an address in the configured signer list. The contract rejects
+unknown addresses and repeated addresses. Passing the same address twice does
+not create two votes. The threshold counts distinct configured signers only.
+
+The epoch is a concurrency guard, not a signature itself. Each signer address
+still participates in the Soroban authorization tree when the transaction is
+submitted. Off-chain tooling must retain the signer approvals and the epoch in
+the incident record.
+
+## Explicit scope
+
+Every activation names one `PauseScope`:
+
+- `Global` blocks all guarded operations;
+- `Module(module)` blocks the named module;
+- `Function(module, function)` blocks one function in one module.
+
+The scope is stored and emitted with the activation. Recovery clears only the
+scope recorded by that activation. A module activation does not accidentally
+clear a global pause, and a function activation does not clear other paused
+functions. Dependent contracts must consult the corresponding global,
+module, or function state before accepting writes.
+
+The activation also records whether that exact scope was already paused. This
+prevents recovery from lifting an independent operator pause that existed
+before the threshold activation. Recovery removes only the pause introduced by
+the activation; pre-existing state is restored unchanged.
+
+The killswitch contract cannot enforce a pause in an unrelated deployment by
+itself. Each dependent contract must integrate the state check and should use
+the same module and function symbols. Integration tests should verify the
+actual write path, not only the killswitch getter.
+
+## Activation invariants
+
+Activation succeeds only when:
+
+1. the supplied epoch equals the configured signer epoch;
+2. a signer set exists and the approval list reaches the threshold;
+3. every approval is configured and distinct;
+4. no prior activation remains active;
+5. the requested function scope is within the bounded paused-function limit;
+6. the scope and recovery deadline are written before the event is emitted.
+
+Failure occurs before activation state is committed. A partial function-scope
+write that would exceed the limit returns an error and the transaction rolls
+back the activation marker as well. A second activation is rejected until the
+first scope has been recovered.
+
+## Recovery invariants
+
+Recovery requires an active marker, the matching current epoch, the same
+threshold validation, and a ledger timestamp at or after the stored
+`RecoveryReadyAt`. The delay is currently one hour. A caller cannot shorten it
+by submitting a different timestamp or by replaying the activation request.
+
+After recovery, the active epoch, scope, and deadline markers are removed in
+the same transaction that clears the pause. A repeated recovery returns
+`NotActive` and cannot emit another successful recovery event. A new incident
+must collect a new quorum and create a new activation marker.
+
+## Failure and retry matrix
+
+| Attempt | Result | Mutable state |
+| --- | --- | --- |
+| missing signer set | rejected | unchanged |
+| wrong signer epoch | rejected | unchanged |
+| duplicate approval | rejected | unchanged |
+| unknown approval | rejected | unchanged |
+| below threshold | rejected | unchanged |
+| second activation | rejected | existing scope retained |
+| recovery before delay | rejected | pause retained |
+| recovery with stale epoch | rejected | pause retained |
+| valid recovery | accepted once | scope cleared |
+
+This matrix is intentionally fail-closed. Operators should not retry a stale
+epoch automatically; they should reload the signer policy and collect fresh
+approvals. A retry after a partial dependent failure is safe only if the
+epoch, scope, and active marker still match the incident record.
+
+## Signer-set changes during an incident
+
+Changing the signer set increments the epoch but does not automatically clear
+an active pause. This preserves the emergency protection while requiring the
+new signer set to approve recovery. If the new policy cannot approve recovery,
+the operator must restore a valid signer configuration through the admin
+governance process; an old approval bundle must never be reused.
+
+The admin cannot lower the threshold to manufacture a quorum for an already
+collected incident without that policy change being visible as a new signer
+epoch. Production governance should require independent review for threshold
+changes and should record the old and new signer lists.
+
+## Event contract
+
+The protocol emits `signers_set`, `activated`, and `recovered` events under the
+`emergency` namespace. Indexers must persist epoch, threshold, scope, and
+ledger sequence. They should treat events as an ordered audit stream and
+deduplicate by transaction hash.
+
+An `activated` event without the corresponding active getter state after
+finality is an operational alert. A `recovered` event must reference an epoch
+that was previously active. A version of the indexer that does not understand
+a future scope variant must preserve the raw XDR and mark it unknown rather
+than treating it as global.
+
+## Threat scenarios
+
+### Replayed activation
+
+The activation marker prevents the same epoch from activating another scope
+while the first scope remains active. Recovery clears the marker, and a later
+activation must use the current epoch and a fresh transaction authorization.
+
+### Replayed recovery
+
+Recovery deletes the marker and deadline on success. The same request then
+fails with `NotActive`. If the signer list changed, the epoch comparison fails
+even before approval validation.
+
+### Duplicate signer counting
+
+The approval list is checked against the configured signer list and for
+duplicate entries. A caller cannot satisfy a 2-of-3 threshold with one signer
+appearing twice.
+
+### Partial downstream pause
+
+The scope is explicit and the activation itself is atomic. A dependent
+contract that fails to observe its pause is an integration defect, not a reason
+to mark the activation partially successful. The integration test suite should
+exercise each dependent write path and report the first non-compliant module.
+
+### Compromised signer
+
+A compromised signer alone cannot activate a threshold requiring additional
+distinct signers. If the threshold is met under an incident, governance should
+rotate the signer set, which invalidates stale recovery approvals while keeping
+the pause active.
+
+## Backward compatibility and rollback
+
+Existing admin-only APIs and storage keys remain available. The new signer
+policy is opt-in through explicit configuration, and no default signer set is
+invented during initialization. This avoids silently changing the behavior of
+deployments that have not completed a governance migration.
+
+To roll back the code, first document whether any threshold activation is
+active. A previous version that does not understand the new markers must not
+be used to clear a live pause without an incident review. Preserve the signer
+epoch and activation events in the deployment record, and verify every
+dependent contract after rollback.
+
+## Validation checklist
+
+- [ ] Configure a valid set and confirm the epoch increments.
+- [ ] Reject missing, duplicate, unknown, and stale approvals.
+- [ ] Activate global, module, and function scopes independently.
+- [ ] Reject a second activation before recovery.
+- [ ] Reject recovery before the delay.
+- [ ] Recover with the current threshold and confirm marker deletion.
+- [ ] Rotate signers and reject old-epoch recovery.
+- [ ] Retry after a dependent failure without weakening the quorum.
+- [ ] Verify events, getters, gas bounds, and no-panic behavior.
+- [ ] Exercise every dependent contract's pause check.
+
+This policy keeps signer authorization, epoch freshness, scope identity,
+recovery delay, and one-time state transitions explicit and independently
+auditable.

--- a/emergency_killswitch/src/lib.rs
+++ b/emergency_killswitch/src/lib.rs
@@ -14,6 +14,23 @@ pub enum Error {
     InvalidSchedule = 5,
     InvalidAdmin = 6,
     EpochMismatch = 7,
+    InvalidSignerThreshold = 8,
+    DuplicateSigner = 9,
+    SignerNotConfigured = 10,
+    DuplicateApproval = 11,
+    ActivationAlreadyActive = 12,
+    RecoveryTooEarly = 13,
+    NotActive = 14,
+    ScopeRequired = 15,
+}
+
+/// The exact pause surface affected by a threshold-approved activation.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PauseScope {
+    Global,
+    Module(Symbol),
+    Function(Symbol, Symbol),
 }
 
 #[contracttype]
@@ -27,7 +44,17 @@ enum DataKey {
     PausedFunctions(Symbol),
     UnpauseSchedule,
     KillSwitchEpoch,
+    Signers,
+    SignerThreshold,
+    SignerEpoch,
+    ActivationEpoch,
+    ActiveScope,
+    RecoveryReadyAt,
+    ScopeWasPaused,
 }
+
+/// Delay between a threshold-approved activation and recovery.
+pub const RECOVERY_DELAY: u64 = 3600;
 
 pub const MAX_PAUSED_FUNCTIONS: u32 = 10;
 
@@ -69,6 +96,249 @@ impl EmergencyKillswitch {
         env.storage()
             .instance()
             .set(&DataKey::KillSwitchEpoch, &0u64);
+        Ok(())
+    }
+
+    fn configured_signers(env: &Env) -> Vec<Address> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Signers)
+            .unwrap_or(Vec::new(env))
+    }
+
+    fn validate_approvals(env: &Env, approvals: &Vec<Address>) -> Result<(), Error> {
+        let signers = Self::configured_signers(env);
+        let threshold: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::SignerThreshold)
+            .ok_or(Error::SignerNotConfigured)?;
+        let mut accepted = 0u32;
+        for approval in approvals.iter() {
+            if !signers.contains(approval) {
+                return Err(Error::SignerNotConfigured);
+            }
+            if accepted > 0 {
+                let mut prior = 0u32;
+                for seen in approvals.iter() {
+                    if seen == approval {
+                        prior += 1;
+                    }
+                    if seen == approval && prior > 1 {
+                        return Err(Error::DuplicateApproval);
+                    }
+                }
+            }
+            accepted += 1;
+        }
+        if accepted < threshold {
+            return Err(Error::InvalidSignerThreshold);
+        }
+        Ok(())
+    }
+
+    /// Configure the signer set used by the explicit activation protocol.
+    /// Updating the set increments its epoch and invalidates all old approval
+    /// bundles. The admin remains the only authority that can change policy.
+    pub fn configure_signers(
+        env: Env,
+        caller: Address,
+        signers: Vec<Address>,
+        threshold: u32,
+    ) -> Result<u64, Error> {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotInitialized)?;
+        admin.require_auth();
+        if caller != admin || signers.is_empty() || threshold == 0 || threshold > signers.len() {
+            return Err(Error::InvalidSignerThreshold);
+        }
+        for (index, signer) in signers.iter().enumerate() {
+            if *signer == env.current_contract_address() {
+                return Err(Error::InvalidAdmin);
+            }
+            for prior in signers.iter().take(index) {
+                if prior == signer {
+                    return Err(Error::DuplicateSigner);
+                }
+            }
+        }
+        let old_epoch: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::SignerEpoch)
+            .unwrap_or(0);
+        let epoch = old_epoch.checked_add(1).ok_or(Error::EpochMismatch)?;
+        env.storage().instance().set(&DataKey::Signers, &signers);
+        env.storage()
+            .instance()
+            .set(&DataKey::SignerThreshold, &threshold);
+        env.storage().instance().set(&DataKey::SignerEpoch, &epoch);
+        env.events().publish(
+            (symbol_short!("emergency"), symbol_short!("signers_set")),
+            (epoch, threshold, signers.len()),
+        );
+        Ok(epoch)
+    }
+
+    pub fn get_signer_epoch(env: Env) -> u64 {
+        env.storage()
+            .instance()
+            .get(&DataKey::SignerEpoch)
+            .unwrap_or(0)
+    }
+
+    pub fn get_signer_threshold(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::SignerThreshold)
+            .unwrap_or(0)
+    }
+
+    /// Activate exactly one explicit scope after validating a current-epoch
+    /// signer quorum. A second activation is rejected until recovery completes.
+    pub fn activate(
+        env: Env,
+        epoch: u64,
+        approvals: Vec<Address>,
+        scope: PauseScope,
+    ) -> Result<(), Error> {
+        if approvals.is_empty() {
+            return Err(Error::InvalidSignerThreshold);
+        }
+        if epoch != Self::get_signer_epoch(env.clone()) {
+            return Err(Error::EpochMismatch);
+        }
+        if env.storage().instance().has(&DataKey::ActivationEpoch) {
+            return Err(Error::ActivationAlreadyActive);
+        }
+        Self::validate_approvals(&env, &approvals)?;
+        env.storage()
+            .instance()
+            .set(&DataKey::ActivationEpoch, &epoch);
+        env.storage().instance().set(&DataKey::ActiveScope, &scope);
+        env.storage().instance().set(
+            &DataKey::RecoveryReadyAt,
+            &(env.ledger().timestamp().saturating_add(RECOVERY_DELAY)),
+        );
+        let scope_was_paused = match scope.clone() {
+            PauseScope::Global => env
+                .storage()
+                .instance()
+                .get(&DataKey::GlobalPaused)
+                .unwrap_or(false),
+            PauseScope::Module(module) => env
+                .storage()
+                .instance()
+                .get(&DataKey::ModulePaused(module))
+                .unwrap_or(false),
+            PauseScope::Function(module, function) => env
+                .storage()
+                .instance()
+                .get(&DataKey::PausedFunctions(module))
+                .unwrap_or(Vec::new(&env))
+                .contains(function),
+        };
+        env.storage()
+            .instance()
+            .set(&DataKey::ScopeWasPaused, &scope_was_paused);
+        match scope.clone() {
+            PauseScope::Global => env.storage().instance().set(&DataKey::GlobalPaused, &true),
+            PauseScope::Module(module) => env
+                .storage()
+                .instance()
+                .set(&DataKey::ModulePaused(module), &true),
+            PauseScope::Function(module, function) => {
+                let mut paused = env
+                    .storage()
+                    .instance()
+                    .get(&DataKey::PausedFunctions(module.clone()))
+                    .unwrap_or(Vec::new(&env));
+                if !paused.contains(function.clone()) {
+                    if paused.len() >= MAX_PAUSED_FUNCTIONS {
+                        return Err(Error::LimitExceeded);
+                    }
+                    paused.push_back(function);
+                    env.storage()
+                        .instance()
+                        .set(&DataKey::PausedFunctions(module), &paused);
+                }
+            }
+        }
+        env.events().publish(
+            (symbol_short!("emergency"), symbol_short!("activated")),
+            (epoch, scope),
+        );
+        Ok(())
+    }
+
+    /// Recover the active scope after the mandatory delay and a fresh quorum.
+    /// The epoch is checked again so a signer-set rotation invalidates a stale
+    /// recovery bundle. Clearing the activation marker makes recovery retryable
+    /// only after a new activation, never by replaying the same request.
+    pub fn recover(env: Env, epoch: u64, approvals: Vec<Address>) -> Result<(), Error> {
+        let active_epoch: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::ActivationEpoch)
+            .ok_or(Error::NotActive)?;
+        if epoch != active_epoch || epoch != Self::get_signer_epoch(env.clone()) {
+            return Err(Error::EpochMismatch);
+        }
+        let ready_at: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::RecoveryReadyAt)
+            .ok_or(Error::RecoveryTooEarly)?;
+        if env.ledger().timestamp() < ready_at {
+            return Err(Error::RecoveryTooEarly);
+        }
+        Self::validate_approvals(&env, &approvals)?;
+        let scope: PauseScope = env
+            .storage()
+            .instance()
+            .get(&DataKey::ActiveScope)
+            .ok_or(Error::NotActive)?;
+        let scope_was_paused: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::ScopeWasPaused)
+            .unwrap_or(false);
+        match scope.clone() {
+            PauseScope::Global if !scope_was_paused => {
+                env.storage().instance().set(&DataKey::GlobalPaused, &false)
+            }
+            PauseScope::Global => {}
+            PauseScope::Module(module) => env
+                .storage()
+                .instance()
+                .set(&DataKey::ModulePaused(module), &scope_was_paused),
+            PauseScope::Function(module, function) => {
+                if !scope_was_paused {
+                    let mut paused = env
+                        .storage()
+                        .instance()
+                        .get(&DataKey::PausedFunctions(module.clone()))
+                        .unwrap_or(Vec::new(&env));
+                    if let Some(index) = paused.first_index_of(function) {
+                        paused.remove(index);
+                    }
+                    env.storage()
+                        .instance()
+                        .set(&DataKey::PausedFunctions(module), &paused);
+                }
+            }
+        }
+        env.storage().instance().remove(&DataKey::ActivationEpoch);
+        env.storage().instance().remove(&DataKey::ActiveScope);
+        env.storage().instance().remove(&DataKey::RecoveryReadyAt);
+        env.storage().instance().remove(&DataKey::ScopeWasPaused);
+        env.events().publish(
+            (symbol_short!("emergency"), symbol_short!("recovered")),
+            (epoch, scope),
+        );
         Ok(())
     }
 
@@ -829,6 +1099,9 @@ mod tests {
         assert_eq!(res, Err(Ok(Error::Unauthorized)));
     }
 }
+
+#[cfg(test)]
+mod threshold_tests;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Expanded kill-switch-epoch guard tests (#1293)

--- a/emergency_killswitch/src/threshold_tests.rs
+++ b/emergency_killswitch/src/threshold_tests.rs
@@ -1,0 +1,150 @@
+#![cfg(test)]
+#![allow(clippy::all)]
+
+use soroban_sdk::testutils::{Address as _, Ledger};
+use soroban_sdk::{vec, Address, Env};
+
+use crate::{EmergencyKillswitch, EmergencyKillswitchClient, Error, PauseScope, RECOVERY_DELAY};
+
+fn setup() -> (
+    Env,
+    EmergencyKillswitchClient<'static>,
+    Address,
+    Address,
+    Address,
+) {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let id = env.register_contract(None, EmergencyKillswitch);
+    let client = EmergencyKillswitchClient::new(&env, &id);
+    let admin = Address::generate(&env);
+    let first = Address::generate(&env);
+    let second = Address::generate(&env);
+    client.initialize(&admin);
+    (env, client, admin, first, second)
+}
+
+fn configure_two(
+    env: &Env,
+    client: &EmergencyKillswitchClient<'_>,
+    admin: &Address,
+    first: &Address,
+    second: &Address,
+) -> u64 {
+    let signers = vec![env, first.clone(), second.clone()];
+    client.configure_signers(admin, &signers, &2)
+}
+
+#[test]
+fn configuration_starts_a_new_signer_epoch() {
+    let (_env, client, admin, first, second) = setup();
+    assert_eq!(configure_two(&_env, &client, &admin, &first, &second), 1);
+    assert_eq!(client.get_signer_epoch(), 1);
+    assert_eq!(client.get_signer_threshold(), 2);
+}
+
+#[test]
+fn duplicate_signers_and_impossible_thresholds_fail() {
+    let (env, client, admin, first, _second) = setup();
+    let duplicate = vec![&env, first.clone(), first.clone()];
+    assert_eq!(
+        client.try_configure_signers(&admin, &duplicate, &2),
+        Err(Ok(Error::DuplicateSigner))
+    );
+    let one = vec![&env, first];
+    assert_eq!(
+        client.try_configure_signers(&admin, &one, &2),
+        Err(Ok(Error::InvalidSignerThreshold))
+    );
+}
+
+#[test]
+fn activation_requires_current_epoch_and_threshold() {
+    let (env, client, admin, first, second) = setup();
+    assert_eq!(
+        client.try_activate(
+            &1,
+            &vec![&env, first.clone(), second.clone()],
+            &PauseScope::Global
+        ),
+        Err(Ok(Error::EpochMismatch))
+    );
+    let epoch = configure_two(&env, &client, &admin, &first, &second);
+    let one = vec![&env, first.clone()];
+    assert_eq!(
+        client.try_activate(&epoch, &one, &PauseScope::Global),
+        Err(Ok(Error::InvalidSignerThreshold))
+    );
+}
+
+#[test]
+fn duplicate_and_unknown_approvals_are_rejected() {
+    let (env, client, admin, first, second) = setup();
+    let epoch = configure_two(&env, &client, &admin, &first, &second);
+    let duplicate = vec![&env, first.clone(), first.clone()];
+    assert_eq!(
+        client.try_activate(&epoch, &duplicate, &PauseScope::Global),
+        Err(Ok(Error::DuplicateApproval))
+    );
+    let stranger = Address::generate(&env);
+    let unknown = vec![&env, first, stranger];
+    assert_eq!(
+        client.try_activate(&epoch, &unknown, &PauseScope::Global),
+        Err(Ok(Error::SignerNotConfigured))
+    );
+}
+
+#[test]
+fn activation_is_idempotence_guarded_and_scope_is_explicit() {
+    let (env, client, admin, first, second) = setup();
+    let epoch = configure_two(&env, &client, &admin, &first, &second);
+    let approvals = vec![&env, first, second];
+    client.activate(
+        &epoch,
+        &approvals,
+        &PauseScope::Module(soroban_sdk::symbol_short!("bills")),
+    );
+    assert!(client.is_module_paused(&soroban_sdk::symbol_short!("bills")));
+    assert_eq!(
+        client.try_activate(&epoch, &approvals, &PauseScope::Global),
+        Err(Ok(Error::ActivationAlreadyActive))
+    );
+}
+
+#[test]
+fn recovery_requires_delay_and_quorum_then_clears_marker() {
+    let (env, client, admin, first, second) = setup();
+    let epoch = configure_two(&env, &client, &admin, &first, &second);
+    let approvals = vec![&env, first, second];
+    client.activate(&epoch, &approvals, &PauseScope::Global);
+    assert!(client.is_paused());
+    assert_eq!(
+        client.try_recover(&epoch, &approvals),
+        Err(Ok(Error::RecoveryTooEarly))
+    );
+    env.ledger()
+        .set_timestamp(env.ledger().timestamp() + RECOVERY_DELAY);
+    client.recover(&epoch, &approvals);
+    assert!(!client.is_paused());
+    assert_eq!(
+        client.try_recover(&epoch, &approvals),
+        Err(Ok(Error::NotActive))
+    );
+}
+
+#[test]
+fn signer_epoch_rotation_invalidates_active_recovery() {
+    let (env, client, admin, first, second) = setup();
+    let epoch = configure_two(&env, &client, &admin, &first, &second);
+    let approvals = vec![&env, first.clone(), second.clone()];
+    client.activate(&epoch, &approvals, &PauseScope::Global);
+    let replacement = Address::generate(&env);
+    let next = vec![&env, second, replacement];
+    assert_eq!(client.configure_signers(&admin, &next, &2), epoch + 1);
+    env.ledger()
+        .set_timestamp(env.ledger().timestamp() + RECOVERY_DELAY);
+    assert_eq!(
+        client.try_recover(&epoch, &approvals),
+        Err(Ok(Error::EpochMismatch))
+    );
+}


### PR DESCRIPTION
## Summary
- add explicit Global/Module/Function pause scopes
- add admin-governed signer sets, thresholds, and epochs that invalidate stale approval bundles
- make activation one-time until recovery and require a one-hour recovery delay plus a fresh quorum
- add missing/duplicate/stale/wrong-epoch tests and an activation/recovery threat-model runbook

## Acceptance criteria
- [x] Activation requires the configured threshold and current signer epoch.
- [x] Activation/recovery markers prevent replay across epochs.
- [x] Pause scope is explicit and stored with activation.
- [x] Recovery requires the configured delay and current quorum.

## Validation
- `rustfmt --edition 2021 --check emergency_killswitch/src/lib.rs emergency_killswitch/src/threshold_tests.rs`
- `git diff --check`
- 570 changed lines
- Workspace cargo tests are currently blocked by a pre-existing unclosed delimiter in `insurance/src/lib.rs`; no checks were disabled.

Closes #1717